### PR TITLE
fix(beholder): finish closing the #fetchImages detached-Frame race

### DIFF
--- a/packages/@d-zero/beholder/src/scraper.ts
+++ b/packages/@d-zero/beholder/src/scraper.ts
@@ -320,9 +320,18 @@ export default class Scraper extends EventEmitter<ScraperEventTypes> {
 	/**
 	 * Navigates the page to the target URL and extracts full page data.
 	 *
-	 * WHY retryable with 3-min timeout: Page navigation can fail due to transient
-	 * network issues or slow-loading pages. The decorator retries automatically,
-	 * emitting `retryWait` / `retryExhausted` phase events for progress monitoring.
+	 * WHY retryable with 25-min timeout: Page navigation can fail due to
+	 * transient network issues or slow-loading pages. The decorator retries
+	 * automatically, emitting `retryWait` / `retryExhausted` phase events for
+	 * progress monitoring. The timeout must accommodate the worst-case
+	 * `#fetchImages` runtime (its own @retryable allows up to 20 min for
+	 * pages with very large `scrollHeight` at narrow viewports). A shorter
+	 * `#fetchData` timeout would race `#fetchImages` to completion: when the
+	 * outer race fires first, `Promise.race` does not cancel the inner
+	 * `#fetchImages`, so a new `#fetchData` retry starts while the previous
+	 * attempt's scroll evaluates are still running on the same page —
+	 * exactly the collision that surfaces as "Attempted to use detached
+	 * Frame" or "Session closed".
 	 *
 	 * Flow:
 	 * 1. Register request/response/requestfailed listeners to capture sub-resources (internal pages only)
@@ -342,7 +351,7 @@ export default class Scraper extends EventEmitter<ScraperEventTypes> {
 	 * @returns Full page data or skipped page data if an exclusion rule matched
 	 */
 	@retryable({
-		timeout: 3 * 60 * 1000,
+		timeout: 25 * 60 * 1000,
 		onWait(this: Scraper, determinedInterval, retryCount, methodName, error) {
 			void this.emit('changePhase', {
 				pid: process.pid,

--- a/packages/@d-zero/puppeteer-scroll/src/scroll-all-over.spec.ts
+++ b/packages/@d-zero/puppeteer-scroll/src/scroll-all-over.spec.ts
@@ -213,4 +213,60 @@ describe('scrollAllOver', () => {
 
 		expect(evaluateCalls[1]?.args[0]).toBe(1);
 	});
+
+	it('page.evaluate が detached Frame で reject したら短い遅延後にリトライして進行する', async () => {
+		const evaluate = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("Attempted to use detached Frame 'X'."))
+			.mockResolvedValueOnce(300)
+			.mockResolvedValueOnce([200, 300])
+			.mockResolvedValueOnce([300, 300])
+			.mockResolvedValue();
+		const page = { evaluate } as unknown as Page;
+		const logger = vi.fn();
+
+		await scrollAllOver(page, { interval: 0, logger });
+
+		expect(evaluate).toHaveBeenCalled();
+		expect(logger).toHaveBeenCalledWith(300, 300, 'End of page');
+	});
+
+	it('page.evaluate が Session closed で reject してもリトライで吸収される', async () => {
+		const evaluate = vi
+			.fn()
+			.mockResolvedValueOnce(300)
+			.mockRejectedValueOnce(
+				new Error('Protocol error (Runtime.callFunctionOn): Session closed.'),
+			)
+			.mockResolvedValueOnce([200, 300])
+			.mockResolvedValueOnce([300, 300])
+			.mockResolvedValue();
+		const page = { evaluate } as unknown as Page;
+		const logger = vi.fn();
+
+		await scrollAllOver(page, { interval: 0, logger });
+
+		expect(logger).toHaveBeenCalledWith(300, 300, 'End of page');
+	});
+
+	it('detached Frame が連続 3 回続くと諦めて呼び出し元にエラーを伝播する', async () => {
+		const evaluate = vi
+			.fn()
+			.mockRejectedValue(new Error("Attempted to use detached Frame 'X'."));
+		const page = { evaluate } as unknown as Page;
+
+		await expect(scrollAllOver(page, { interval: 0 })).rejects.toThrow(
+			"Attempted to use detached Frame 'X'.",
+		);
+	});
+
+	it('detached Frame 以外のエラーは即座に伝播し、リトライされない', async () => {
+		const evaluate = vi
+			.fn()
+			.mockRejectedValue(new Error('TypeError: foo is not a function'));
+		const page = { evaluate } as unknown as Page;
+
+		await expect(scrollAllOver(page, { interval: 0 })).rejects.toThrow('TypeError');
+		expect(evaluate).toHaveBeenCalledTimes(1);
+	});
 });

--- a/packages/@d-zero/puppeteer-scroll/src/scroll-all-over.ts
+++ b/packages/@d-zero/puppeteer-scroll/src/scroll-all-over.ts
@@ -15,6 +15,51 @@ import { resolveValue } from './resolve-value.js';
 const MAX_STUCK_ITERATIONS = 3;
 
 /**
+ * Max attempts for each `page.evaluate` call when it fails with a transient
+ * frame error (Chrome may briefly swap or re-attach the main frame during a
+ * long scroll, even when the target site is not doing anything observable).
+ * Three attempts with a 200 ms gap absorbs the typical re-attach window
+ * without masking a genuinely broken page.
+ */
+const MAX_EVALUATE_RETRIES = 3;
+const DETACHED_RETRY_DELAY_MS = 200;
+
+/**
+ * Transient errors that occur when `page.evaluate` lands inside Puppeteer's
+ * own frame-swap or session-teardown window. Retrying after a short delay
+ * usually succeeds because the new execution context is then in place.
+ * @param error - Error caught from `page.evaluate`.
+ * @returns `true` when the error is a known transient frame/session error.
+ */
+function isTransientFrameError(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	return /Attempted to use detached Frame|Session closed|Execution context was destroyed/i.test(
+		error.message,
+	);
+}
+
+/**
+ * Retries `evaluator` (typically a `page.evaluate` call) when it fails with
+ * a transient frame error. Non-transient errors are re-thrown immediately.
+ * @template T - Evaluator return type.
+ * @param evaluator - Thunk that performs a single `page.evaluate` call.
+ * @returns Whatever `evaluator` returns on success.
+ */
+async function evaluateWithFrameRetry<T>(evaluator: () => Promise<T>): Promise<T> {
+	let lastError: unknown;
+	for (let attempt = 0; attempt < MAX_EVALUATE_RETRIES; attempt++) {
+		try {
+			return await evaluator();
+		} catch (error) {
+			lastError = error;
+			if (!isTransientFrameError(error)) throw error;
+			await new Promise((resolve) => setTimeout(resolve, DETACHED_RETRY_DELAY_MS));
+		}
+	}
+	throw lastError;
+}
+
+/**
  * Default interval range (ms) used when `options.interval` is omitted.
  * Randomized to mimic human-like reading pauses while staying close to the
  * historical 300 ms fixed default.
@@ -57,7 +102,9 @@ export async function scrollAllOver(page: Page, options?: Options) {
 	const distance = options?.distance;
 
 	let currentScrollY = 0;
-	let scrollHeight = await page.evaluate(() => document.body.scrollHeight);
+	let scrollHeight = await evaluateWithFrameRetry(() =>
+		page.evaluate(() => document.body.scrollHeight),
+	);
 	let prevScrollY = -1;
 	let stuckCount = 0;
 
@@ -66,28 +113,30 @@ export async function scrollAllOver(page: Page, options?: Options) {
 		// cannot stall the loop into the stuck-detection bail out.
 		const stepDistance =
 			distance === undefined ? null : Math.max(1, resolveValue(distance));
-		[currentScrollY, scrollHeight] = await page.evaluate(
-			(step, ratioMin, ratioMax) => {
-				// When step is null, sample a random fraction of the viewport
-				// height so each scroll feels less mechanical.
-				const actualStep =
-					step ??
-					Math.max(
-						1,
-						Math.floor(
-							document.documentElement.clientHeight *
-								(ratioMin + Math.random() * (ratioMax - ratioMin)),
-						),
-					);
-				globalThis.scrollBy(0, actualStep);
-				return [
-					Math.ceil(globalThis.scrollY + globalThis.innerHeight),
-					Math.ceil(document.body.scrollHeight),
-				] as const;
-			},
-			stepDistance,
-			DEFAULT_DISTANCE_RATIO_MIN,
-			DEFAULT_DISTANCE_RATIO_MAX,
+		[currentScrollY, scrollHeight] = await evaluateWithFrameRetry(() =>
+			page.evaluate(
+				(step, ratioMin, ratioMax) => {
+					// When step is null, sample a random fraction of the viewport
+					// height so each scroll feels less mechanical.
+					const actualStep =
+						step ??
+						Math.max(
+							1,
+							Math.floor(
+								document.documentElement.clientHeight *
+									(ratioMin + Math.random() * (ratioMax - ratioMin)),
+							),
+						);
+					globalThis.scrollBy(0, actualStep);
+					return [
+						Math.ceil(globalThis.scrollY + globalThis.innerHeight),
+						Math.ceil(document.body.scrollHeight),
+					] as const;
+				},
+				stepDistance,
+				DEFAULT_DISTANCE_RATIO_MIN,
+				DEFAULT_DISTANCE_RATIO_MAX,
+			),
 		);
 		options?.logger?.(currentScrollY, scrollHeight, 'Scrolling');
 
@@ -107,10 +156,12 @@ export async function scrollAllOver(page: Page, options?: Options) {
 
 	options?.logger?.(currentScrollY, scrollHeight, 'End of page');
 
-	await page.evaluate(() => {
-		// Move the scroll position to the top of the page.
-		globalThis.scrollTo(0, 0);
-	});
+	await evaluateWithFrameRetry(() =>
+		page.evaluate(() => {
+			// Move the scroll position to the top of the page.
+			globalThis.scrollTo(0, 0);
+		}),
+	);
 	await delay(400);
 
 	options?.logger?.(currentScrollY, scrollHeight, 'End of page');


### PR DESCRIPTION
## Summary

#881 のフォローアップ。 実機検証 (`puppeteer` で tepco の `daily_analysis/drainage` を直接 scrape) で、 前回の修正だけでは **同じ症状が別経路で残ること** が判明したので、 2 つ追加で塞ぐ。

## Root cause (実機検証で更新)

| 観察された経路 | 修正 |
| --- | --- |
| **`#fetchData` の 3 min `@retryable` が `#fetchImages` (20 min budget) を race** で kill しないまま新しい retry を始め、 旧 `#fetchImages` の scroll evaluate と新 `goto`/`setViewport` が同じ page で衝突 | `#fetchData` の timeout を 3 min → 25 min に拡張し、 内側の 20 min `#fetchImages` を完全に内包させる |
| **`scrollAllOver` の `page.evaluate` が、 tepco 側に DOM mutation が一切無いのに Chrome の内部 frame swap で稀に detached Frame を吐く** (Chrome DevTools MCP で iframe 0 / navigation 0 / URL 不変を実機確認済み) | 各 `page.evaluate` を **最大 3 attempts (200 ms gap)** でラップし、 transient な `detached Frame` / `Session closed` / `Execution context was destroyed` を吸収 |

## Changes

### `@d-zero/puppeteer-scroll`

- `scrollAllOver` 内の 3 箇所の `page.evaluate` (初期 scrollHeight 測定 / 各 scroll step / 末尾の `scrollTo(0,0)`) を `evaluateWithFrameRetry` ヘルパでラップ
- transient エラーパターン (`Attempted to use detached Frame` / `Session closed` / `Execution context was destroyed`) を検出して 200 ms 後に retry、 最大 3 attempts

### `@d-zero/beholder`

- `#fetchData` の `@retryable` timeout を 3 min → 25 min に変更
- JSDoc に「`#fetchImages` (20 min) を内包する必要がある」「Promise.race が fn を kill しない仕様で外側が race すると collision が起きる」を明記

## Verification

ローカルの実機 scrape (`tepco/decommission/data/daily_analysis/drainage/index-j.html`) を 3 回実行:

| 実行 | 修正前 (3 min) | 修正後 (25 min のみ) | **本 PR (25 min + retry)** |
| --- | --- | --- | --- |
| elapsed | 538 s | 333 s / 47 s (実行毎にばらつき) | **490 s** |
| desktop images | 22 | 22 or 0 | **22** ✓ |
| mobile images | **0** | 0 | **22** ✓ |
| detached-Frame events | 1 | 1 | **0** ✓ |
| retry 二重実行 | あり (4回) | なし | なし |

## Test plan

- [x] `yarn test` (779 tests pass, +4 for scroll-all-over の retry テスト)
- [x] `yarn lint` (cspell pass)
- [x] `yarn build` (27 projects pass)
- [x] 実機 scrape (tepco) で `desktop-compact` + `mobile-small` 両方 22 images / detached events 0 を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)