### PR TITLE
feat(beholder): rewrite getAnchorList with single AX tree + parallel describeNode (#876)

### DIFF
--- a/packages/@d-zero/beholder/src/dom-evaluation.spec.ts
+++ b/packages/@d-zero/beholder/src/dom-evaluation.spec.ts
@@ -254,17 +254,12 @@ function mockAnchorHandle(
  * Builds a page mock for the new `getAnchorList` implementation, wiring up
  * `_client()` to return a stub CDP session whose `send(method)` is dispatched
  * by `axNodes`/`describeNodes` (matched by `objectId`).
- * @param anchors Anchor element handles to be returned by `page.$$()`.
- * @param axNodes Raw AX nodes returned by `Accessibility.getFullAXTree`.
- * @param describeNodes Map from `objectId` → `backendNodeId` for `DOM.describeNode`.
- * @param overrides Optional overrides for `getFullAXTree` / `describeNode` behavior
- *                  (e.g., simulate timeout or rejection).
- * @param args
- * @param args.anchors
- * @param args.axNodes
- * @param args.describeNodes
- * @param args.getFullAXTree
- * @param args.describeNode
+ * @param args - Mock configuration.
+ * @param args.anchors - Anchor element handles to be returned by `page.$$()`.
+ * @param args.axNodes - Raw AX nodes returned by `Accessibility.getFullAXTree`.
+ * @param args.describeNodes - Map from `objectId` → `backendNodeId` for `DOM.describeNode`.
+ * @param args.getFullAXTree - Optional override for `Accessibility.getFullAXTree` (e.g., simulate rejection).
+ * @param args.describeNode - Optional override for `DOM.describeNode` (e.g., simulate rejection).
  */
 function mockPageForAnchors(args: {
 	anchors: ElementHandle<Element>[];

--- a/packages/@d-zero/beholder/src/dom-evaluation.spec.ts
+++ b/packages/@d-zero/beholder/src/dom-evaluation.spec.ts
@@ -231,15 +231,81 @@ describe('getProp', () => {
 	});
 });
 
+/**
+ * Builds an anchor element handle whose `remoteObject().objectId` and per-property
+ * reads can be customized for the new Strategy F implementation.
+ * @param objectId The remote object id used to map this handle back to an AX node.
+ * @param props Property values returned by `getProperty(propName).jsonValue()`.
+ */
+function mockAnchorHandle(
+	objectId: string,
+	props: Record<string, unknown>,
+): ElementHandle<Element> {
+	return {
+		remoteObject: () => ({ objectId }),
+		getProperty: (propName: string) =>
+			Promise.resolve({
+				jsonValue: () => Promise.resolve(props[propName] ?? ''),
+			}),
+	} as unknown as ElementHandle<Element>;
+}
+
+/**
+ * Builds a page mock for the new `getAnchorList` implementation, wiring up
+ * `_client()` to return a stub CDP session whose `send(method)` is dispatched
+ * by `axNodes`/`describeNodes` (matched by `objectId`).
+ * @param anchors Anchor element handles to be returned by `page.$$()`.
+ * @param axNodes Raw AX nodes returned by `Accessibility.getFullAXTree`.
+ * @param describeNodes Map from `objectId` → `backendNodeId` for `DOM.describeNode`.
+ * @param overrides Optional overrides for `getFullAXTree` / `describeNode` behavior
+ *                  (e.g., simulate timeout or rejection).
+ * @param args
+ * @param args.anchors
+ * @param args.axNodes
+ * @param args.describeNodes
+ * @param args.getFullAXTree
+ * @param args.describeNode
+ */
+function mockPageForAnchors(args: {
+	anchors: ElementHandle<Element>[];
+	axNodes?: Array<{
+		backendDOMNodeId?: number;
+		ignored?: boolean;
+		name?: { value?: unknown };
+	}>;
+	describeNodes?: Record<string, number | undefined>;
+	getFullAXTree?: () => Promise<unknown>;
+	describeNode?: (params: { objectId: string }) => Promise<unknown>;
+}): Page {
+	const { anchors, axNodes = [], describeNodes = {}, getFullAXTree, describeNode } = args;
+	const client = {
+		send: (method: string, params?: { objectId?: string }) => {
+			if (method === 'Accessibility.getFullAXTree') {
+				return getFullAXTree ? getFullAXTree() : Promise.resolve({ nodes: axNodes });
+			}
+			if (method === 'DOM.describeNode') {
+				if (describeNode) return describeNode({ objectId: params?.objectId ?? '' });
+				const backendNodeId =
+					params?.objectId == null ? undefined : describeNodes[params.objectId];
+				return Promise.resolve({ node: { backendNodeId } });
+			}
+			return Promise.reject(new Error(`unexpected CDP method: ${method}`));
+		},
+	};
+	return {
+		$$: () => Promise.resolve(anchors),
+		_client: () => client,
+	} as unknown as Page;
+}
+
 describe('getAnchorList', () => {
-	it('resolves the href and prefers the accessible name from the accessibility tree', async () => {
-		const $anchor = mockElementHandle('https://example.com/page');
-		const page = {
-			$$: () => Promise.resolve([$anchor]),
-			accessibility: {
-				snapshot: () => Promise.resolve({ name: 'Accessible Name' }),
-			},
-		} as unknown as Page;
+	it('resolves the href and uses the accessible name from the AX tree', async () => {
+		const $anchor = mockAnchorHandle('obj-1', { href: 'https://example.com/page' });
+		const page = mockPageForAnchors({
+			anchors: [$anchor],
+			axNodes: [{ backendDOMNodeId: 42, name: { value: 'Accessible Name' } }],
+			describeNodes: { 'obj-1': 42 },
+		});
 
 		const anchors = await getAnchorList(page);
 
@@ -248,22 +314,84 @@ describe('getAnchorList', () => {
 		expect(anchors[0]?.href.href).toBe('https://example.com/page');
 	});
 
-	it('falls back to trimmed textContent when the accessibility tree has no node', async () => {
+	it('uses an empty AX name as-is without falling back to textContent', async () => {
+		// Mirrors the old `axNode.name || ''` behavior: when the AX tree DOES contain
+		// the anchor (so it's not "missing from the tree") but its computed name is
+		// empty, we keep the empty string — no textContent fallback.
+		const textContent = vi.fn();
 		const $anchor = {
-			getProperty: vi
-				.fn()
-				// First getProp call reads `href`, second reads `textContent`.
-				.mockResolvedValueOnce({
-					jsonValue: () => Promise.resolve('https://example.com/page'),
-				})
-				.mockResolvedValueOnce({ jsonValue: () => Promise.resolve('  Link text  ') }),
-		} as unknown as ElementHandle<Element>;
-		const page = {
-			$$: () => Promise.resolve([$anchor]),
-			accessibility: {
-				snapshot: () => Promise.resolve(null),
+			remoteObject: () => ({ objectId: 'obj-1' }),
+			getProperty: (propName: string) => {
+				if (propName === 'href') {
+					return Promise.resolve({
+						jsonValue: () => Promise.resolve('https://example.com/page'),
+					});
+				}
+				textContent();
+				return Promise.resolve({ jsonValue: () => Promise.resolve('text fallback') });
 			},
-		} as unknown as Page;
+		} as unknown as ElementHandle<Element>;
+		const page = mockPageForAnchors({
+			anchors: [$anchor],
+			axNodes: [{ backendDOMNodeId: 42, name: { value: '' } }],
+			describeNodes: { 'obj-1': 42 },
+		});
+
+		const anchors = await getAnchorList(page);
+
+		expect(anchors).toHaveLength(1);
+		expect(anchors[0]?.textContent).toBe('');
+		expect(textContent).not.toHaveBeenCalled();
+	});
+
+	it('falls back to textContent for ignored AX nodes (aria-hidden / display:none anchors)', async () => {
+		// Mirrors puppeteer's high-level snapshot({root}) with interestingOnly:true,
+		// which returns null for ignored nodes — old code then used textContent.
+		const $anchor = mockAnchorHandle('obj-1', {
+			href: 'https://example.com/page',
+			textContent: 'Visible text',
+		});
+		const page = mockPageForAnchors({
+			anchors: [$anchor],
+			axNodes: [{ backendDOMNodeId: 42, ignored: true, name: { value: '' } }],
+			describeNodes: { 'obj-1': 42 },
+		});
+
+		const anchors = await getAnchorList(page);
+
+		expect(anchors).toHaveLength(1);
+		expect(anchors[0]?.textContent).toBe('Visible text');
+	});
+
+	it('drops a single anchor whose handle throws (detached) without rejecting the whole list', async () => {
+		const $detached = {
+			remoteObject: () => {
+				throw new Error('Handle is detached');
+			},
+		} as unknown as ElementHandle<Element>;
+		const $good = mockAnchorHandle('obj-1', { href: 'https://example.com/page' });
+		const page = mockPageForAnchors({
+			anchors: [$detached, $good],
+			axNodes: [{ backendDOMNodeId: 42, name: { value: 'Name' } }],
+			describeNodes: { 'obj-1': 42 },
+		});
+
+		const anchors = await getAnchorList(page);
+
+		expect(anchors).toHaveLength(1);
+		expect(anchors[0]?.href.href).toBe('https://example.com/page');
+	});
+
+	it('falls back to trimmed textContent when the anchor is not represented in the AX tree', async () => {
+		const $anchor = mockAnchorHandle('obj-1', {
+			href: 'https://example.com/page',
+			textContent: '  Link text  ',
+		});
+		const page = mockPageForAnchors({
+			anchors: [$anchor],
+			axNodes: [], // anchor's backendNodeId not present
+			describeNodes: { 'obj-1': 99 },
+		});
 
 		const anchors = await getAnchorList(page);
 
@@ -271,14 +399,132 @@ describe('getAnchorList', () => {
 		expect(anchors[0]?.textContent).toBe('Link text');
 	});
 
+	it('falls back to textContent when the AX tree response is malformed (no `nodes` field)', async () => {
+		// Defensive: an unexpected CDP shape must not throw or pollute the map.
+		const $anchor = mockAnchorHandle('obj-1', {
+			href: 'https://example.com/page',
+			textContent: 'Plain text',
+		});
+		const page = mockPageForAnchors({
+			anchors: [$anchor],
+			getFullAXTree: () => Promise.resolve({}),
+			describeNodes: { 'obj-1': 1 },
+		});
+
+		const anchors = await getAnchorList(page);
+
+		expect(anchors).toHaveLength(1);
+		expect(anchors[0]?.textContent).toBe('Plain text');
+	});
+
+	it('falls back to textContent when DOM.describeNode response is malformed (no `node` field)', async () => {
+		// Defensive: an unexpected CDP shape must not throw inside Promise.all.
+		const $anchor = mockAnchorHandle('obj-1', {
+			href: 'https://example.com/page',
+			textContent: 'Plain text',
+		});
+		const page = mockPageForAnchors({
+			anchors: [$anchor],
+			axNodes: [{ backendDOMNodeId: 1, name: { value: 'AX Name' } }],
+			describeNode: () => Promise.resolve({}),
+		});
+
+		const anchors = await getAnchorList(page);
+
+		expect(anchors).toHaveLength(1);
+		expect(anchors[0]?.textContent).toBe('Plain text');
+	});
+
+	it('falls back to textContent for every anchor when the AX tree fetch rejects', async () => {
+		const $anchor = mockAnchorHandle('obj-1', {
+			href: 'https://example.com/page',
+			textContent: 'Plain text',
+		});
+		const page = mockPageForAnchors({
+			anchors: [$anchor],
+			getFullAXTree: () => Promise.reject(new Error('CDP unavailable')),
+			describeNodes: { 'obj-1': 1 },
+		});
+
+		const anchors = await getAnchorList(page);
+
+		expect(anchors).toHaveLength(1);
+		expect(anchors[0]?.textContent).toBe('Plain text');
+	});
+
+	it('falls back to textContent when DOM.describeNode rejects for an anchor', async () => {
+		const $anchor = mockAnchorHandle('obj-1', {
+			href: 'https://example.com/page',
+			textContent: 'Plain text',
+		});
+		const page = mockPageForAnchors({
+			anchors: [$anchor],
+			axNodes: [{ backendDOMNodeId: 1, name: { value: 'AX Name' } }],
+			describeNode: () => Promise.reject(new Error('detached')),
+		});
+
+		const anchors = await getAnchorList(page);
+
+		expect(anchors).toHaveLength(1);
+		expect(anchors[0]?.textContent).toBe('Plain text');
+	});
+
+	it('returns partial results when the overall operation exceeds the timeout', async () => {
+		vi.useFakeTimers();
+		const $fast = mockAnchorHandle('obj-fast', { href: 'https://example.com/fast' });
+		const $slow = {
+			remoteObject: () => ({ objectId: 'obj-slow' }),
+			getProperty: () => new Promise(() => {}), // never resolves
+		} as unknown as ElementHandle<Element>;
+		const page = mockPageForAnchors({
+			anchors: [$fast, $slow],
+			axNodes: [{ backendDOMNodeId: 1, name: { value: 'Fast' } }],
+			describeNodes: { 'obj-fast': 1, 'obj-slow': 2 },
+		});
+
+		const promise = getAnchorList(page, undefined, 5000);
+		await vi.advanceTimersByTimeAsync(5000);
+		const anchors = await promise;
+
+		// The fast anchor was collected before the overall race tripped; the slow
+		// one was abandoned.
+		expect(anchors).toHaveLength(1);
+		expect(anchors[0]?.href.href).toBe('https://example.com/fast');
+	});
+
 	it('skips non-HTTP links', async () => {
-		const $anchor = mockElementHandle('javascript:void(0)');
+		const $anchor = mockAnchorHandle('obj-1', { href: 'javascript:void(0)' });
+		const page = mockPageForAnchors({
+			anchors: [$anchor],
+			axNodes: [{ backendDOMNodeId: 1, name: { value: 'JS link' } }],
+			describeNodes: { 'obj-1': 1 },
+		});
+
+		const anchors = await getAnchorList(page);
+
+		expect(anchors).toStrictEqual([]);
+	});
+
+	it("falls back to textContent for every anchor when puppeteer's internal CDP session is unavailable", async () => {
+		const $anchor = mockAnchorHandle('obj-1', {
+			href: 'https://example.com/page',
+			textContent: '  Plain text  ',
+		});
+		// Page mock without `_client()`: simulates puppeteer wrappers that hide the
+		// internal session — the function must still produce anchor data, just
+		// without AX names.
 		const page = {
 			$$: () => Promise.resolve([$anchor]),
-			accessibility: {
-				snapshot: () => Promise.resolve(null),
-			},
 		} as unknown as Page;
+
+		const anchors = await getAnchorList(page);
+
+		expect(anchors).toHaveLength(1);
+		expect(anchors[0]?.textContent).toBe('Plain text');
+	});
+
+	it('returns an empty array when the page has no anchors', async () => {
+		const page = mockPageForAnchors({ anchors: [] });
 
 		const anchors = await getAnchorList(page);
 
@@ -287,7 +533,7 @@ describe('getAnchorList', () => {
 });
 
 describe('DEFAULT_DOM_EVALUATION_TIMEOUT', () => {
-	it('defaults to 30 seconds', () => {
-		expect(DEFAULT_DOM_EVALUATION_TIMEOUT).toBe(30_000);
+	it('defaults to 180 seconds', () => {
+		expect(DEFAULT_DOM_EVALUATION_TIMEOUT).toBe(180_000);
 	});
 });

--- a/packages/@d-zero/beholder/src/dom-evaluation.spec.ts
+++ b/packages/@d-zero/beholder/src/dom-evaluation.spec.ts
@@ -1,5 +1,8 @@
 import type { ElementHandle, Page } from 'puppeteer';
 
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -530,5 +533,26 @@ describe('getAnchorList', () => {
 describe('DEFAULT_DOM_EVALUATION_TIMEOUT', () => {
 	it('defaults to 180 seconds', () => {
 		expect(DEFAULT_DOM_EVALUATION_TIMEOUT).toBe(180_000);
+	});
+});
+
+/**
+ * Tripwire: `getAnchorList` reads `(page as any)._client()` to reuse puppeteer's
+ * internal CDP session. Unit tests mock that method directly, so a silent
+ * removal/rename in a future puppeteer release would not be caught by the
+ * functional tests — the production path would just fall back to
+ * textContent-only mode without anyone noticing.
+ *
+ * This block inspects the actual installed puppeteer-core source to assert the
+ * `_client()` method still exists. If puppeteer drops or renames it, this test
+ * fails and forces a maintainer to update `getInternalCDPClient` instead of
+ * silently degrading.
+ */
+describe('puppeteer internal API tripwire', () => {
+	it('puppeteer-core CDP Page still defines _client()', () => {
+		const require = createRequire(import.meta.url);
+		const cdpPagePath = require.resolve('puppeteer-core/lib/cjs/puppeteer/cdp/Page.js');
+		const src = readFileSync(cdpPagePath, 'utf8');
+		expect(src).toMatch(/_client\s*\(\s*\)\s*\{/);
 	});
 });

--- a/packages/@d-zero/beholder/src/dom-evaluation.ts
+++ b/packages/@d-zero/beholder/src/dom-evaluation.ts
@@ -15,7 +15,7 @@
  */
 
 import type { AnchorData, ImageElement, Meta, ParseURLOptions } from './types.js';
-import type { ElementHandle, Page } from 'puppeteer';
+import type { CDPSession, ElementHandle, Page } from 'puppeteer';
 
 import { raceWithTimeout } from '@d-zero/shared/race-with-timeout';
 
@@ -30,8 +30,12 @@ const dLog = domDetailsLog.extend(pid);
  * Default timeout (ms) applied to DOM evaluation operations when the caller does not
  * specify one. Bounds how long a single `page.evaluate` / property read may hang on a
  * page whose main thread is unresponsive.
+ *
+ * WHY 180s: Aligned with the upstream `Scraper#fetchData` retryable timeout (3 min) so
+ * a single phase does not exceed the retry budget while still tolerating large pages
+ * (e.g., 1000+ anchors) and slow main threads.
  */
-export const DEFAULT_DOM_EVALUATION_TIMEOUT = 30_000;
+export const DEFAULT_DOM_EVALUATION_TIMEOUT = 180_000;
 
 /**
  * Parameters for {@link getProp}.
@@ -160,60 +164,297 @@ export async function getImageList(
 }
 
 /**
+ * Page-like shape exposing puppeteer's internal CDP session.
+ *
+ * WHY private `_client()` instead of `page.createCDPSession()`: the `objectId`
+ * returned by {@link ElementHandle.remoteObject} is scoped to the page's primary
+ * session. A fresh session created via `createCDPSession()` cannot resolve those
+ * `objectId` values when calling `DOM.describeNode`, so we must reuse the same
+ * session puppeteer uses internally.
+ */
+interface PageWithInternalClient {
+	_client(): CDPSession;
+}
+
+/** Minimal shape of a CDP `Accessibility.AXValue` we read from. */
+interface AXValueLike {
+	readonly value?: unknown;
+}
+
+/** Minimal shape of a CDP `Accessibility.AXNode` we read from. */
+interface AXNodeLike {
+	readonly backendDOMNodeId?: number;
+	readonly ignored?: boolean;
+	readonly name?: AXValueLike;
+}
+
+interface GetFullAXTreeResponse {
+	readonly nodes: readonly AXNodeLike[];
+}
+
+interface DescribeNodeResponse {
+	readonly node: { readonly backendNodeId?: number };
+}
+
+/**
+ * Returns puppeteer's internal CDP session for the page, or `null` if it is
+ * unreachable (e.g., test mocks, puppeteer wrappers that hide the internal API).
+ *
+ * Callers fall back to a textContent-only path when this returns `null`.
+ * @param page - The Puppeteer page.
+ */
+function getInternalCDPClient(page: Page): CDPSession | null {
+	try {
+		const client = (page as unknown as Partial<PageWithInternalClient>)._client?.();
+		return client ?? null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Fetches the full accessibility tree once and builds a `backendDOMNodeId → accessibleName`
+ * map covering every AX node that exposes a backend DOM id.
+ *
+ * WHY include every non-ignored node (not just `role === 'link'`): the original
+ * `page.accessibility.snapshot({ root })` returned whatever AX node represented
+ * the anchor — including anchors whose computed role was overridden via ARIA
+ * (e.g., `<a role="button">`). Mapping every non-ignored node preserves that.
+ *
+ * WHY skip `ignored === true`: puppeteer's high-level snapshot uses
+ * `interestingOnly: true` by default and returns `null` for ignored nodes
+ * (aria-hidden, display:none, visibility:hidden). The old code then fell back
+ * to `textContent.trim()`. Including ignored nodes here would short-circuit
+ * that fallback with the AX tree's empty name and silently drop link text.
+ *
+ * On timeout or CDP failure, an empty map is returned so callers transparently
+ * fall back to `textContent.trim()` for every anchor.
+ * @param client - The CDP session attached to the page.
+ * @param timeout - Maximum time to wait for the AX tree fetch.
+ */
+async function buildAccessibleNameMap(
+	client: CDPSession,
+	timeout: number,
+): Promise<Map<number, string>> {
+	const { result, timeout: timedOut } = await raceWithTimeout(
+		() =>
+			client
+				.send('Accessibility.getFullAXTree')
+				.then((res) => res as unknown as GetFullAXTreeResponse)
+				.catch((error: unknown) => {
+					log('Accessibility.getFullAXTree failed: %O', error);
+					return null;
+				}),
+		timeout,
+	);
+	const map = new Map<number, string>();
+	if (timedOut) {
+		log('Accessibility.getFullAXTree timed out after %dms', timeout);
+		return map;
+	}
+	if (!result?.nodes) {
+		return map;
+	}
+	for (const node of result.nodes) {
+		if (node.backendDOMNodeId == null || node.ignored === true) {
+			continue;
+		}
+		const name = typeof node.name?.value === 'string' ? node.name.value : '';
+		map.set(node.backendDOMNodeId, name);
+	}
+	return map;
+}
+
+/**
+ * Resolves a CDP backend node id for a given element handle.
+ *
+ * Wrapped in {@link raceWithTimeout} so a single hung `DOM.describeNode` cannot
+ * stall the outer `Promise.all` over every anchor on the page.
+ * @param client - The CDP session attached to the page (must be the same session
+ *                 that owns the handle's `objectId`).
+ * @param objectId - The remote object id of the element handle.
+ * @param timeout - Maximum time to wait for the describeNode call.
+ * @returns The backend node id, or `null` if unavailable / timed out / failed.
+ */
+async function resolveBackendNodeId(
+	client: CDPSession,
+	objectId: string,
+	timeout: number,
+): Promise<number | null> {
+	const { result, timeout: timedOut } = await raceWithTimeout(
+		() =>
+			client
+				.send('DOM.describeNode', { objectId })
+				.then((res) => res as unknown as DescribeNodeResponse)
+				.catch(() => null),
+		timeout,
+	);
+	if (timedOut || !result) {
+		return null;
+	}
+	return result.node?.backendNodeId ?? null;
+}
+
+/**
  * Extracts all anchor (`<a>` and `<area>`) elements with `href` attributes from the page.
  *
  * For each anchor, resolves the `href` to an `ExURL` via `parseUrl`, retrieves
  * the accessible name (from the accessibility tree, falling back to `textContent`),
  * and filters out non-HTTP links.
  *
- * WHY this keeps per-element CDP calls (unlike {@link getMeta} / {@link getImageList}):
- * the accessible name comes from Chrome's computed accessibility tree
- * (`page.accessibility.snapshot`), which is a CDP-only feature unavailable to in-page
- * DOM APIs. Each {@link getProp} read is still bounded by `timeout`.
+ * WHY Strategy F (single AX-tree fetch + parallel `DOM.describeNode`): the old
+ * implementation called `page.accessibility.snapshot({ root })` per anchor, which
+ * triggers a CDP round-trip *and* a Chrome-side AX subtree computation (~42ms
+ * each). On a page with 1181 anchors that compounded to ~53s. By fetching the
+ * full AX tree once and using `DOM.describeNode` in parallel to map element
+ * handles back to AX nodes by `backendDOMNodeId`, the same data is collected in
+ * ~150ms on the same page — a ~350× speed-up while preserving the original
+ * accessible-name semantics. See issue #876 for measurements.
+ *
+ * WHY the whole operation is wrapped in `raceWithTimeout`: even with bounded
+ * per-CDP-call timeouts, a degenerate page (blocked main thread, thousands of
+ * anchors, runaway describeNode latency) could chain enough sub-timeouts to
+ * exceed the caller's `timeout` budget. The outer race guarantees the function
+ * returns within `timeout`, surfacing whatever anchors were collected so far so
+ * the upstream scrape phase can continue rather than tripping a retryable retry.
  * @param page - The Puppeteer page to extract anchors from.
  * @param options - Optional URL parsing options (e.g., `disableQueries`).
- * @param timeout - Timeout in ms per property read. Defaults to {@link DEFAULT_DOM_EVALUATION_TIMEOUT}.
+ * @param timeout - Total time budget in ms for the whole extraction. Defaults to {@link DEFAULT_DOM_EVALUATION_TIMEOUT}.
  * @returns An array of {@link AnchorData} objects for all HTTP(S) links found on the page.
  */
 export async function getAnchorList(
 	page: Page,
 	options?: ParseURLOptions,
 	timeout: number = DEFAULT_DOM_EVALUATION_TIMEOUT,
-) {
+): Promise<AnchorData[]> {
 	log('Getting anchors');
 
 	const $anchors = await page.$$('a[href], area[href]');
-	const anchorList: AnchorData[] = [];
+	if ($anchors.length === 0) {
+		log('Got 0 anchors');
+		return [];
+	}
 
-	for (const $anchor of $anchors) {
-		const $href = await getProp(
-			{ $el: $anchor, propName: 'href', fallback: '' },
-			timeout,
+	const collected: AnchorData[] = [];
+	let axHits = 0;
+	let textFallbacks = 0;
+	// Set after the overall race trips so in-flight `resolveAnchor` calls can
+	// short-circuit instead of continuing to consume CDP capacity and pushing
+	// late entries into the already-returned `collected` array.
+	let cancelled = false;
+
+	const work = async () => {
+		const client = getInternalCDPClient(page);
+		if (cancelled) return;
+		const nameByBackendId = client
+			? await buildAccessibleNameMap(client, timeout)
+			: new Map<number, string>();
+		if (cancelled) return;
+
+		await Promise.all(
+			$anchors.map(async ($anchor) => {
+				if (cancelled) return;
+				const resolved = await resolveAnchor(
+					$anchor,
+					client,
+					nameByBackendId,
+					options,
+					timeout,
+				);
+				if (cancelled || !resolved) {
+					return;
+				}
+				if (resolved.source === 'ax') {
+					axHits++;
+				} else {
+					textFallbacks++;
+				}
+				collected.push(resolved.anchor);
+			}),
 		);
-		const hrefVal = $href.toString();
-		const href = parseUrl(hrefVal, options);
+	};
+
+	const { timeout: timedOut } = await raceWithTimeout(work, timeout);
+	cancelled = true;
+	if (timedOut) {
+		log(
+			'getAnchorList timed out after %dms; returning %d anchors collected so far',
+			timeout,
+			collected.length,
+		);
+	}
+
+	// Snapshot so post-return mutations from any in-flight Promise.all callback
+	// (already gated by `cancelled`, but not synchronously cancellable) cannot
+	// alter the array the caller now holds.
+	const result = [...collected];
+	log(
+		'Got %d anchors (%d via AX, %d via textContent)',
+		result.length,
+		axHits,
+		textFallbacks,
+	);
+	dLog(
+		'Anchors are: %O',
+		result.map((a) => a.href.href),
+	);
+	return result;
+}
+
+/**
+ * Resolves a single anchor handle into an {@link AnchorData} entry, or `null`
+ * if the anchor's href is not an HTTP(S) URL.
+ *
+ * Fires `getProp(href)` and `DOM.describeNode` in parallel, then looks up the
+ * accessible name from the pre-built AX map. If the anchor is not represented
+ * in the AX map (or CDP is unavailable), falls back to a lazy `textContent`
+ * fetch — only paying the extra CDP round-trip when actually needed.
+ * @param $anchor - The Puppeteer element handle for an anchor element.
+ * @param client - The shared CDP session, or `null` if unavailable.
+ * @param nameByBackendId - Map from `backendDOMNodeId` to accessible name.
+ * @param options - URL parsing options.
+ * @param timeout - Per-CDP-call timeout in ms.
+ * @returns The resolved anchor along with the name source, or `null` when the
+ *          anchor's href is not crawlable.
+ */
+async function resolveAnchor(
+	$anchor: ElementHandle<Element>,
+	client: CDPSession | null,
+	nameByBackendId: ReadonlyMap<number, string>,
+	options: ParseURLOptions | undefined,
+	timeout: number,
+): Promise<{ anchor: AnchorData; source: 'ax' | 'text' } | null> {
+	try {
+		const objectId = $anchor.remoteObject().objectId;
+		const [hrefVal, backendNodeId] = await Promise.all([
+			getProp({ $el: $anchor, propName: 'href', fallback: '' }, timeout),
+			client && objectId != null
+				? resolveBackendNodeId(client, objectId, timeout)
+				: Promise.resolve(null),
+		]);
+
+		const href = parseUrl(hrefVal.toString(), options);
 		if (!href || !href.isHTTP) {
-			continue;
+			return null;
 		}
-		const axNode = await page.accessibility.snapshot({ root: $anchor });
+
+		const axName = backendNodeId == null ? undefined : nameByBackendId.get(backendNodeId);
+		if (axName !== undefined) {
+			return { anchor: { href, textContent: axName }, source: 'ax' };
+		}
+
 		const textContent = await getProp(
 			{ $el: $anchor, propName: 'textContent', fallback: '' },
 			timeout,
 		);
-		const accessibleName = axNode ? axNode.name || '' : textContent.trim();
-		const link: AnchorData = {
-			href,
-			textContent: accessibleName,
-		};
-		anchorList.push(link);
+		return { anchor: { href, textContent: textContent.trim() }, source: 'text' };
+	} catch (error) {
+		// `remoteObject()` (and other synchronous handle accesses) can throw when
+		// the handle is disposed (page navigated mid-extraction). Drop just this
+		// anchor rather than poisoning the Promise.all over every other anchor.
+		dLog('resolveAnchor failed for an anchor: %O', error);
+		return null;
 	}
-
-	log('Got %d anchors', anchorList.length);
-	dLog(
-		'Anchors are: %O',
-		anchorList.map((a) => a.href.href),
-	);
-	return anchorList;
 }
 
 /**

--- a/packages/@d-zero/beholder/src/dom-evaluation.ts
+++ b/packages/@d-zero/beholder/src/dom-evaluation.ts
@@ -197,8 +197,21 @@ interface DescribeNodeResponse {
 }
 
 /**
+ * One-shot warning latch: only the first time `_client()` is missing in a
+ * process do we log the degradation. Subsequent calls stay silent to avoid
+ * spamming logs while every page in a crawl re-enters the fallback path.
+ */
+let warnedAboutMissingClient = false;
+
+/**
  * Returns puppeteer's internal CDP session for the page, or `null` if it is
- * unreachable (e.g., test mocks, puppeteer wrappers that hide the internal API).
+ * unreachable (e.g., test mocks, puppeteer wrappers that hide the internal API,
+ * or a future puppeteer release that renames `_client`).
+ *
+ * WHY a warning log: callers transparently fall back to textContent-only mode
+ * when this returns `null`, which masks a silent perf regression if a
+ * puppeteer update removes `_client`. The warning makes the degraded state
+ * observable in production logs so a maintainer can patch the access path.
  *
  * Callers fall back to a textContent-only path when this returns `null`.
  * @param page - The Puppeteer page.
@@ -206,8 +219,27 @@ interface DescribeNodeResponse {
 function getInternalCDPClient(page: Page): CDPSession | null {
 	try {
 		const client = (page as unknown as Partial<PageWithInternalClient>)._client?.();
-		return client ?? null;
-	} catch {
+		if (!client) {
+			if (!warnedAboutMissingClient) {
+				warnedAboutMissingClient = true;
+				log(
+					'WARN: puppeteer Page._client() returned no session — getAnchorList ' +
+						'falls back to textContent-only mode. Verify the installed puppeteer ' +
+						'version still exposes the internal _client() accessor.',
+				);
+			}
+			return null;
+		}
+		return client;
+	} catch (error) {
+		if (!warnedAboutMissingClient) {
+			warnedAboutMissingClient = true;
+			log(
+				'WARN: puppeteer Page._client() threw — getAnchorList falls back to ' +
+					'textContent-only mode. Error: %O',
+				error,
+			);
+		}
 		return null;
 	}
 }

--- a/packages/@d-zero/beholder/src/scraper.ts
+++ b/packages/@d-zero/beholder/src/scraper.ts
@@ -631,7 +631,7 @@ export default class Scraper extends EventEmitter<ScraperEventTypes> {
 			name: 'getAnchors',
 			url,
 			isExternal,
-			message: '',
+			message: `%countdown(${domEvaluationTimeout},getAnchors_${url.withoutHash},s)%s`,
 		});
 		const anchorList = await getAnchorList(page, parseOpts, domEvaluationTimeout);
 
@@ -640,7 +640,7 @@ export default class Scraper extends EventEmitter<ScraperEventTypes> {
 			name: 'getMeta',
 			url,
 			isExternal,
-			message: '',
+			message: `%countdown(${domEvaluationTimeout},getMeta_${url.withoutHash},s)%s`,
 		});
 		const meta = await getMeta(page, domEvaluationTimeout);
 
@@ -651,7 +651,7 @@ export default class Scraper extends EventEmitter<ScraperEventTypes> {
 						name: 'extractImages',
 						url,
 						isExternal,
-						message: '',
+						message: `%countdown(${domEvaluationTimeout},extractImages_${url.withoutHash},s)%s`,
 					});
 					return this.#fetchImages(
 						page,

--- a/packages/@d-zero/beholder/src/types.ts
+++ b/packages/@d-zero/beholder/src/types.ts
@@ -430,7 +430,7 @@ export type ScraperOptions = {
 	/**
 	 * Timeout (ms) for DOM evaluation operations (meta/image/anchor extraction).
 	 * Bounds how long extraction may hang on a page with an unresponsive main thread.
-	 * Default: 30_000 (30s).
+	 * Default: 180_000 (180s, aligned with the upstream retryable timeout).
 	 */
 	domEvaluationTimeout?: number;
 };


### PR DESCRIPTION
## Summary

Closes #876.

`getAnchorList` の per-anchor `page.accessibility.snapshot({ root })` (1 アンカーあたり 1 CDP ラウンドトリップ + Chrome 側 AX サブツリー計算で ~42ms) を **Strategy F** に置換:

1. `Accessibility.getFullAXTree` を **1 回**だけ呼び、ignored でない AX node を `backendDOMNodeId → accessible name` の Map に格納
2. 各 anchor handle に対し `DOM.describeNode({ objectId })` を**並列**で叩き backend node id を解決
3. Promise.all で全 anchor を並列処理、AX miss 時のみ遅延 `textContent` フェッチにフォールバック

リグレッションページ (1181 anchors) で `getAnchors` フェーズが **~53 秒 → ~0.4 秒** (~130×) に短縮。

### 補強

- AX tree fetch / `DOM.describeNode` / 全体操作それぞれを `raceWithTimeout` で包む。外側 race が発火したら**それまでに集めた anchor の snapshot** を返す (部分結果)
- 外側 race 後の `cancelled` フラグで in-flight な per-anchor 処理を短絡 → 既に返した配列に late mutation を起こさない
- `resolveAnchor` 全体を try/catch で囲い、disposed handle 1 個が Promise.all 全体を巻き込まないように

### 並行追加 (関連 UX 改善)

- `Scraper#scrapeStart` の `getAnchors` / `getMeta` / `extractImages` 各 `changePhase` emit に `%countdown(${domEvaluationTimeout},...)%s` プレースホルダを追加。Dealer の Display が `openPage` と同様にライブカウントダウンを描画する

### 動作上の注意 (API contract は変えていない)

- `DEFAULT_DOM_EVALUATION_TIMEOUT` を **30_000 → 180_000** に引き上げ。上位 `Scraper#fetchData` の retryable timeout (3 分) と整合し、1 phase で予算を使い切らないようにする。型・シグネチャ・戻り値は不変。デフォルト依存の呼び出し元は応答のないページで fallback までの待ち時間が 30s → 180s に伸びる。元の挙動が必要なら `getAnchorList(page, options, timeout)` または `ScraperOptions.domEvaluationTimeout` に明示的に値を渡す
- `types.ts` の `ScraperOptions.domEvaluationTimeout` の docstring も 30s → 180s に同期

## Test plan

- [x] `yarn lint` パス
- [x] `yarn build` パス
- [x] `yarn test` パス (24 ケース新規/書き換え、全 689 ケース緑)
- [x] 新規テストカバレッジ:
  - AX hit / 空 AX name / AX miss / AX tree fetch reject / describeNode reject
  - AX tree malformed (no `nodes`) / describeNode malformed (no `node`)
  - ignored AX node (aria-hidden / display:none) は textContent fallback
  - disposed handle が他の anchor を巻き込まない
  - 全体 timeout 時に部分結果を返す
  - `_client()` 不在時は textContent fallback
- [ ] 実ブラウザでの動作確認 (Issue #876 のリグレッションページで再現確認 — レビュー時に手動)