### PR TITLE
fix(beholder): prevent getMeta from hanging on unresponsive pages

### DIFF
--- a/packages/@d-zero/beholder/src/dom-evaluation.spec.ts
+++ b/packages/@d-zero/beholder/src/dom-evaluation.spec.ts
@@ -1,0 +1,293 @@
+import type { ElementHandle, Page } from 'puppeteer';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+	DEFAULT_DOM_EVALUATION_TIMEOUT,
+	getAnchorList,
+	getImageList,
+	getMeta,
+	getProp,
+} from './dom-evaluation.js';
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+/**
+ * Builds a minimal `Page` mock whose `evaluate` resolves with the given value.
+ * @param value
+ */
+function mockPageEvaluate(value: unknown): Page {
+	return {
+		evaluate: () => Promise.resolve(value),
+	} as unknown as Page;
+}
+
+/**
+ * Builds an `ElementHandle` mock returning the given property value.
+ * @param value
+ */
+function mockElementHandle(value: unknown): ElementHandle<Element> {
+	return {
+		getProperty: () =>
+			Promise.resolve({
+				jsonValue: () => Promise.resolve(value),
+			}),
+	} as unknown as ElementHandle<Element>;
+}
+
+describe('getMeta', () => {
+	it('maps raw evaluation result into a Meta object and parses robots directives', async () => {
+		const page = mockPageEvaluate({
+			title: 'Example',
+			lang: 'ja',
+			description: 'desc',
+			keywords: 'a,b',
+			robots: 'noindex, NOFOLLOW',
+			canonical: 'https://example.com/',
+			alternate: 'https://example.com/en',
+			'og:type': 'website',
+			'og:title': 'OG Title',
+			'og:site_name': 'Site',
+			'og:description': 'OG desc',
+			'og:url': 'https://example.com/',
+			'og:image': 'https://example.com/img.png',
+			'twitter:card': 'summary',
+		});
+
+		const meta = await getMeta(page);
+
+		expect(meta).toStrictEqual({
+			title: 'Example',
+			lang: 'ja',
+			description: 'desc',
+			keywords: 'a,b',
+			noindex: true,
+			nofollow: true,
+			noarchive: false,
+			canonical: 'https://example.com/',
+			alternate: 'https://example.com/en',
+			'og:type': 'website',
+			'og:title': 'OG Title',
+			'og:site_name': 'Site',
+			'og:description': 'OG desc',
+			'og:url': 'https://example.com/',
+			'og:image': 'https://example.com/img.png',
+			'twitter:card': 'summary',
+		});
+	});
+
+	it('returns a minimal fallback when evaluation rejects', async () => {
+		const page = {
+			evaluate: () => Promise.reject(new Error('execution context destroyed')),
+		} as unknown as Page;
+
+		const meta = await getMeta(page);
+
+		expect(meta).toStrictEqual({ title: '' });
+	});
+
+	it('returns a minimal fallback when the main thread is unresponsive (timeout)', async () => {
+		vi.useFakeTimers();
+		const page = {
+			// Never resolves — simulates a blocked main thread.
+			evaluate: () => new Promise(() => {}),
+		} as unknown as Page;
+
+		const promise = getMeta(page, 5000);
+		await vi.advanceTimersByTimeAsync(5000);
+		const meta = await promise;
+
+		expect(meta).toStrictEqual({ title: '' });
+		expect(vi.getTimerCount()).toBe(0);
+	});
+});
+
+describe('getImageList', () => {
+	it('maps raw images, deriving isLazy and recording the viewport width', async () => {
+		const page = mockPageEvaluate([
+			{
+				src: 'https://example.com/a.png',
+				currentSrc: 'https://example.com/a.png',
+				alt: 'A',
+				width: 100,
+				height: 50,
+				naturalWidth: 200,
+				naturalHeight: 100,
+				loading: 'LAZY',
+				sourceCode: '<img>',
+			},
+			{
+				src: 'https://example.com/b.png',
+				currentSrc: 'https://example.com/b.png',
+				alt: 'B',
+				width: 0,
+				height: 0,
+				naturalWidth: 0,
+				naturalHeight: 0,
+				loading: 'eager',
+				sourceCode: '<img>',
+			},
+		]);
+
+		const images = await getImageList(page, 375);
+
+		expect(images).toStrictEqual([
+			{
+				src: 'https://example.com/a.png',
+				currentSrc: 'https://example.com/a.png',
+				alt: 'A',
+				width: 100,
+				height: 50,
+				naturalWidth: 200,
+				naturalHeight: 100,
+				isLazy: true,
+				viewportWidth: 375,
+				sourceCode: '<img>',
+			},
+			{
+				src: 'https://example.com/b.png',
+				currentSrc: 'https://example.com/b.png',
+				alt: 'B',
+				width: 0,
+				height: 0,
+				naturalWidth: 0,
+				naturalHeight: 0,
+				isLazy: false,
+				viewportWidth: 375,
+				sourceCode: '<img>',
+			},
+		]);
+	});
+
+	it('returns an empty array when extraction rejects', async () => {
+		const page = {
+			evaluate: () => Promise.reject(new Error('execution context destroyed')),
+		} as unknown as Page;
+
+		const images = await getImageList(page, 375);
+
+		expect(images).toStrictEqual([]);
+	});
+
+	it('returns an empty array (not a failure fallback) for a page with no images', async () => {
+		const page = mockPageEvaluate([]);
+
+		const images = await getImageList(page, 375);
+
+		expect(images).toStrictEqual([]);
+	});
+
+	it('returns an empty array when extraction times out', async () => {
+		vi.useFakeTimers();
+		const page = {
+			evaluate: () => new Promise(() => {}),
+		} as unknown as Page;
+
+		const promise = getImageList(page, 375, 5000);
+		await vi.advanceTimersByTimeAsync(5000);
+		const images = await promise;
+
+		expect(images).toStrictEqual([]);
+		expect(vi.getTimerCount()).toBe(0);
+	});
+});
+
+describe('getProp', () => {
+	it('returns the property value and clears the loser-side timer', async () => {
+		vi.useFakeTimers();
+		const $el = mockElementHandle('hello');
+
+		const result = await getProp({ $el, propName: 'textContent', fallback: '' });
+
+		expect(result).toBe('hello');
+		// raceWithTimeout must clear the timeout it lost so it cannot keep the event loop alive.
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it('returns the fallback when property retrieval throws', async () => {
+		const $el = {
+			getProperty: () => Promise.reject(new Error('detached')),
+		} as unknown as ElementHandle<Element>;
+
+		const result = await getProp({ $el, propName: 'textContent', fallback: 'fb' });
+
+		expect(result).toBe('fb');
+	});
+
+	it('returns the fallback when retrieval hangs past the timeout', async () => {
+		vi.useFakeTimers();
+		const $el = {
+			getProperty: () => new Promise(() => {}),
+		} as unknown as ElementHandle<Element>;
+
+		const promise = getProp({ $el, propName: 'textContent', fallback: 'fb' }, 5000);
+		await vi.advanceTimersByTimeAsync(5000);
+		const result = await promise;
+
+		expect(result).toBe('fb');
+		expect(vi.getTimerCount()).toBe(0);
+	});
+});
+
+describe('getAnchorList', () => {
+	it('resolves the href and prefers the accessible name from the accessibility tree', async () => {
+		const $anchor = mockElementHandle('https://example.com/page');
+		const page = {
+			$$: () => Promise.resolve([$anchor]),
+			accessibility: {
+				snapshot: () => Promise.resolve({ name: 'Accessible Name' }),
+			},
+		} as unknown as Page;
+
+		const anchors = await getAnchorList(page);
+
+		expect(anchors).toHaveLength(1);
+		expect(anchors[0]?.textContent).toBe('Accessible Name');
+		expect(anchors[0]?.href.href).toBe('https://example.com/page');
+	});
+
+	it('falls back to trimmed textContent when the accessibility tree has no node', async () => {
+		const $anchor = {
+			getProperty: vi
+				.fn()
+				// First getProp call reads `href`, second reads `textContent`.
+				.mockResolvedValueOnce({
+					jsonValue: () => Promise.resolve('https://example.com/page'),
+				})
+				.mockResolvedValueOnce({ jsonValue: () => Promise.resolve('  Link text  ') }),
+		} as unknown as ElementHandle<Element>;
+		const page = {
+			$$: () => Promise.resolve([$anchor]),
+			accessibility: {
+				snapshot: () => Promise.resolve(null),
+			},
+		} as unknown as Page;
+
+		const anchors = await getAnchorList(page);
+
+		expect(anchors).toHaveLength(1);
+		expect(anchors[0]?.textContent).toBe('Link text');
+	});
+
+	it('skips non-HTTP links', async () => {
+		const $anchor = mockElementHandle('javascript:void(0)');
+		const page = {
+			$$: () => Promise.resolve([$anchor]),
+			accessibility: {
+				snapshot: () => Promise.resolve(null),
+			},
+		} as unknown as Page;
+
+		const anchors = await getAnchorList(page);
+
+		expect(anchors).toStrictEqual([]);
+	});
+});
+
+describe('DEFAULT_DOM_EVALUATION_TIMEOUT', () => {
+	it('defaults to 30 seconds', () => {
+		expect(DEFAULT_DOM_EVALUATION_TIMEOUT).toBe(30_000);
+	});
+});

--- a/packages/@d-zero/beholder/src/dom-evaluation.ts
+++ b/packages/@d-zero/beholder/src/dom-evaluation.ts
@@ -3,11 +3,21 @@
  *
  * These functions are called by {@link ./scraper.ts | Scraper.#fetchData} to extract
  * anchors, images, and meta information after page navigation completes.
+ *
+ * WHY timeouts everywhere: A page whose main thread is blocked (heavy JS, autoplay
+ * video players, infinite loops) makes every CDP round-trip hang. `getMeta` and
+ * `getImageList` therefore collect all data in a single `page.evaluate` and wrap it
+ * in {@link raceWithTimeout} so a blocked thread is abandoned after a bounded budget
+ * instead of accumulating per-property timeouts up to the caller's global timeout.
+ * Note that `page.evaluate` itself runs on the page's main thread and has no built-in
+ * timeout, so the surrounding race is what actually bounds the hang.
  * @see {@link ./types.ts} for the data types returned by these functions
  */
 
-import type { AnchorData, ImageElement, ParseURLOptions } from './types.js';
+import type { AnchorData, ImageElement, Meta, ParseURLOptions } from './types.js';
 import type { ElementHandle, Page } from 'puppeteer';
+
+import { raceWithTimeout } from '@d-zero/shared/race-with-timeout';
 
 import { domDetailsLog, domLog } from './debug.js';
 import { parseUrl } from './parse-url.js';
@@ -15,6 +25,13 @@ import { parseUrl } from './parse-url.js';
 const pid = `${process.pid}`;
 const log = domLog.extend(pid);
 const dLog = domDetailsLog.extend(pid);
+
+/**
+ * Default timeout (ms) applied to DOM evaluation operations when the caller does not
+ * specify one. Bounds how long a single `page.evaluate` / property read may hang on a
+ * page whose main thread is unresponsive.
+ */
+export const DEFAULT_DOM_EVALUATION_TIMEOUT = 30_000;
 
 /**
  * Parameters for {@link getProp}.
@@ -32,18 +49,24 @@ export interface GetPropParams<T> {
 /**
  * Retrieves a DOM property value from a Puppeteer element handle with a timeout.
  *
- * Races the actual property retrieval against a 10-second timeout.
+ * Races the actual property retrieval against a timeout via {@link raceWithTimeout},
+ * which clears the loser-side timer so it cannot keep the event loop alive.
  * If the property cannot be read or the timeout expires, the fallback value is returned.
  * @template T - The expected type of the property value.
  * @param params - Parameters containing the element, property name, and fallback.
- * @returns The property value, or the fallback if retrieval fails.
+ * @param timeout - Timeout in ms before falling back. Defaults to {@link DEFAULT_DOM_EVALUATION_TIMEOUT}.
+ * @returns The property value, or the fallback if retrieval fails or times out.
  */
-export async function getProp<T>(params: GetPropParams<T>) {
+export async function getProp<T>(
+	params: GetPropParams<T>,
+	timeout: number = DEFAULT_DOM_EVALUATION_TIMEOUT,
+): Promise<T> {
 	const { $el, propName, fallback } = params;
-	return Promise.race([
-		_getProp($el, propName, fallback),
-		new Promise<T>((res) => setTimeout(() => res(fallback), 10 * 1000)),
-	]);
+	const { result, timeout: timedOut } = await raceWithTimeout(
+		() => _getProp($el, propName, fallback),
+		timeout,
+	);
+	return timedOut ? fallback : result;
 }
 
 /**
@@ -54,7 +77,11 @@ export async function getProp<T>(params: GetPropParams<T>) {
  * @param fallback - The default value on failure.
  * @returns The property value cast to `T`, or the fallback.
  */
-async function _getProp<T>($el: ElementHandle<Element>, propName: string, fallback: T) {
+async function _getProp<T>(
+	$el: ElementHandle<Element>,
+	propName: string,
+	fallback: T,
+): Promise<T> {
 	try {
 		const prop = await $el.getProperty(propName);
 		if (!prop) {
@@ -68,107 +95,61 @@ async function _getProp<T>($el: ElementHandle<Element>, propName: string, fallba
 }
 
 /**
- * Parameters for {@link getPropBySelector}.
- * @template T - The expected type of the property value.
- */
-export interface GetPropBySelectorParams<T> {
-	/** The Puppeteer page to query. */
-	readonly page: Page;
-	/** A CSS selector to find the target element. */
-	readonly selector: string;
-	/** The DOM property name to read from the matched element. */
-	readonly propName: string;
-	/** The default value if no element matches or the property cannot be read. */
-	readonly fallback: T;
-}
-
-/**
- * Retrieves a DOM property value from the first element matching a CSS selector.
- *
- * Combines `page.$()` with {@link getProp} for convenient single-element lookups.
- * @template T - The expected type of the property value.
- * @param params - Parameters containing the page, selector, property name, and fallback.
- * @returns The property value, or the fallback if the element is not found or retrieval fails.
- */
-export async function getPropBySelector<T>(params: GetPropBySelectorParams<T>) {
-	const { page, selector, propName, fallback } = params;
-	const $el = await page.$(selector);
-	if (!$el) {
-		return fallback;
-	}
-
-	return getProp({ $el, propName, fallback });
-}
-
-/**
  * Extracts all `<img>` elements from the page and returns their properties.
  *
- * For each image, collects the `src`, `currentSrc`, `alt`, bounding box dimensions,
- * natural dimensions, lazy-loading status, and the outer HTML source code.
+ * Collects every image's `src`, `currentSrc`, `alt`, layout dimensions,
+ * natural dimensions, lazy-loading status, and outer HTML in a single
+ * `page.evaluate` call, wrapped in {@link raceWithTimeout}. On timeout (an
+ * unresponsive page) an empty array is returned rather than hanging.
  * @param page - The Puppeteer page to extract images from.
  * @param viewportWidth - The current viewport width in pixels, recorded alongside each image entry.
+ * @param timeout - Timeout in ms for the evaluation. Defaults to {@link DEFAULT_DOM_EVALUATION_TIMEOUT}.
  * @returns An array of {@link ImageElement} objects describing each image on the page.
  */
 export async function getImageList(
 	page: Page,
 	viewportWidth: number,
+	timeout: number = DEFAULT_DOM_EVALUATION_TIMEOUT,
 ): Promise<ImageElement[]> {
 	log('Getting images (Viewport: %dpx)', viewportWidth);
 
-	const $images = await page.$$('img');
-	const imageList: {
-		src: string;
-		currentSrc: string;
-		alt: string;
-		width: number;
-		height: number;
-		naturalWidth: number;
-		naturalHeight: number;
-		isLazy: boolean;
-		viewportWidth: number;
-		sourceCode: string;
-	}[] = [];
-	for (const $image of $images) {
-		const boundingBox = await $image.boundingBox();
-		const width = boundingBox?.width || 0;
-		const height = boundingBox?.height || 0;
-		const src = await getProp({ $el: $image, propName: 'src', fallback: '' });
-		const currentSrc = await getProp({
-			$el: $image,
-			propName: 'currentSrc',
-			fallback: '',
-		});
-		const alt = await getProp({ $el: $image, propName: 'alt', fallback: '' });
-		const naturalWidth = await getProp({
-			$el: $image,
-			propName: 'naturalWidth',
-			fallback: 0,
-		});
-		const naturalHeight = await getProp({
-			$el: $image,
-			propName: 'naturalHeight',
-			fallback: 0,
-		});
-		const loading = await getProp({ $el: $image, propName: 'loading', fallback: '' });
-		const sourceCode = await getProp({
-			$el: $image,
-			propName: 'outerHTML',
-			fallback: '',
-		});
-		const isLazy = loading.toLowerCase().trim() === 'lazy';
-		imageList.push({
-			src,
-			currentSrc,
-			alt,
-			width,
-			height,
-			naturalWidth,
-			naturalHeight,
-			isLazy,
+	const { result, timeout: timedOut } = await raceWithTimeout(
+		() =>
+			page
+				.evaluate(() => {
+					/* global document */
+					return [...document.images].map((img) => {
+						const rect = img.getBoundingClientRect();
+						return {
+							src: img.src,
+							currentSrc: img.currentSrc,
+							alt: img.alt,
+							width: rect.width,
+							height: rect.height,
+							naturalWidth: img.naturalWidth,
+							naturalHeight: img.naturalHeight,
+							loading: img.loading,
+							sourceCode: img.outerHTML,
+						};
+					});
+				})
+				.catch(() => null),
+		timeout,
+	);
+
+	if (timedOut || result == null) {
+		log(
+			'Image extraction timed out or failed (Viewport: %dpx); returning []',
 			viewportWidth,
-			sourceCode,
-		});
+		);
+		return [];
 	}
+
+	const imageList: ImageElement[] = result.map(({ loading, ...img }) => ({
+		...img,
+		isLazy: loading.toLowerCase().trim() === 'lazy',
+		viewportWidth,
+	}));
 
 	log('Got %d images (Viewport: %dpx)', imageList.length, viewportWidth);
 	dLog(
@@ -184,29 +165,41 @@ export async function getImageList(
  * For each anchor, resolves the `href` to an `ExURL` via `parseUrl`, retrieves
  * the accessible name (from the accessibility tree, falling back to `textContent`),
  * and filters out non-HTTP links.
+ *
+ * WHY this keeps per-element CDP calls (unlike {@link getMeta} / {@link getImageList}):
+ * the accessible name comes from Chrome's computed accessibility tree
+ * (`page.accessibility.snapshot`), which is a CDP-only feature unavailable to in-page
+ * DOM APIs. Each {@link getProp} read is still bounded by `timeout`.
  * @param page - The Puppeteer page to extract anchors from.
  * @param options - Optional URL parsing options (e.g., `disableQueries`).
+ * @param timeout - Timeout in ms per property read. Defaults to {@link DEFAULT_DOM_EVALUATION_TIMEOUT}.
  * @returns An array of {@link AnchorData} objects for all HTTP(S) links found on the page.
  */
-export async function getAnchorList(page: Page, options?: ParseURLOptions) {
+export async function getAnchorList(
+	page: Page,
+	options?: ParseURLOptions,
+	timeout: number = DEFAULT_DOM_EVALUATION_TIMEOUT,
+) {
 	log('Getting anchors');
 
 	const $anchors = await page.$$('a[href], area[href]');
 	const anchorList: AnchorData[] = [];
 
 	for (const $anchor of $anchors) {
-		const $href = await getProp({ $el: $anchor, propName: 'href', fallback: '' });
+		const $href = await getProp(
+			{ $el: $anchor, propName: 'href', fallback: '' },
+			timeout,
+		);
 		const hrefVal = $href.toString();
 		const href = parseUrl(hrefVal, options);
 		if (!href || !href.isHTTP) {
 			continue;
 		}
 		const axNode = await page.accessibility.snapshot({ root: $anchor });
-		const textContent = await getProp({
-			$el: $anchor,
-			propName: 'textContent',
-			fallback: '',
-		});
+		const textContent = await getProp(
+			{ $el: $anchor, propName: 'textContent', fallback: '' },
+			timeout,
+		);
 		const accessibleName = axNode ? axNode.name || '' : textContent.trim();
 		const link: AnchorData = {
 			href,
@@ -226,7 +219,11 @@ export async function getAnchorList(page: Page, options?: ParseURLOptions) {
 /**
  * Extracts comprehensive meta information from the page's `<head>`.
  *
- * Collects the following metadata:
+ * Collects all metadata in a single `page.evaluate` call (14 CDP round-trips
+ * collapsed into 1) wrapped in {@link raceWithTimeout}. On timeout (an unresponsive
+ * page) a minimal `{ title: '' }` is returned rather than hanging.
+ *
+ * Collected metadata:
  * - `title` - The document title.
  * - `lang` - The `lang` attribute of the `<html>` element.
  * - `description` - The `<meta name="description">` content.
@@ -237,100 +234,61 @@ export async function getAnchorList(page: Page, options?: ParseURLOptions) {
  * - Open Graph tags: `og:type`, `og:title`, `og:site_name`, `og:description`, `og:url`, `og:image`.
  * - `twitter:card` - The Twitter Card type.
  * @param page - The Puppeteer page to extract meta information from.
+ * @param timeout - Timeout in ms for the evaluation. Defaults to {@link DEFAULT_DOM_EVALUATION_TIMEOUT}.
  * @returns An object containing all extracted meta properties.
  */
-export async function getMeta(page: Page) {
+export async function getMeta(
+	page: Page,
+	timeout: number = DEFAULT_DOM_EVALUATION_TIMEOUT,
+): Promise<Meta> {
 	log('Getting Meta');
 
-	const robotsVal = await getPropBySelector({
-		page,
-		selector: 'meta[name="robots"]',
-		propName: 'content',
-		fallback: '',
-	});
+	const { result, timeout: timedOut } = await raceWithTimeout(
+		() =>
+			page
+				.evaluate(() => {
+					/* global document, HTMLMetaElement, HTMLLinkElement */
+					const content = (selector: string): string => {
+						const el = document.querySelector(selector);
+						return el instanceof HTMLMetaElement ? el.content : '';
+					};
+					const linkHref = (selector: string): string => {
+						const el = document.querySelector(selector);
+						return el instanceof HTMLLinkElement ? el.href : '';
+					};
+					return {
+						title: document.title,
+						lang: document.documentElement.lang,
+						description: content('meta[name="description"]'),
+						keywords: content('meta[name="keywords"]'),
+						robots: content('meta[name="robots"]'),
+						canonical: linkHref('link[rel="canonical"]'),
+						alternate: linkHref('link[rel="alternate"]'),
+						'og:type': content('meta[property="og:type"]'),
+						'og:title': content('meta[property="og:title"]'),
+						'og:site_name': content('meta[property="og:site_name"]'),
+						'og:description': content('meta[property="og:description"]'),
+						'og:url': content('meta[property="og:url"]'),
+						'og:image': content('meta[property="og:image"]'),
+						'twitter:card': content('meta[name="twitter:card"]'),
+					};
+				})
+				.catch(() => null),
+		timeout,
+	);
+
+	if (timedOut || result == null) {
+		log('Meta extraction timed out or failed; returning fallback');
+		return { title: '' };
+	}
+
+	const { robots: robotsVal, ...rest } = result;
 	const robots = new Set(robotsVal.split(',').map((robot) => robot.trim().toLowerCase()));
-	const meta = {
-		title: await getPropBySelector({
-			page,
-			selector: 'title',
-			propName: 'textContent',
-			fallback: '',
-		}),
-		lang: await getPropBySelector({
-			page,
-			selector: 'html',
-			propName: 'lang',
-			fallback: '',
-		}),
-		description: await getPropBySelector({
-			page,
-			selector: 'meta[name="description"]',
-			propName: 'content',
-			fallback: '',
-		}),
-		keywords: await getPropBySelector({
-			page,
-			selector: 'meta[name="keywords"]',
-			propName: 'content',
-			fallback: '',
-		}),
+	const meta: Meta = {
+		...rest,
 		noindex: robots.has('noindex'),
 		nofollow: robots.has('nofollow'),
 		noarchive: robots.has('noarchive'),
-		canonical: await getPropBySelector({
-			page,
-			selector: 'link[rel="canonical"]',
-			propName: 'href',
-			fallback: '',
-		}),
-		alternate: await getPropBySelector({
-			page,
-			selector: 'link[rel="alternate"]',
-			propName: 'href',
-			fallback: '',
-		}),
-		'og:type': await getPropBySelector({
-			page,
-			selector: 'meta[property="og:type"]',
-			propName: 'content',
-			fallback: '',
-		}),
-		'og:title': await getPropBySelector({
-			page,
-			selector: 'meta[property="og:title"]',
-			propName: 'content',
-			fallback: '',
-		}),
-		'og:site_name': await getPropBySelector({
-			page,
-			selector: 'meta[property="og:site_name"]',
-			propName: 'content',
-			fallback: '',
-		}),
-		'og:description': await getPropBySelector({
-			page,
-			selector: 'meta[property="og:description"]',
-			propName: 'content',
-			fallback: '',
-		}),
-		'og:url': await getPropBySelector({
-			page,
-			selector: 'meta[property="og:url"]',
-			propName: 'content',
-			fallback: '',
-		}),
-		'og:image': await getPropBySelector({
-			page,
-			selector: 'meta[property="og:image"]',
-			propName: 'content',
-			fallback: '',
-		}),
-		'twitter:card': await getPropBySelector({
-			page,
-			selector: 'meta[name="twitter:card"]',
-			propName: 'content',
-			fallback: '',
-		}),
 	};
 
 	log('Got meta');

--- a/packages/@d-zero/beholder/src/scraper.ts
+++ b/packages/@d-zero/beholder/src/scraper.ts
@@ -22,7 +22,12 @@ import { retry as retryable } from '@d-zero/shared/retry';
 import { TypedAwaitEventEmitter as EventEmitter } from '@d-zero/shared/typed-await-event-emitter';
 
 import { resourceLog, scraperLog } from './debug.js';
-import { getAnchorList, getImageList, getMeta } from './dom-evaluation.js';
+import {
+	DEFAULT_DOM_EVALUATION_TIMEOUT,
+	getAnchorList,
+	getImageList,
+	getMeta,
+} from './dom-evaluation.js';
 import { isError } from './is-error.js';
 import { keywordCheck } from './keyword-check.js';
 import { findDisconnectionFailures } from './network-disconnection.js';
@@ -360,6 +365,8 @@ export default class Scraper extends EventEmitter<ScraperEventTypes> {
 			options?.disableQueries == null
 				? undefined
 				: { disableQueries: options.disableQueries };
+		const domEvaluationTimeout =
+			options?.domEvaluationTimeout ?? DEFAULT_DOM_EVALUATION_TIMEOUT;
 		const networkLogs: Record<string, NetworkLog> = {};
 
 		// Clear stale state from previous retries (@retryable may re-invoke this method
@@ -626,7 +633,7 @@ export default class Scraper extends EventEmitter<ScraperEventTypes> {
 			isExternal,
 			message: '',
 		});
-		const anchorList = await getAnchorList(page, parseOpts);
+		const anchorList = await getAnchorList(page, parseOpts, domEvaluationTimeout);
 
 		void this.emit('changePhase', {
 			pid: process.pid,
@@ -635,7 +642,7 @@ export default class Scraper extends EventEmitter<ScraperEventTypes> {
 			isExternal,
 			message: '',
 		});
-		const meta = await getMeta(page);
+		const meta = await getMeta(page, domEvaluationTimeout);
 
 		const imageList = captureImages
 			? await (async () => {
@@ -651,6 +658,7 @@ export default class Scraper extends EventEmitter<ScraperEventTypes> {
 						url.withoutHashAndAuth,
 						isExternal,
 						imageLoadTimeout,
+						domEvaluationTimeout,
 					);
 				})()
 			: [];
@@ -691,6 +699,7 @@ export default class Scraper extends EventEmitter<ScraperEventTypes> {
 	 * @param url - The page URL string (without hash and auth)
 	 * @param isExternal - Whether the page is external
 	 * @param imageLoadTimeout - Timeout (ms) for waiting images to complete loading
+	 * @param domEvaluationTimeout - Timeout (ms) for the in-page image extraction `page.evaluate`
 	 * @returns Array of image elements from all device presets (may be partial if some viewports failed)
 	 */
 	@retryable({
@@ -720,6 +729,7 @@ export default class Scraper extends EventEmitter<ScraperEventTypes> {
 		url: string,
 		isExternal: boolean,
 		imageLoadTimeout: number,
+		domEvaluationTimeout: number,
 	): Promise<ImageElement[]> {
 		const listener = this.#createPageScanListener(isExternal);
 		const devices: { key: string; preset: { width: number; resolution?: number } }[] = [
@@ -767,7 +777,7 @@ export default class Scraper extends EventEmitter<ScraperEventTypes> {
 					isExternal,
 					message: `📸 ${key}: Extracting images%dots%`,
 				});
-				const images = await getImageList(page, preset.width);
+				const images = await getImageList(page, preset.width, domEvaluationTimeout);
 				imageList.push(...images);
 			} catch (error) {
 				const errorMessage = error instanceof Error ? error.message : String(error);

--- a/packages/@d-zero/beholder/src/types.ts
+++ b/packages/@d-zero/beholder/src/types.ts
@@ -427,4 +427,10 @@ export type ScraperOptions = {
 	headCheckResult?: PageData;
 	/** Timeout (ms) for page.goto(). Default: 60_000 (60s). */
 	navigationTimeout?: number;
+	/**
+	 * Timeout (ms) for DOM evaluation operations (meta/image/anchor extraction).
+	 * Bounds how long extraction may hang on a page with an unresponsive main thread.
+	 * Default: 30_000 (30s).
+	 */
+	domEvaluationTimeout?: number;
 };


### PR DESCRIPTION
## 概要

`@d-zero/beholder` の `getMeta` が、メインスレッドが応答しないページ（重い JS・自動再生プレイヤー・無限ループ等）に対して長時間ハングし、最終的に呼び出し側の全体タイムアウトに達するまで戻ってこない問題を修正する。リトライ構成では 1 URL あたり数分〜十数分を浪費し `status=-1`（ハード失敗）になっていた。

Closes #874

## 原因（`dom-evaluation.ts`）

1. `getPropBySelector` の `page.$()` にタイムアウトが無く、CDP が応答しないと無限に待つ
2. `getMeta` が `getPropBySelector` を ~14 個逐次 `await` し、各 10 秒 fallback が累積（10s × 14 ≈ 140s+）
3. `getProp` の `Promise.race` が負け側 `setTimeout` を `clearTimeout` せず、イベントループ滞留の原因に

## 変更内容

- **`getMeta`**: 14 回の CDP 往復を **1 回の `page.evaluate`** に集約し、`@d-zero/shared/race-with-timeout` の `raceWithTimeout` で全体を打ち切る。タイムアウト／失敗時は `{ title: '' }` を返す。
  - `page.evaluate` 自体もメインスレッドで動くため、組み込みタイムアウトの無い `page.evaluate` を race でラップすることがハング打ち切りの要。
- **`getImageList`**: 同様に 1 回の `page.evaluate` へ集約し race でラップ。タイムアウト時は `[]`。
- **`getProp`**: 漏れていたタイマーを `raceWithTimeout`（`clearTimeout` 実装済み）で解消。`getAnchorList` 経由でも恩恵。
- **`getAnchorList`**: アクセシブル名は CDP 専用機能（`accessibility.snapshot`）のため従来構造を維持しつつ、各 `getProp` をタイムアウト境界内に。
- **`ScraperOptions.domEvaluationTimeout`**（既定 30 秒）を追加し、取得成功を最大化できるよう設定可能に。

## 挙動変化（合意済み）

- 完全タイムアウト時の meta は `{ title: '' }` のみ（従来はそもそも全体タイムアウトでハード失敗）。`Meta` の該当フィールドは型上 optional。
- image の width/height は `getBoundingClientRect` ベース（従来の `boundingBox` と実質等価）。
- title は `document.title`（scraper.ts の既存 `document.title` 使用と整合）。

## 互換性

- `getMeta` 等は `index.ts` 未エクスポートの内部関数で**公開 API 変更なし**。
- 追加した `domEvaluationTimeout` は optional で**非破壊的**（v2.1.x のパッチ／マイナー範囲）。

## テスト

- `dom-evaluation.spec.ts` を新規追加（14 ケース）: 正常系のマッピング、タイムアウト／reject 時の fallback、画像 0 件、`getProp` のタイマークリア、`getAnchorList` の textContent フォールバックを検証。
- `yarn lint` / `yarn build` / `yarn test`（679 passed）すべてパス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)