### PR TITLE
feat(replicator): add Basic authentication support

### DIFF
--- a/packages/@d-zero/replicator/README.md
+++ b/packages/@d-zero/replicator/README.md
@@ -26,6 +26,7 @@ npx @d-zero/replicator <url...> -o <output-directory> [options]
 - `--interval <ms>`: 並列実行間の間隔（デフォルト: なし）
   - 数値または"min-max"形式でランダム範囲を指定可能
 - `--only <type>`: ダウンロード対象を限定（`page` または `resource`）
+- `-a, --auth <user:pass>`: Basic認証の認証情報（`ユーザー名:パスワード` 形式）
 - `-v, --verbose`: 詳細ログモード
 
 ##### `--only` オプション
@@ -67,6 +68,9 @@ npx @d-zero/replicator https://example.com -o ./output --only page
 
 # リソースのみダウンロード（HTMLを除外）
 npx @d-zero/replicator https://example.com -o ./output --only resource
+
+# Basic認証が必要なページ
+npx @d-zero/replicator https://example.com -o ./output -a username:password
 ```
 
 ### プログラマティック使用
@@ -116,10 +120,19 @@ await replicate({
 	outputDir: './output',
 	only: 'resource',
 });
+
+// Basic認証が必要なページ
+await replicate({
+	urls: ['https://example.com'],
+	outputDir: './output',
+	username: 'username',
+	password: 'password',
+});
 ```
 
 ## 機能
 
+- **Basic認証対応**: `--auth user:pass`オプションでBasic認証が必要なページにアクセス可能
 - **並列処理**: 複数のURLを並列で効率的に処理
 - **メモリ効率**: リソースを直接ディスクに保存してメモリ使用量を最小化
 - **選択的ダウンロード**: `--only`オプションでHTMLページのみまたはリソースのみをダウンロード可能

