### PR TITLE
fix(puppeteer-page-scan): finish closing the post-reload detached-Frame race

### DIFF
--- a/packages/@d-zero/puppeteer-page-scan/src/before-page-scan.spec.ts
+++ b/packages/@d-zero/puppeteer-page-scan/src/before-page-scan.spec.ts
@@ -5,9 +5,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { beforePageScan } from './before-page-scan.js';
 
-vi.mock('@d-zero/puppeteer-scroll', () => ({
-	scrollAllOver: vi.fn(() => Promise.resolve()),
-}));
+vi.mock('@d-zero/puppeteer-scroll', async () => {
+	const actual = await vi.importActual<typeof import('@d-zero/puppeteer-scroll')>(
+		'@d-zero/puppeteer-scroll',
+	);
+	return {
+		...actual,
+		scrollAllOver: vi.fn(() => Promise.resolve()),
+	};
+});
 
 /**
  *
@@ -248,15 +254,40 @@ describe('beforePageScan → maxScrollHeight ガード', () => {
 		expect(scrollAllOver).toHaveBeenCalledTimes(1);
 	});
 
-	it('page.evaluate が reject した場合 beforePageScan も reject し、scrollAllOver は呼ばれない', async () => {
+	it('page.evaluate が detached Frame で reject しても 3 回までリトライして scroll を続行する', async () => {
+		const evaluate = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("Attempted to use detached Frame 'XXX'."))
+			.mockResolvedValueOnce(500_000);
 		const page = {
 			url: vi.fn(() => 'about:blank'),
 			setViewport: vi.fn(() => Promise.resolve()),
 			goto: vi.fn(() => Promise.resolve()),
 			reload: vi.fn(() => Promise.resolve()),
-			evaluate: vi.fn(() =>
-				Promise.reject(new Error("Attempted to use detached Frame 'XXX'.")),
-			),
+			evaluate,
+		} as unknown as Page;
+
+		const result = await beforePageScan(page, 'https://example.com', {
+			name: 'mobile-small',
+			width: 320,
+			maxScrollHeight: 1_000_000,
+		});
+
+		expect(result).toEqual({ scrolled: true, scrollHeight: 500_000 });
+		expect(evaluate).toHaveBeenCalledTimes(2);
+		expect(scrollAllOver).toHaveBeenCalledTimes(1);
+	});
+
+	it('detached Frame が連続 3 回続くと諦めて呼び出し元にエラーを伝播する', async () => {
+		const evaluate = vi
+			.fn()
+			.mockRejectedValue(new Error("Attempted to use detached Frame 'XXX'."));
+		const page = {
+			url: vi.fn(() => 'about:blank'),
+			setViewport: vi.fn(() => Promise.resolve()),
+			goto: vi.fn(() => Promise.resolve()),
+			reload: vi.fn(() => Promise.resolve()),
+			evaluate,
 		} as unknown as Page;
 
 		await expect(
@@ -266,6 +297,29 @@ describe('beforePageScan → maxScrollHeight ガード', () => {
 				maxScrollHeight: 1_000_000,
 			}),
 		).rejects.toThrow("Attempted to use detached Frame 'XXX'.");
+		expect(evaluate).toHaveBeenCalledTimes(3);
 		expect(scrollAllOver).not.toHaveBeenCalled();
+	});
+
+	it('detached Frame 以外のエラーは即座に伝播し、リトライされない', async () => {
+		const evaluate = vi
+			.fn()
+			.mockRejectedValue(new Error('TypeError: foo is not a function'));
+		const page = {
+			url: vi.fn(() => 'about:blank'),
+			setViewport: vi.fn(() => Promise.resolve()),
+			goto: vi.fn(() => Promise.resolve()),
+			reload: vi.fn(() => Promise.resolve()),
+			evaluate,
+		} as unknown as Page;
+
+		await expect(
+			beforePageScan(page, 'https://example.com', {
+				name: 'mobile-small',
+				width: 320,
+				maxScrollHeight: 1_000_000,
+			}),
+		).rejects.toThrow('TypeError');
+		expect(evaluate).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/@d-zero/puppeteer-page-scan/src/before-page-scan.ts
+++ b/packages/@d-zero/puppeteer-page-scan/src/before-page-scan.ts
@@ -3,7 +3,7 @@ import type { Listener } from '@d-zero/puppeteer-general-actions';
 import type { DelayOptions } from '@d-zero/shared/delay';
 import type { Page } from 'puppeteer';
 
-import { scrollAllOver } from '@d-zero/puppeteer-scroll';
+import { evaluateWithFrameRetry, scrollAllOver } from '@d-zero/puppeteer-scroll';
 
 type Options = {
 	name: string;
@@ -162,7 +162,17 @@ export async function beforePageScan(
 	// for tens of minutes — long enough to exceed any reasonable retry
 	// timeout, leaving the scroll's page.evaluate calls executing in the
 	// background while the next retry attempts to use the same page.
-	const scrollHeight = await page.evaluate(() => document.body.scrollHeight);
+	//
+	// WHY retry on detached-Frame: this evaluation runs immediately after
+	// `page.reload()` resolves, which is exactly when Chrome may still be
+	// finishing an internal main-frame swap. A single read landing in that
+	// window throws even though the page itself is doing nothing observable,
+	// and the throw escapes `beforePageScan` before `scrollAllOver`'s own
+	// retry layer can absorb anything. Reuse the same retry helper as
+	// `scrollAllOver` to keep the swap-window absorption consistent.
+	const scrollHeight = await evaluateWithFrameRetry(() =>
+		page.evaluate(() => document.body.scrollHeight),
+	);
 
 	if (maxScrollHeight !== undefined && scrollHeight > maxScrollHeight) {
 		listener?.('hook', {

--- a/packages/@d-zero/puppeteer-scroll/src/evaluate-with-frame-retry.spec.ts
+++ b/packages/@d-zero/puppeteer-scroll/src/evaluate-with-frame-retry.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+	evaluateWithFrameRetry,
+	isTransientFrameError,
+} from './evaluate-with-frame-retry.js';
+
+describe('isTransientFrameError', () => {
+	it('Attempted to use detached Frame は transient と判定する', () => {
+		expect(isTransientFrameError(new Error("Attempted to use detached Frame 'X'."))).toBe(
+			true,
+		);
+	});
+
+	it('Session closed は transient と判定する', () => {
+		expect(
+			isTransientFrameError(
+				new Error('Protocol error (Runtime.callFunctionOn): Session closed.'),
+			),
+		).toBe(true);
+	});
+
+	it('Execution context was destroyed は transient と判定する', () => {
+		expect(
+			isTransientFrameError(
+				new Error('Execution context was destroyed during navigation'),
+			),
+		).toBe(true);
+	});
+
+	it('大文字小文字は区別しない (Session)', () => {
+		expect(isTransientFrameError(new Error('SESSION CLOSED'))).toBe(true);
+	});
+
+	it('大文字小文字は区別しない (detached Frame)', () => {
+		expect(isTransientFrameError(new Error('ATTEMPTED TO USE DETACHED FRAME'))).toBe(
+			true,
+		);
+	});
+
+	it('大文字小文字は区別しない (Execution context)', () => {
+		expect(isTransientFrameError(new Error('EXECUTION CONTEXT WAS DESTROYED'))).toBe(
+			true,
+		);
+	});
+
+	it('Error 以外のオブジェクトは false', () => {
+		expect(isTransientFrameError('detached Frame')).toBe(false);
+		expect(isTransientFrameError(null)).toBe(false);
+		expect(isTransientFrameError()).toBe(false);
+		expect(isTransientFrameError({ message: 'detached Frame' })).toBe(false);
+	});
+
+	it('関係ない Error は false', () => {
+		expect(isTransientFrameError(new Error('TypeError: foo is not a function'))).toBe(
+			false,
+		);
+	});
+});
+
+describe('evaluateWithFrameRetry', () => {
+	it('成功時はそのまま resolve する', async () => {
+		const evaluator = vi.fn().mockResolvedValue(42);
+
+		await expect(evaluateWithFrameRetry(evaluator)).resolves.toBe(42);
+		expect(evaluator).toHaveBeenCalledTimes(1);
+	});
+
+	it('transient エラーが 1 回出てもリトライで吸収して resolve する', async () => {
+		const evaluator = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("Attempted to use detached Frame 'X'."))
+			.mockResolvedValueOnce(42);
+
+		await expect(evaluateWithFrameRetry(evaluator)).resolves.toBe(42);
+		expect(evaluator).toHaveBeenCalledTimes(2);
+	});
+
+	it('transient エラーが連続 3 回続くと最後のエラーを throw する', async () => {
+		const evaluator = vi
+			.fn()
+			.mockRejectedValue(new Error("Attempted to use detached Frame 'X'."));
+
+		await expect(evaluateWithFrameRetry(evaluator)).rejects.toThrow(
+			"Attempted to use detached Frame 'X'.",
+		);
+		expect(evaluator).toHaveBeenCalledTimes(3);
+	});
+
+	it('非 transient エラーは即座に throw されリトライしない', async () => {
+		const evaluator = vi
+			.fn()
+			.mockRejectedValue(new Error('TypeError: foo is not a function'));
+
+		await expect(evaluateWithFrameRetry(evaluator)).rejects.toThrow('TypeError');
+		expect(evaluator).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/@d-zero/puppeteer-scroll/src/evaluate-with-frame-retry.ts
+++ b/packages/@d-zero/puppeteer-scroll/src/evaluate-with-frame-retry.ts
@@ -1,0 +1,67 @@
+/**
+ * Max attempts for each `page.evaluate` call when it fails with a transient
+ * frame error. Chrome may briefly swap or re-attach the main frame during a
+ * long scroll or immediately after navigation, even when the target site is
+ * not doing anything observable. Three attempts with a 200 ms gap absorbs
+ * the typical re-attach window without masking a genuinely broken page.
+ */
+export const MAX_EVALUATE_RETRIES = 3;
+export const DETACHED_RETRY_DELAY_MS = 200;
+
+/**
+ * Transient errors that occur when `page.evaluate` lands inside Puppeteer's
+ * own frame-swap or session-teardown window. Retrying after a short delay
+ * usually succeeds because the new execution context is then in place.
+ * @param error - Error caught from `page.evaluate`.
+ * @returns `true` when the error is a known transient frame/session error.
+ * @example
+ * ```ts
+ * try {
+ *   await page.evaluate(...);
+ * } catch (error) {
+ *   if (isTransientFrameError(error)) {
+ *     // retry after a short delay
+ *   } else {
+ *     throw error;
+ *   }
+ * }
+ * ```
+ */
+export function isTransientFrameError(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	return /Attempted to use detached Frame|Session closed|Execution context was destroyed/i.test(
+		error.message,
+	);
+}
+
+/**
+ * Retries `evaluator` (typically a `page.evaluate` call) when it fails with
+ * a transient frame error. Non-transient errors are re-thrown immediately.
+ *
+ * Used both inside long-running scroll loops and around the single
+ * `page.evaluate` calls that bracket them, so that Chrome's brief
+ * post-navigation main-frame swap does not surface as an unrecoverable
+ * "Attempted to use detached Frame" error in the caller.
+ * @template T - Evaluator return type.
+ * @param evaluator - Thunk that performs a single `page.evaluate` call.
+ * @returns Whatever `evaluator` returns on success.
+ * @example
+ * ```ts
+ * const scrollHeight = await evaluateWithFrameRetry(() =>
+ *   page.evaluate(() => document.body.scrollHeight),
+ * );
+ * ```
+ */
+export async function evaluateWithFrameRetry<T>(evaluator: () => Promise<T>): Promise<T> {
+	let lastError: unknown;
+	for (let attempt = 0; attempt < MAX_EVALUATE_RETRIES; attempt++) {
+		try {
+			return await evaluator();
+		} catch (error) {
+			lastError = error;
+			if (!isTransientFrameError(error)) throw error;
+			await new Promise((resolve) => setTimeout(resolve, DETACHED_RETRY_DELAY_MS));
+		}
+	}
+	throw lastError;
+}

