### PR TITLE
chore(repo): exclude CODEOWNERS from cspell checks

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -34,6 +34,9 @@
 
 		// Test data
 		"mypassword",
-		"mypassphrase"
+		"mypassphrase",
+
+		// Shell keywords
+		"elif"
 	]
 }

--- a/cspell.json
+++ b/cspell.json
@@ -1,6 +1,6 @@
 {
 	"import": ["@d-zero/cspell-config"],
-	"ignorePaths": [".vscode/*"],
+	"ignorePaths": [".vscode/*", "**/CODEOWNERS"],
 	"words": [
 		//
 		"gaxios",


### PR DESCRIPTION
`.github/CODEOWNERS` にはユーザー名のみが並ぶため、cspell がスペルミスとして拾わないよう `ignorePaths` に `**/CODEOWNERS` を追加します。