--- a/packages/@d-zero/replicator/src/child-process.ts
+++ b/packages/@d-zero/replicator/src/child-process.ts
@@ -7,7 +7,7 @@ import { scrollAllOver } from '@d-zero/puppeteer-scroll';
 import { encodeResourcePath } from '@d-zero/shared/encode-resource-path';
 
 createChildProcess<ChildProcessInput, ChildProcessResult>((param) => {
-	const { devices, timeout } = param;
+	const { devices, timeout, username, password } = param;
 
 	return {
 		async eachPage({ page, url }, logger) {
@@ -53,6 +53,10 @@ createChildProcess<ChildProcessInput, ChildProcessResult>((param) => {
 			};
 
 			page.on('response', responseHandler);
+
+			if (username && password) {
+				await page.authenticate({ username, password });
+			}
 
 			const defaultSizes = {
 				'desktop-compact': devicePresets['desktop-compact'],

--- a/packages/@d-zero/replicator/src/cli.ts
+++ b/packages/@d-zero/replicator/src/cli.ts
@@ -18,6 +18,7 @@ interface ReplicatorCLIOptions extends BaseCLIOptions {
 	devices?: string;
 	limit?: number;
 	only?: string;
+	auth?: string;
 }
 
 const { options, args } = createCLI<ReplicatorCLIOptions>({
@@ -29,6 +30,7 @@ const { options, args } = createCLI<ReplicatorCLIOptions>({
 		t: 'timeout',
 		d: 'devices',
 		l: 'limit',
+		a: 'auth',
 	},
 	usage: [
 		'Usage: replicator <url1> [url2...] -o <output-directory> [options]',
@@ -41,6 +43,7 @@ const { options, args } = createCLI<ReplicatorCLIOptions>({
 		'  --interval <ms>           Interval between parallel executions (default: none)',
 		'                             Format: number or "min-max" for random range',
 		'  --only <type>             Download only specified type: page or resource',
+		'  -a, --auth <user:pass>    Credentials for Basic authentication',
 		'  -v, --verbose             Enable verbose logging',
 		'',
 		'Available device presets:',
@@ -61,6 +64,7 @@ const { options, args } = createCLI<ReplicatorCLIOptions>({
 		devices: cli.devices,
 		limit: cli.limit ? Number(cli.limit) : undefined,
 		only: cli.only,
+		auth: cli.auth,
 	}),
 	validateArgs: (options, cli) => {
 		if (options.only && options.only !== 'page' && options.only !== 'resource') {
@@ -83,6 +87,10 @@ try {
 	const deviceNames = options.devices ? parseList(options.devices) : undefined;
 	const devices = parseDevicesOption(deviceNames);
 
+	const colonIndex = options.auth ? options.auth.indexOf(':') : -1;
+	const username = colonIndex >= 0 ? options.auth!.slice(0, colonIndex) : undefined;
+	const password = colonIndex >= 0 ? options.auth!.slice(colonIndex + 1) : undefined;
+
 	await replicate({
 		urls,
 		outputDir,
@@ -92,6 +100,8 @@ try {
 		limit: options.limit,
 		only: options.only as 'page' | 'resource' | undefined,
 		interval: options.interval,
+		username,
+		password,
 	});
 } catch (error) {
 	if (error instanceof Error) {

--- a/packages/@d-zero/replicator/src/index.ts
+++ b/packages/@d-zero/replicator/src/index.ts
@@ -45,6 +45,8 @@ function collectPageUrlsOnly(
  * @param limit - Parallel execution limit
  * @param progress - Progress logger function
  * @param interval
+ * @param username
+ * @param password
  * @returns Set of encoded URLs
  */
 async function collectAllResourceUrls(
@@ -55,6 +57,8 @@ async function collectAllResourceUrls(
 	limit: number,
 	progress: (message: string) => void,
 	interval?: number | DelayOptions,
+	username?: string,
+	password?: string,
 ): Promise<Set<string>> {
 	progress(c.bold.yellow('📡 Phase 1: Collecting resource metadata...'));
 
@@ -72,6 +76,8 @@ async function collectAllResourceUrls(
 				{
 					devices: targetSizes,
 					timeout,
+					username,
+					password,
 				},
 				{},
 			),
@@ -147,6 +153,8 @@ export async function replicate(options: ReplicateOptions): Promise<void> {
 		limit = 3,
 		only,
 		interval,
+		username,
+		password,
 	} = options;
 
 	if (urls.length === 0) {
@@ -198,6 +206,8 @@ export async function replicate(options: ReplicateOptions): Promise<void> {
 				limit,
 				progress,
 				interval,
+				username,
+				password,
 			);
 			break;
 		}
@@ -225,6 +235,8 @@ export async function replicate(options: ReplicateOptions): Promise<void> {
 		verbose,
 		only,
 		interval,
+		username,
+		password,
 	);
 
 	progress('');

--- a/packages/@d-zero/replicator/src/resource-downloader.ts
+++ b/packages/@d-zero/replicator/src/resource-downloader.ts
@@ -31,6 +31,8 @@ interface ResourceTask {
  * @param verbose
  * @param only
  * @param interval
+ * @param username
+ * @param password
  */
 export async function downloadResources(
 	encodedPaths: string[],
@@ -40,6 +42,8 @@ export async function downloadResources(
 	verbose = false,
 	only?: 'page' | 'resource',
 	interval?: number | DelayOptions,
+	username?: string,
+	password?: string,
 ): Promise<void> {
 	const uniqueResources = new Map<string, ResourceTask>();
 
@@ -70,6 +74,10 @@ export async function downloadResources(
 	}
 
 	const tasks = [...uniqueResources.values()];
+	const authHeader =
+		username && password
+			? `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`
+			: undefined;
 
 	if (tasks.length === 0) {
 		logger(c.yellow('⚠️  No resources to download'));
@@ -92,7 +100,9 @@ export async function downloadResources(
 			return async () => {
 				update('Fetching%dots%');
 
-				const response = await fetch(task.url).catch((error) => {
+				const response = await fetch(task.url, {
+					headers: authHeader ? { Authorization: authHeader } : {},
+				}).catch((error) => {
 					update(c.red(`❌ Fetch failed: ${error.message}`));
 					failed++;
 					return null;

--- a/packages/@d-zero/replicator/src/types.ts
+++ b/packages/@d-zero/replicator/src/types.ts
@@ -9,6 +9,8 @@ export interface ReplicateOptions {
 	limit?: number;
 	only?: 'page' | 'resource';
 	interval?: number | DelayOptions;
+	username?: string;
+	password?: string;
 }
 
 export interface Resource {
@@ -19,6 +21,8 @@ export interface Resource {
 export interface ChildProcessInput {
 	devices?: Record<string, { width: number; resolution?: number }>;
 	timeout?: number;
+	username?: string;
+	password?: string;
 }
 
 export interface ChildProcessResult {


### PR DESCRIPTION
## Summary

- Add `-a, --auth <user:pass>` CLI option to support Basic authentication
- Use `page.authenticate()` in Puppeteer phase (Phase 1: resource metadata collection)
- Add `Authorization: Basic ...` header in fetch phase (Phase 2: resource download)
- Expose `username` / `password` fields in `ReplicateOptions` for programmatic use

## Changes

- `src/types.ts` — Add `username` / `password` to `ReplicateOptions` and `ChildProcessInput`
- `src/child-process.ts` — Call `page.authenticate()` before page scan
- `src/resource-downloader.ts` — Pass `Authorization` header to `fetch()`
- `src/index.ts` — Thread credentials through both phases
- `src/cli.ts` — Add `-a, --auth <user:pass>` option (splits on first `:` to support colons in passwords)
- `README.md` — Document new option and usage examples

Made with [Cursor](https://cursor.com)