--- a/packages/@d-zero/puppeteer-scroll/src/index.ts
+++ b/packages/@d-zero/puppeteer-scroll/src/index.ts
@@ -1,1 +1,5 @@
 export { scrollAllOver } from './scroll-all-over.js';
+export {
+	evaluateWithFrameRetry,
+	isTransientFrameError,
+} from './evaluate-with-frame-retry.js';

--- a/packages/@d-zero/puppeteer-scroll/src/scroll-all-over.ts
+++ b/packages/@d-zero/puppeteer-scroll/src/scroll-all-over.ts
@@ -2,6 +2,7 @@ import type { Page } from 'puppeteer';
 
 import { delay, type DelayOptions } from '@d-zero/shared/delay';
 
+import { evaluateWithFrameRetry } from './evaluate-with-frame-retry.js';
 import { resolveValue } from './resolve-value.js';
 
 /**
@@ -13,51 +14,6 @@ import { resolveValue } from './resolve-value.js';
  * enough to confirm that scrolling is genuinely blocked.
  */
 const MAX_STUCK_ITERATIONS = 3;
-
-/**
- * Max attempts for each `page.evaluate` call when it fails with a transient
- * frame error (Chrome may briefly swap or re-attach the main frame during a
- * long scroll, even when the target site is not doing anything observable).
- * Three attempts with a 200 ms gap absorbs the typical re-attach window
- * without masking a genuinely broken page.
- */
-const MAX_EVALUATE_RETRIES = 3;
-const DETACHED_RETRY_DELAY_MS = 200;
-
-/**
- * Transient errors that occur when `page.evaluate` lands inside Puppeteer's
- * own frame-swap or session-teardown window. Retrying after a short delay
- * usually succeeds because the new execution context is then in place.
- * @param error - Error caught from `page.evaluate`.
- * @returns `true` when the error is a known transient frame/session error.
- */
-function isTransientFrameError(error: unknown): boolean {
-	if (!(error instanceof Error)) return false;
-	return /Attempted to use detached Frame|Session closed|Execution context was destroyed/i.test(
-		error.message,
-	);
-}
-
-/**
- * Retries `evaluator` (typically a `page.evaluate` call) when it fails with
- * a transient frame error. Non-transient errors are re-thrown immediately.
- * @template T - Evaluator return type.
- * @param evaluator - Thunk that performs a single `page.evaluate` call.
- * @returns Whatever `evaluator` returns on success.
- */
-async function evaluateWithFrameRetry<T>(evaluator: () => Promise<T>): Promise<T> {
-	let lastError: unknown;
-	for (let attempt = 0; attempt < MAX_EVALUATE_RETRIES; attempt++) {
-		try {
-			return await evaluator();
-		} catch (error) {
-			lastError = error;
-			if (!isTransientFrameError(error)) throw error;
-			await new Promise((resolve) => setTimeout(resolve, DETACHED_RETRY_DELAY_MS));
-		}
-	}
-	throw lastError;
-}
 
 /**
  * Default interval range (ms) used when `options.interval` is omitted.


### PR DESCRIPTION
## Summary

#882 のフォローアップ。 nitpicker の本番運用で、稀に `mobile-small: skipped — Attempted to use detached Frame` がまだ残ることが確認された経路を塞ぐ。

## Root cause

前回までの修正で 2 つの経路を塞いだが、 もう一つ未対応の経路があった:

| 経路 | カバー状況 |
|---|---|
| `scrollAllOver` 内の `page.evaluate` (scroll step / 初期 scrollHeight / 末尾 scrollTo) | #882 で 3 attempts retry ✓ |
| `#fetchData` の 3 min timeout が `#fetchImages` (20 min) を内包せず race | #882 で 25 min に拡張 ✓ |
| **`beforePageScan` 内の `page.evaluate(() => document.body.scrollHeight)`** (reload 直後、 scrollAllOver の前) | **未対応** ← 本 PR |

`page.reload()` が resolve した直後でも Chrome の internal main-frame swap が完了していない瞬間があり、 そこで実行された `page.evaluate` が detached Frame を投げる。 一度投げると `beforePageScan` 全体が reject → `scrollAllOver` の retry レイヤーに到達する前に per-device catch でスキップ。

## Changes

### `@d-zero/puppeteer-scroll`

- `evaluateWithFrameRetry` / `isTransientFrameError` を inline ヘルパーから独立モジュール `evaluate-with-frame-retry.ts` に切り出し、 package root から export
- code-review 指摘 (puppeteer-scroll と puppeteer-page-scan で同じ retry 仕様を 2 重メンテする状況) を解消
- helper 単体テスト 12 件追加 (transient error 3 種・大文字小文字 3 種・非 Error・非 transient・成功・1回 retry・3 連続失敗・即 throw)

### `@d-zero/puppeteer-page-scan`

- `before-page-scan.ts` の post-reload `document.body.scrollHeight` 読み取りを `evaluateWithFrameRetry` でラップ
- WHY コメントで「reload resolves before Chrome's internal main-frame swap is fully complete」を明示
- retry integration テスト 3 件追加 (リトライ吸収・3 連続失敗で伝播・非 transient 即 throw)

## Test plan

- [x] `yarn test` (52 tests in scroll + page-scan、合計 783 tests pass)
- [x] `yarn lint` (cspell pass)
- [x] `yarn build` (27 projects pass)

## Verification (本番運用への反映後)

- [ ] nitpicker で再現性のあった URL 群を再 scrape し、 `mobile-small: skipped — Attempted to use detached Frame` の出現率を確認 (前回は ~5-10% 程度の頻度で残っていた経路)

🤖 Generated with [Claude Code](https://claude.com/claude-code)