### PR TITLE
feat(github): workflow_dispatch full_matrix input

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,12 @@ on:
       - dev
   schedule:
     - cron: "0 17 * * 1-5" # UTC 17:00 = JST 02:00, weekdays
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      full_matrix:
+        description: "Run build-test on the full multi-OS matrix (like nightly)"
+        type: boolean
+        default: false
 
 concurrency:
   group: test-${{ github.workflow }}-${{ github.ref }}
@@ -50,7 +55,7 @@ jobs:
         id: set
         shell: bash
         run: |
-          if [ "${{ github.event_name }}" = "schedule" ]; then
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event.inputs.full_matrix }}" = "true" ]; then
             echo 'matrix={"os":["ubuntu-latest","macOS-latest","windows-latest"]}' >> "$GITHUB_OUTPUT"
           else
             echo 'matrix={"os":["ubuntu-latest"]}' >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

nightly cron (`0 17 * * 1-5` UTC) を待たずに macOS/Windows 検証を手動発火できるよう `workflow_dispatch.inputs.full_matrix` (boolean, default false) を追加。

- true で発火すると `setup-matrix` が 3-OS matrix を返し、nightly と同じルート (`build-test` × 3 OS) を実行
- false (デフォルト) は従来通り Linux only

## Test plan

- [x] `actionlint` パス
- [ ] マージ後、Actions UI から手動で `full_matrix=true` で発火し、macOS/Windows でも build/test が通ることを確認