### PR TITLE
fix(a11y-check-axe-scenario): support @axe-core/puppeteer 4.11.3

### DIFF
--- a/packages/@d-zero/a11y-check-axe-scenario/package.json
+++ b/packages/@d-zero/a11y-check-axe-scenario/package.json
@@ -23,7 +23,7 @@
 		"clean": "tsc --build --clean"
 	},
 	"dependencies": {
-		"@axe-core/puppeteer": "4.11.0",
+		"@axe-core/puppeteer": "4.11.3",
 		"@d-zero/a11y-check-core": "0.7.3",
 		"@d-zero/db-wcag": "1.0.0-alpha.1",
 		"@d-zero/shared": "0.22.0"

--- a/packages/@d-zero/a11y-check-axe-scenario/package.json
+++ b/packages/@d-zero/a11y-check-axe-scenario/package.json
@@ -29,11 +29,11 @@
 		"@d-zero/shared": "0.22.0"
 	},
 	"devDependencies": {
-		"axe-core": "4.11.1",
+		"axe-core": "4.11.4",
 		"puppeteer": "24.37.5"
 	},
 	"peerDependencies": {
-		"axe-core": "4.11.1",
+		"axe-core": "4.11.4",
 		"puppeteer": "24.37.5"
 	},
 	"repository": {

--- a/packages/@d-zero/a11y-check-axe-scenario/src/axe.ts
+++ b/packages/@d-zero/a11y-check-axe-scenario/src/axe.ts
@@ -1,7 +1,7 @@
 import type { A11yCheckAxeOptions } from './types.js';
 import type { AxeResults } from 'axe-core';
 
-import AxePuppeteer from '@axe-core/puppeteer';
+import { AxePuppeteer } from '@axe-core/puppeteer';
 import { createScenario } from '@d-zero/a11y-check-core';
 import { Cache } from '@d-zero/shared/cache';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -966,10 +966,10 @@ __metadata:
     "@d-zero/a11y-check-core": "npm:0.7.3"
     "@d-zero/db-wcag": "npm:1.0.0-alpha.1"
     "@d-zero/shared": "npm:0.22.0"
-    axe-core: "npm:4.11.1"
+    axe-core: "npm:4.11.4"
     puppeteer: "npm:24.37.5"
   peerDependencies:
-    axe-core: 4.11.1
+    axe-core: 4.11.4
     puppeteer: 24.37.5
   languageName: unknown
   linkType: soft
@@ -5008,14 +5008,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axe-core@npm:4.11.1":
-  version: 4.11.1
-  resolution: "axe-core@npm:4.11.1"
-  checksum: 10c0/1e6997454b61c7c9a4d740f395952835dcf87f2c04fd81577217d68634d197d602c224f9e8f17b22815db4c117a2519980cfc8911fc0027c54a6d8ebca47c6a7
-  languageName: node
-  linkType: hard
-
-"axe-core@npm:~4.11.4":
+"axe-core@npm:4.11.4, axe-core@npm:~4.11.4":
   version: 4.11.4
   resolution: "axe-core@npm:4.11.4"
   checksum: 10c0/c4aa83fc3eac5f7a0d0cb1a28f9d073acf0c06ce8daacc38608faa278c57ce084c028c850746b98817ae4c101c30c1a32e95ea34748c4b4c7419b9b81221ef84

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,14 +45,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@axe-core/puppeteer@npm:4.11.0":
-  version: 4.11.0
-  resolution: "@axe-core/puppeteer@npm:4.11.0"
+"@axe-core/puppeteer@npm:4.11.3":
+  version: 4.11.3
+  resolution: "@axe-core/puppeteer@npm:4.11.3"
   dependencies:
-    axe-core: "npm:~4.11.0"
+    axe-core: "npm:~4.11.4"
   peerDependencies:
     puppeteer: ">=1.10.0"
-  checksum: 10c0/4599f0d8a925172bbe0f380e9330616b56f08eed93495f94c84086e4adf1ce191e73e876ec7df08eaf15252028cdfb7b70a688e1f237e1a0cb29317970a86df0
+  checksum: 10c0/adca342479d1cff0cef2db9eb8ef898aa9d843e76dc1269bcf4fe8fc58d3461b773e8e85bc1ae3c8dc3f7e3aa185dca4170ecf1212d5d6e7651a329afe76badd
   languageName: node
   linkType: hard
 
@@ -962,7 +962,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@d-zero/a11y-check-axe-scenario@workspace:packages/@d-zero/a11y-check-axe-scenario"
   dependencies:
-    "@axe-core/puppeteer": "npm:4.11.0"
+    "@axe-core/puppeteer": "npm:4.11.3"
     "@d-zero/a11y-check-core": "npm:0.7.3"
     "@d-zero/db-wcag": "npm:1.0.0-alpha.1"
     "@d-zero/shared": "npm:0.22.0"
@@ -5008,10 +5008,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axe-core@npm:4.11.1, axe-core@npm:~4.11.0":
+"axe-core@npm:4.11.1":
   version: 4.11.1
   resolution: "axe-core@npm:4.11.1"
   checksum: 10c0/1e6997454b61c7c9a4d740f395952835dcf87f2c04fd81577217d68634d197d602c224f9e8f17b22815db4c117a2519980cfc8911fc0027c54a6d8ebca47c6a7
+  languageName: node
+  linkType: hard
+
+"axe-core@npm:~4.11.4":
+  version: 4.11.4
+  resolution: "axe-core@npm:4.11.4"
+  checksum: 10c0/c4aa83fc3eac5f7a0d0cb1a28f9d073acf0c06ce8daacc38608faa278c57ce084c028c850746b98817ae4c101c30c1a32e95ea34748c4b4c7419b9b81221ef84
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

PR #834（`@axe-core/puppeteer` を 4.11.3 へバンプ）がビルド失敗していたのを解消する。併せて `axe-core` も実体に合わせて 4.11.4 に更新。

- `@axe-core/puppeteer@4.11.1` 以降で exports の順序が変更され（types を先頭に配置: dequelabs/axe-core-npm#1261）、NodeNext + esModuleInterop 環境でデフォルトインポートが「constructable でない」と TypeScript に判定されるようになった。`AxePuppeteer` を named import に変更して回避。
- `axe-core` を 4.11.1 → 4.11.4 に更新（`@axe-core/puppeteer@4.11.3` がバンドルする `axe-core: ~4.11.4` 実体に揃える）。

## Test plan

- [x] `yarn build`
- [x] `yarn test`（769 tests passed）
- [x] `yarn lint`