### PR TITLE
feat(replicator): add downloadLimit option to control Phase 2 parallelism

### DIFF
--- a/packages/@d-zero/replicator/README.md
+++ b/packages/@d-zero/replicator/README.md
@@ -22,7 +22,8 @@ npx @d-zero/replicator <url...> -o <output-directory> [options]
 - `-o, --output <dir>`: 出力ディレクトリ（必須）
 - `-t, --timeout <ms>`: リクエストタイムアウト（ミリ秒、デフォルト: 30000）
 - `-d, --devices <devices>`: デバイスプリセット（カンマ区切り、デフォルト: desktop-compact,mobile）
-- `-l, --limit <number>`: 並列処理数の上限（デフォルト: 3）
+- `-l, --limit <number>`: ページスキャン（Phase 1）の並列処理数の上限（デフォルト: 3）
+- `--download-limit <number>`: リソースダウンロード（Phase 2）の並列処理数の上限（デフォルト: 10）
 - `--interval <ms>`: 並列実行間の間隔（デフォルト: なし）
   - 数値または"min-max"形式でランダム範囲を指定可能
 - `--only <type>`: ダウンロード対象を限定（`page` または `resource`）
@@ -92,7 +93,8 @@ await replicate({
 		'https://example.com/page3',
 	],
 	outputDir: './output',
-	limit: 2, // 最大2つのURLを同時処理
+	limit: 2, // ページスキャン（Phase 1）は最大2並列
+	downloadLimit: 5, // リソースダウンロード（Phase 2）は最大5並列
 });
 
 // カスタムデバイス

--- a/packages/@d-zero/replicator/src/cli.ts
+++ b/packages/@d-zero/replicator/src/cli.ts
@@ -17,6 +17,7 @@ interface ReplicatorCLIOptions extends BaseCLIOptions {
 	timeout?: number;
 	devices?: string;
 	limit?: number;
+	downloadLimit?: number;
 	only?: string;
 	auth?: string;
 }
@@ -39,7 +40,8 @@ const { options, args } = createCLI<ReplicatorCLIOptions>({
 		'  -o, --output <dir>        Output directory (required)',
 		'  -t, --timeout <ms>        Request timeout in milliseconds (default: 30000)',
 		'  -d, --devices <devices>   Device presets (comma-separated, default: desktop-compact,mobile)',
-		'  -l, --limit <number>      Parallel execution limit (default: 3)',
+		'  -l, --limit <number>      Parallel execution limit for page scan (default: 3)',
+		'  --download-limit <number> Parallel execution limit for resource download (default: 10)',
 		'  --interval <ms>           Interval between parallel executions (default: none)',
 		'                             Format: number or "min-max" for random range',
 		'  --only <type>             Download only specified type: page or resource',
@@ -63,6 +65,7 @@ const { options, args } = createCLI<ReplicatorCLIOptions>({
 		timeout: cli.timeout ? Number(cli.timeout) : undefined,
 		devices: cli.devices,
 		limit: cli.limit ? Number(cli.limit) : undefined,
+		downloadLimit: cli['download-limit'] ? Number(cli['download-limit']) : undefined,
 		only: cli.only,
 		auth: cli.auth,
 	}),
@@ -98,6 +101,7 @@ try {
 		timeout: options.timeout,
 		devices,
 		limit: options.limit,
+		downloadLimit: options.downloadLimit,
 		only: options.only as 'page' | 'resource' | undefined,
 		interval: options.interval,
 		username,

--- a/packages/@d-zero/replicator/src/index.ts
+++ b/packages/@d-zero/replicator/src/index.ts
@@ -151,6 +151,7 @@ export async function replicate(options: ReplicateOptions): Promise<void> {
 		timeout = 30_000,
 		devices,
 		limit = 3,
+		downloadLimit = 10,
 		only,
 		interval,
 		username,
@@ -187,6 +188,7 @@ export async function replicate(options: ReplicateOptions): Promise<void> {
 	progress(c.bold.cyan(`🌐 Replicating ${urls.length} URL(s)`));
 	progress(c.gray(`   Output: ${outputDir}`));
 	progress(c.gray(`   Parallel limit: ${limit}`));
+	progress(c.gray(`   Download limit: ${downloadLimit}`));
 	progress('');
 
 	// Phase 1: Collect resource metadata from all URLs
@@ -237,6 +239,7 @@ export async function replicate(options: ReplicateOptions): Promise<void> {
 		interval,
 		username,
 		password,
+		downloadLimit,
 	);
 
 	progress('');

--- a/packages/@d-zero/replicator/src/resource-downloader.ts
+++ b/packages/@d-zero/replicator/src/resource-downloader.ts
@@ -33,6 +33,7 @@ interface ResourceTask {
  * @param interval
  * @param username
  * @param password
+ * @param limit
  */
 export async function downloadResources(
 	encodedPaths: string[],
@@ -44,6 +45,7 @@ export async function downloadResources(
 	interval?: number | DelayOptions,
 	username?: string,
 	password?: string,
+	limit = 10,
 ): Promise<void> {
 	const uniqueResources = new Map<string, ResourceTask>();
 
@@ -154,7 +156,7 @@ export async function downloadResources(
 			};
 		},
 		{
-			limit: 10,
+			limit,
 			verbose,
 			interval,
 			header: (progress, done, total, limit) => {

--- a/packages/@d-zero/replicator/src/types.ts
+++ b/packages/@d-zero/replicator/src/types.ts
@@ -7,6 +7,7 @@ export interface ReplicateOptions {
 	timeout?: number;
 	devices?: Record<string, { width: number; resolution?: number }>;
 	limit?: number;
+	downloadLimit?: number;
 	only?: 'page' | 'resource';
 	interval?: number | DelayOptions;
 	username?: string;


### PR DESCRIPTION
## Summary

- `replicate()` の `limit` オプションは Phase 1（ページスキャン）にのみ適用されており、Phase 2（リソースダウンロード）の並列数は `resource-downloader.ts` で `10` にハードコードされていた。
- 新たに `downloadLimit` オプション（デフォルト 10）と CLI フラグ `--download-limit` を追加し、Phase 2 の並列数を独立して制御できるようにした。
- 既存のデフォルト値（Phase 1: 3 / Phase 2: 10）は維持しているため後方互換。

## Background

README には `--limit` のデフォルトが `3` と書かれていたが、実コードでは Phase 2 が常に `10` で動作していたため、ユーザーが `limit: 1` を指定しても `Phase 2: Downloading resources...` の段階で 10 件同時実行されていた。

Phase 1（Puppeteer 子プロセス）と Phase 2（`fetch()`）は処理性質が異なり、それぞれに最適な並列数が違うため、単一オプションに統合せず別オプションとして導入した。

## Test plan

- [x] `yarn lint`
- [x] `yarn build`
- [x] `yarn test`（全 566 テスト pass）
- [ ] `npx @d-zero/replicator <url> -o ./out --limit 1 --download-limit 1` で両フェーズが 1 並列で動作することを実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)