### PR TITLE
fix(shared): correct holiday spelling from holyday to holiday

### DIFF
--- a/packages/@d-zero/backlog-projects/src/assign.ts
+++ b/packages/@d-zero/backlog-projects/src/assign.ts
@@ -3,7 +3,7 @@ import type { Backlog } from 'backlog-js';
 import type { Project, User } from 'backlog-js/dist/types/entity.js';
 
 import { NotionDB } from '@d-zero/notion';
-import { skipHolydayPeriod } from '@d-zero/shared/skip-holyday-period';
+import { skipHolidayPeriod } from '@d-zero/shared/skip-holiday-period';
 import dayjs from 'dayjs';
 
 import { PROJECT_COMMON_TASK_LIST_NOTION_URL } from './define.js';
@@ -65,7 +65,7 @@ export async function assign(backlog: Backlog, params: Params) {
 	for (const value of data['課題名']) {
 		const days = +(data['工数（人日）']?.[i] || 1) - 1;
 
-		const { startDate, dueDate } = skipHolydayPeriod(
+		const { startDate, dueDate } = skipHolidayPeriod(
 			currentDate,
 			currentDate.add(days, 'day'),
 		);

--- a/packages/@d-zero/shared/README.md
+++ b/packages/@d-zero/shared/README.md
@@ -13,8 +13,8 @@
 | `@d-zero/shered/hash`                      | Generates a hash value for the given string.                                                           |
 | `@d-zero/shared/race-with-timeout`         | Races a given promise against a timeout and returns the result of the promise or a timeout indication. |
 | `@d-zero/shared/retry`                     | Decorator factory that adds retry logic to a method.                                                   |
-| `@d-zero/shared/skip-holyday-period`       | Skips the holiday period between the start and due dates.                                              |
-| `@d-zero/shared/skip-holydays`             | Skips holidays and weekends in the given date and returns the next available date.                     |
+| `@d-zero/shared/skip-holiday-period`       | Skips the holiday period between the start and due dates.                                              |
+| `@d-zero/shared/skip-holidays`             | Skips holidays and weekends in the given date and returns the next available date.                     |
 | `@d-zero/shared/str-to-regex`              | Converts a string pattern to a regular expression.                                                     |
 | `@d-zero/shared/split-array`               | Splits an array into chunks of the specified size.                                                     |
 | `@d-zero/shared/timestamp`                 | Generates a timestamp. If no format is provided, returns the Linux time (epoch seconds) as a string.   |

--- a/packages/@d-zero/shared/package.json
+++ b/packages/@d-zero/shared/package.json
@@ -56,13 +56,13 @@
 			"import": "./dist/retry.js",
 			"types": "./dist/retry.d.ts"
 		},
-		"./skip-holyday-period": {
-			"import": "./dist/skip-holyday-period.js",
-			"types": "./dist/skip-holyday-period.d.ts"
+		"./skip-holiday-period": {
+			"import": "./dist/skip-holiday-period.js",
+			"types": "./dist/skip-holiday-period.d.ts"
 		},
-		"./skip-holydays": {
-			"import": "./dist/skip-holydays.js",
-			"types": "./dist/skip-holydays.d.ts"
+		"./skip-holidays": {
+			"import": "./dist/skip-holidays.js",
+			"types": "./dist/skip-holidays.d.ts"
 		},
 		"./split-array": {
 			"import": "./dist/split-array.js",

--- a/packages/@d-zero/shared/src/index.ts
+++ b/packages/@d-zero/shared/src/index.ts
@@ -19,8 +19,8 @@ export { urlToFileName } from './url-to-file-name.js';
 
 // Date utilities
 export { betweenWeekendDays } from './between-weekend-days.js';
-export { skipHolydayPeriod } from './skip-holyday-period.js';
-export { skipHolydays } from './skip-holydays.js';
+export { skipHolidayPeriod } from './skip-holiday-period.js';
+export { skipHolidays } from './skip-holidays.js';
 
 // Sort utilities
 export { alphabeticalComparator } from './sort/alphabetical.js';

--- a/packages/@d-zero/shared/src/skip-holiday-period.spec.ts
+++ b/packages/@d-zero/shared/src/skip-holiday-period.spec.ts
@@ -1,13 +1,13 @@
 import dayjs from 'dayjs';
 import { describe, test, expect } from 'vitest';
 
-import { skipHolydayPeriod } from './skip-holyday-period.js';
+import { skipHolidayPeriod } from './skip-holiday-period.js';
 
-describe('skipHolydayPeriod', () => {
+describe('skipHolidayPeriod', () => {
 	test('2021-08-01 to 2021-08-03', () => {
 		const start = dayjs('2021-08-01');
 		const due = dayjs('2021-08-03');
-		const { startDate, dueDate } = skipHolydayPeriod(start, due);
+		const { startDate, dueDate } = skipHolidayPeriod(start, due);
 		expect(start.day()).toBe(0);
 		expect(due.day()).toBe(2);
 		expect(startDate.format('YYYY-MM-DD')).toBe('2021-08-02');
@@ -19,7 +19,7 @@ describe('skipHolydayPeriod', () => {
 	test('2021-08-01 to 2021-08-30', () => {
 		const start = dayjs('2021-08-01');
 		const due = dayjs('2021-08-30');
-		const { startDate, dueDate } = skipHolydayPeriod(start, due);
+		const { startDate, dueDate } = skipHolidayPeriod(start, due);
 		expect(start.day()).toBe(0);
 		expect(due.day()).toBe(1);
 		expect(startDate.format('YYYY-MM-DD')).toBe('2021-08-02');
@@ -31,7 +31,7 @@ describe('skipHolydayPeriod', () => {
 	test('2023-12-25 to 2024-01-03', () => {
 		const start = dayjs('2023-12-25');
 		const due = dayjs('2024-01-03');
-		const { startDate, dueDate } = skipHolydayPeriod(start, due);
+		const { startDate, dueDate } = skipHolidayPeriod(start, due);
 		expect(due.diff(start, 'day')).toBe(9);
 		expect(start.day()).toBe(1);
 		expect(due.day()).toBe(3);

--- a/packages/@d-zero/shared/src/skip-holiday-period.ts
+++ b/packages/@d-zero/shared/src/skip-holiday-period.ts
@@ -3,7 +3,7 @@ import type dayjs from 'dayjs';
 import holiday_jp from '@holiday-jp/holiday_jp';
 
 import { betweenWeekendDays } from './between-weekend-days.js';
-import { skipHolydays } from './skip-holydays.js';
+import { skipHolidays } from './skip-holidays.js';
 
 /**
  * Skips the holiday period between the start and due dates.
@@ -11,23 +11,23 @@ import { skipHolydays } from './skip-holydays.js';
  * @param due The due date.
  * @returns An object containing the updated start and due dates.
  */
-export function skipHolydayPeriod(start: dayjs.Dayjs, due: dayjs.Dayjs) {
+export function skipHolidayPeriod(start: dayjs.Dayjs, due: dayjs.Dayjs) {
 	let startDate = start.clone();
 	const period = due.diff(startDate, 'day');
 
-	startDate = skipHolydays(startDate);
+	startDate = skipHolidays(startDate);
 	let dueDate = startDate.add(period, 'day');
 
 	const weekendDays = betweenWeekendDays(startDate.toDate(), dueDate.toDate());
 	if (weekendDays.length > 0) {
 		dueDate = dueDate.add(weekendDays.length, 'day');
-		dueDate = skipHolydays(dueDate);
+		dueDate = skipHolidays(dueDate);
 	}
 
 	const holidays = holiday_jp.between(startDate.toDate(), dueDate.toDate());
 	if (holidays.length > 0) {
 		dueDate = dueDate.add(holidays.length, 'day');
-		dueDate = skipHolydays(dueDate);
+		dueDate = skipHolidays(dueDate);
 	}
 
 	return {

--- a/packages/@d-zero/shared/src/skip-holidays.spec.ts
+++ b/packages/@d-zero/shared/src/skip-holidays.spec.ts
@@ -1,12 +1,12 @@
 import dayjs from 'dayjs';
 import { describe, test, expect } from 'vitest';
 
-import { skipHolydays } from './skip-holydays.js';
+import { skipHolidays } from './skip-holidays.js';
 
-describe('skipHolydays', () => {
+describe('skipHolidays', () => {
 	test('skip from Sunday', () => {
 		const current = dayjs('2021-08-01');
-		const skipped = skipHolydays(current);
+		const skipped = skipHolidays(current);
 		expect(current.day()).toBe(0);
 		expect(skipped.format('YYYY-MM-DD')).toBe('2021-08-02');
 		expect(skipped.day()).toBe(1);
@@ -14,7 +14,7 @@ describe('skipHolydays', () => {
 
 	test('skip from Sunday', () => {
 		const current = dayjs('2022-01-01');
-		const skipped = skipHolydays(current);
+		const skipped = skipHolidays(current);
 		expect(current.day()).toBe(6);
 		expect(skipped.format('YYYY-MM-DD')).toBe('2022-01-03');
 		expect(skipped.day()).toBe(1);

--- a/packages/@d-zero/shared/src/skip-holidays.ts
+++ b/packages/@d-zero/shared/src/skip-holidays.ts
@@ -7,7 +7,7 @@ import holiday_jp from '@holiday-jp/holiday_jp';
  * @param date - The date to skip holidays and weekends from.
  * @returns The next available date after skipping holidays and weekends.
  */
-export function skipHolydays(date: dayjs.Dayjs) {
+export function skipHolidays(date: dayjs.Dayjs) {
 	let current = date.clone();
 
 	if (current.day() === 0) {


### PR DESCRIPTION
## Summary
- Fix spelling error from `holyday` to `holiday` in function names, file names, and export paths
- BREAKING CHANGE: Public API function names changed

## Test plan
- [x] Build passes
- [x] All tests pass
- [x] File renames completed
- [x] Import/export paths updated

🤖 Generated with [Claude Code](https://claude.ai/code)