### PR TITLE
feat(page-cluster): improve real-world structural clustering accuracy

### DIFF
--- a/packages/@d-zero/page-cluster/README.md
+++ b/packages/@d-zero/page-cluster/README.md
@@ -35,6 +35,8 @@ tokenize(html, {
 
 自由編集ブロックエディタ（CMSが各コンテンツブロックに固有のdata属性を付与するタイプ）を使うサイトでは、`contentBlockAttribute` オプションでその属性名を指定すると、ページごとに異なるブロック構成が構造比較のノイズになるのを防げる（既定は未指定＝無効、サイトごとの属性名を推測できないため）。詳細は `removeContentBlocks()` のJSDocを参照。
 
+CMSのブロック属性名が分からない・サイトごとに違う場合は `autoCapMainDepth: true` を使う。`<main>`/`role="main"`という標準タグを起点に、構造クラスタ数が急増する直前の深さを実データから自動検出して打ち切るため、サイト固有の設定が一切不要（既定はfalse。実データ検証では`contentBlockAttribute`より良い結果になる場合もあった一方、計算コストが実測で約20倍になる）。詳細は `detectContentDepthCap()` のJSDocを参照。
+
 ```ts
 import { resolvePageClusterKeys } from '@d-zero/page-cluster/resolve-page-cluster-keys';
 

--- a/packages/@d-zero/page-cluster/README.md
+++ b/packages/@d-zero/page-cluster/README.md
@@ -31,7 +31,7 @@ tokenize(html, {
 
 ### クラスタリング
 
-クロールしたページ群から最終的なクラスタキーを得るには `resolvePageClusterKeys()` を使う。ブロッキング（URLパス/スタイルシートによる粗い絞り込み）と構造クラスタリング（ブロック内でのcomplete-linkage階層的クラスタリング）を内部で連結し、ブロックを跨いで一意なキーを返す。既定で各ページの`<header>`/`<footer>`/`<nav>`/`<aside>`（タグ名またはARIAランドマークロール）を比較対象から除外し、共通chromeの影響を受けにくくする。
+クロールしたページ群から最終的なクラスタキーを得るには `resolvePageClusterKeys()` を使う。ブロッキング（URLパス/スタイルシートによる粗い絞り込み）と構造クラスタリング（ブロック内でのcomplete-linkage階層的クラスタリング）を内部で連結し、ブロックを跨いで一意なキーを返す。既定で各ページの`<header>`/`<footer>`/`<nav>`/`<aside>`（タグ名またはARIAランドマークロール）を比較対象から除外し、共通chromeの影響を受けにくくする。また、スタイルシート参照が記録されていない「孤児」ページを、同一URLセクションに閉じたスタイルシート・ブロックへ再割当する処理（`reassignOrphanBlockKeys()`）も既定で有効。挙動の詳細・トレードオフは`src/reassign-orphan-block-keys.ts`のJSDocを参照。
 
 ```ts
 import { resolvePageClusterKeys } from '@d-zero/page-cluster/resolve-page-cluster-keys';

--- a/packages/@d-zero/page-cluster/README.md
+++ b/packages/@d-zero/page-cluster/README.md
@@ -31,7 +31,9 @@ tokenize(html, {
 
 ### クラスタリング
 
-クロールしたページ群から最終的なクラスタキーを得るには `resolvePageClusterKeys()` を使う。ブロッキング（URLパス/スタイルシートによる粗い絞り込み）と構造クラスタリング（ブロック内でのcomplete-linkage階層的クラスタリング）を内部で連結し、ブロックを跨いで一意なキーを返す。既定で各ページの`<header>`/`<footer>`/`<nav>`/`<aside>`（タグ名またはARIAランドマークロール）を比較対象から除外し、共通chromeの影響を受けにくくする。また、スタイルシート参照が記録されていない「孤児」ページを、同一URLセクションに閉じたスタイルシート・ブロックへ再割当する処理（`reassignOrphanBlockKeys()`）も既定で有効。挙動の詳細・トレードオフは`src/reassign-orphan-block-keys.ts`のJSDocを参照。
+クロールしたページ群から最終的なクラスタキーを得るには `resolvePageClusterKeys()` を使う。ブロッキング（URLパス/スタイルシートによる粗い絞り込み）と構造クラスタリング（ブロック内でのcomplete-linkage階層的クラスタリング）を内部で連結し、ブロックを跨いで一意なキーを返す。既定で各ページの`<header>`/`<footer>`/`<nav>`/`<aside>`（タグ名またはARIAランドマークロール）を比較対象から除外し、共通chromeの影響を受けにくくする。また、スタイルシート参照が記録されていない「孤児」ページを、同一URLセクションに閉じたスタイルシート・ブロックへ再割当する処理（`reassignOrphanBlockKeys()`）や、埋め込みコンテンツが引き込むサードパーティCSS参照をブロッキング判定から除外する処理（`filterFirstPartyStylesheetHrefs()`）も既定で有効。挙動の詳細・トレードオフはそれぞれのJSDocを参照。
+
+自由編集ブロックエディタ（CMSが各コンテンツブロックに固有のdata属性を付与するタイプ）を使うサイトでは、`contentBlockAttribute` オプションでその属性名を指定すると、ページごとに異なるブロック構成が構造比較のノイズになるのを防げる（既定は未指定＝無効、サイトごとの属性名を推測できないため）。詳細は `removeContentBlocks()` のJSDocを参照。
 
 ```ts
 import { resolvePageClusterKeys } from '@d-zero/page-cluster/resolve-page-cluster-keys';
@@ -42,6 +44,7 @@ const keys = resolvePageClusterKeys(
 		stylesheetHrefs: page.stylesheetHrefs,
 		html: page.html,
 	})),
+	{ contentBlockAttribute: 'data-bgb' }, // 使っているCMSのブロック属性名に合わせて指定
 );
 // pagesと同じ順序・同じ長さ。同じキーのページが同一テンプレートと判定されたページ群
 ```

--- a/packages/@d-zero/page-cluster/README.md
+++ b/packages/@d-zero/page-cluster/README.md
@@ -35,7 +35,7 @@ tokenize(html, {
 
 自由編集ブロックエディタ（CMSが各コンテンツブロックに固有のdata属性を付与するタイプ）を使うサイトでは、`contentBlockAttribute` オプションでその属性名を指定すると、ページごとに異なるブロック構成が構造比較のノイズになるのを防げる（既定は未指定＝無効、サイトごとの属性名を推測できないため）。詳細は `removeContentBlocks()` のJSDocを参照。
 
-CMSのブロック属性名が分からない・サイトごとに違う場合は `autoCapMainDepth: true` を使う。`<main>`/`role="main"`という標準タグを起点に、構造クラスタ数が急増する直前の深さを実データから自動検出して打ち切るため、サイト固有の設定が一切不要（既定はfalse。実データ検証では`contentBlockAttribute`より良い結果になる場合もあった一方、計算コストが実測で約20倍になる）。詳細は `detectContentDepthCap()` のJSDocを参照。
+CMSのブロック属性名が分からない・サイトごとに違う場合は `autoCapMainDepth: true` を使う。`<main>`/`role="main"`という標準タグを起点に、構造クラスタ数が急増する直前の深さをブロックごとに実データから自動検出して打ち切るため、サイト固有の設定が一切不要（既定はfalse。実データ検証では`contentBlockAttribute`より良い結果になる場合もあった一方、計算コストが実測で数倍〜1桁台後半になる。倍率はコーパスのブロック構成に依存する）。詳細は `detectContentDepthCap()` のJSDocを参照。
 
 ```ts
 import { resolvePageClusterKeys } from '@d-zero/page-cluster/resolve-page-cluster-keys';

--- a/packages/@d-zero/page-cluster/package.json
+++ b/packages/@d-zero/page-cluster/package.json
@@ -33,6 +33,10 @@
 			"import": "./dist/extract-landmarks.js",
 			"types": "./dist/extract-landmarks.d.ts"
 		},
+		"./filter-first-party-stylesheet-hrefs": {
+			"import": "./dist/filter-first-party-stylesheet-hrefs.js",
+			"types": "./dist/filter-first-party-stylesheet-hrefs.d.ts"
+		},
 		"./jaccard-similarity": {
 			"import": "./dist/jaccard-similarity.js",
 			"types": "./dist/jaccard-similarity.d.ts"
@@ -40,6 +44,10 @@
 		"./reassign-orphan-block-keys": {
 			"import": "./dist/reassign-orphan-block-keys.js",
 			"types": "./dist/reassign-orphan-block-keys.d.ts"
+		},
+		"./remove-content-blocks": {
+			"import": "./dist/remove-content-blocks.js",
+			"types": "./dist/remove-content-blocks.d.ts"
 		},
 		"./resolve-blocking-group-keys": {
 			"import": "./dist/resolve-blocking-group-keys.js",

--- a/packages/@d-zero/page-cluster/package.json
+++ b/packages/@d-zero/page-cluster/package.json
@@ -17,6 +17,10 @@
 			"import": "./dist/array-edit-distance.js",
 			"types": "./dist/array-edit-distance.d.ts"
 		},
+		"./cap-content-depth": {
+			"import": "./dist/cap-content-depth.js",
+			"types": "./dist/cap-content-depth.d.ts"
+		},
 		"./compute-document-frequency": {
 			"import": "./dist/compute-document-frequency.js",
 			"types": "./dist/compute-document-frequency.d.ts"
@@ -28,6 +32,10 @@
 		"./derive-stylesheet-group-key": {
 			"import": "./dist/derive-stylesheet-group-key.js",
 			"types": "./dist/derive-stylesheet-group-key.d.ts"
+		},
+		"./detect-content-depth-cap": {
+			"import": "./dist/detect-content-depth-cap.js",
+			"types": "./dist/detect-content-depth-cap.d.ts"
 		},
 		"./extract-landmarks": {
 			"import": "./dist/extract-landmarks.js",

--- a/packages/@d-zero/page-cluster/package.json
+++ b/packages/@d-zero/page-cluster/package.json
@@ -37,6 +37,10 @@
 			"import": "./dist/jaccard-similarity.js",
 			"types": "./dist/jaccard-similarity.d.ts"
 		},
+		"./reassign-orphan-block-keys": {
+			"import": "./dist/reassign-orphan-block-keys.js",
+			"types": "./dist/reassign-orphan-block-keys.d.ts"
+		},
 		"./resolve-blocking-group-keys": {
 			"import": "./dist/resolve-blocking-group-keys.js",
 			"types": "./dist/resolve-blocking-group-keys.d.ts"

--- a/packages/@d-zero/page-cluster/src/cap-content-depth.spec.ts
+++ b/packages/@d-zero/page-cluster/src/cap-content-depth.spec.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'vitest';
+
+import { capContentDepth } from './cap-content-depth.js';
+
+describe('capContentDepth', () => {
+	test('matches the exact output documented in the JSDoc @example', () => {
+		// Kept in sync with capContentDepth's @example: if this ever fails, the
+		// JSDoc example is out of date and must be corrected alongside the
+		// implementation, not the other way around.
+		const result = capContentDepth(
+			'<body><main><div><div><div><div>too deep</div></div></div></div></main></body>',
+			{ landmark: 'main', maxDepth: 2 },
+		);
+		expect(result).toStrictEqual({
+			remainderHtml: '<body><main><div><div></div></div></main></body>',
+		});
+	});
+
+	test('content shallower than maxDepth is left completely unchanged', () => {
+		const html = '<body><main><div><p>shallow</p></div></main></body>';
+		expect(capContentDepth(html, { landmark: 'main', maxDepth: 3 })).toStrictEqual({
+			remainderHtml: html,
+		});
+	});
+
+	test('role="main" is recognized even without a <main> tag', () => {
+		const result = capContentDepth(
+			'<body><div role="main"><div><div><div>deep</div></div></div></div></body>',
+			{ landmark: 'main', maxDepth: 1 },
+		);
+		expect(result.remainderHtml).toBe('<body><div role="main"><div></div></div></body>');
+	});
+
+	test('a page with no <main> and no role="main" is left unchanged', () => {
+		const html = '<body><p>no main here</p></body>';
+		expect(capContentDepth(html, { landmark: 'main', maxDepth: 1 })).toStrictEqual({
+			remainderHtml: html,
+		});
+	});
+
+	test('<main> itself (its own opening and closing tags, including attributes) is always kept, even at maxDepth 0', () => {
+		const result = capContentDepth(
+			'<body><main class="detail"><div>content</div></main></body>',
+			{ landmark: 'main', maxDepth: 0 },
+		);
+		expect(result.remainderHtml).toBe('<body><main class="detail"></main></body>');
+	});
+
+	test('multiple independent too-deep branches at the same level are each capped correctly', () => {
+		const html =
+			'<body><main><section><div><div>deep-a</div></div></section><section><div><div>deep-b</div></div></section></main></body>';
+		const result = capContentDepth(html, { landmark: 'main', maxDepth: 2 });
+		expect(result.remainderHtml).toBe(
+			'<body><main><section><div></div></section><section><div></div></section></main></body>',
+		);
+	});
+
+	test('multiple <main> elements (malformed markup): the shallowest one wins, matching extractLandmarks', () => {
+		const html =
+			'<body><div><main><div><div><div>deep</div></div></div></main></div><main><div><div><div>also-deep</div></div></div></main></body>';
+		const result = capContentDepth(html, { landmark: 'main', maxDepth: 1 });
+		// The second <main> (depth 0, direct child of body) is shallower than
+		// the first (depth 1, nested inside a <div>), so it wins.
+		expect(result.remainderHtml).toBe(
+			'<body><div><main><div><div><div>deep</div></div></div></main></div><main><div></div></main></body>',
+		);
+	});
+
+	test('content inside an opaque tag (script) is never counted toward depth or capped', () => {
+		const html =
+			'<body><main><div><script>var deep = { a: { b: { c: 1 } } };</script></div></main></body>';
+		const result = capContentDepth(html, { landmark: 'main', maxDepth: 1 });
+		expect(result.remainderHtml).toBe(html);
+	});
+
+	test('an unclosed too-deep element is left in place rather than corrupting the remainder', () => {
+		// No closing </div> for the too-deep element before </main> arrives —
+		// htmlparser2 force-closes it at a position that doesn't correspond to
+		// any real closing tag for it, so isGenuineClose rejects the candidate
+		// and it is not excised.
+		const html = '<body><main><div><div>unclosed</main></body>';
+		const result = capContentDepth(html, { landmark: 'main', maxDepth: 1 });
+		expect(result.remainderHtml).toBe(html);
+	});
+
+	test.each([-1, 0.5, Number.NaN])(
+		'rejects a maxDepth that is not a non-negative integer (%s)',
+		(maxDepth) => {
+			expect(() =>
+				capContentDepth('<body><main></main></body>', { landmark: 'main', maxDepth }),
+			).toThrow(RangeError);
+		},
+	);
+});

--- a/packages/@d-zero/page-cluster/src/cap-content-depth.ts
+++ b/packages/@d-zero/page-cluster/src/cap-content-depth.ts
@@ -1,0 +1,225 @@
+import { Parser } from 'htmlparser2';
+
+import { excise } from './excise.js';
+import { findShallowestElements } from './find-shallowest-elements.js';
+import { isGenuineClose } from './is-genuine-close.js';
+import { isOpaqueTagName } from './opaque-tags.js';
+
+/**
+ * The only landmark this function knows how to depth-cap. A closed union
+ * (not an open `string`) because, unlike
+ * {@link ./remove-content-blocks.js | removeContentBlocks}'s caller-supplied
+ * CMS attribute, `<main>`/`role="main"` is an HTML5/ARIA standard — there is
+ * exactly one vocabulary to support, not one per site.
+ */
+export type ContentDepthLandmark = 'main';
+
+/**
+ * @see capContentDepth
+ */
+export type CapContentDepthOptions = {
+	landmark: ContentDepthLandmark;
+	/**
+	 * How many levels of elements *inside* the landmark to keep, counting the
+	 * landmark's own direct children as depth 1. Must be a non-negative
+	 * integer (0 keeps none of the landmark's content, only its own opening/
+	 * closing tags). See {@link ./cap-content-depth.js | capContentDepth}'s
+	 * JSDoc for how to choose this.
+	 */
+	maxDepth: number;
+};
+
+/**
+ * Result of {@link ./cap-content-depth.js | capContentDepth}.
+ */
+export type CapContentDepthResult = {
+	remainderHtml: string;
+};
+
+const TAG_TO_LANDMARK: Readonly<Record<string, ContentDepthLandmark>> = { main: 'main' };
+const ROLE_TO_LANDMARK: Readonly<Record<string, ContentDepthLandmark>> = { main: 'main' };
+
+/**
+ * Finds the single shallowest `<main>`/`role="main"` element in `html` via
+ * {@link ./find-shallowest-elements.js | findShallowestElements} (same
+ * "shallowest wins" rule as {@link ./extract-landmarks.js | extractLandmarks}
+ * uses for its own four landmark types, for the same reason: the site-wide,
+ * outermost instance is the real one), and returns the offsets of its
+ * content (excluding its own opening/closing tags) — or `undefined` if there
+ * is no genuine one.
+ * @param html
+ * @param landmark
+ */
+function findShallowestLandmarkContent(
+	html: string,
+	landmark: ContentDepthLandmark,
+): { contentStart: number; contentEnd: number } | undefined {
+	const [winner] = findShallowestElements(html, (name, role) =>
+		TAG_TO_LANDMARK[name] === landmark ||
+		(role !== undefined && ROLE_TO_LANDMARK[role] === landmark)
+			? [landmark]
+			: [],
+	);
+	return winner
+		? { contentStart: winner.contentStart, contentEnd: winner.contentEnd }
+		: undefined;
+}
+
+type DeepFrame = {
+	tagName: string;
+	startOffset: number;
+};
+
+/**
+ * Within `html.slice(contentStart, contentEnd)`, finds every element whose
+ * nesting depth (the landmark's own direct children are depth 1) exceeds
+ * `maxDepth`, and returns their `[start, end)` spans (absolute offsets into
+ * the original `html`) for excision. Once a too-deep element is found, its
+ * subtree is not explored further — same reasoning as
+ * {@link ./remove-content-blocks.js | removeContentBlocks} not diving into
+ * an already-matched block: nothing inside a span already marked for
+ * removal needs its own depth checked.
+ * @param html
+ * @param contentStart
+ * @param contentEnd
+ * @param maxDepth
+ */
+function collectDeepSpans(
+	html: string,
+	contentStart: number,
+	contentEnd: number,
+	maxDepth: number,
+): { start: number; end: number }[] {
+	const spans: { start: number; end: number }[] = [];
+	const stack: DeepFrame[] = [];
+	let opaque: { tagName: string; depth: number } | null = null;
+	// Set once a too-deep element opens; cleared when that same element
+	// closes. While set, every nested open/close (other than matching
+	// closes of the capped tag itself) is ignored, same shape as the
+	// `opaque` tracking above.
+	let cappedAt: { tagName: string; depth: number } | null = null;
+
+	const parser = new Parser(
+		{
+			onopentag(name) {
+				if (opaque) {
+					if (name === opaque.tagName) opaque.depth++;
+					return;
+				}
+				if (cappedAt) {
+					if (name === cappedAt.tagName) cappedAt.depth++;
+					return;
+				}
+				if (isOpaqueTagName(name)) {
+					opaque = { tagName: name, depth: 1 };
+					return;
+				}
+				const depth = stack.length + 1;
+				if (depth > maxDepth) {
+					cappedAt = { tagName: name, depth: 1 };
+					spans.push({ start: contentStart + parser.startIndex, end: -1 });
+					return;
+				}
+				stack.push({ tagName: name, startOffset: parser.startIndex });
+			},
+			onclosetag(name) {
+				if (opaque) {
+					if (name === opaque.tagName) {
+						opaque.depth--;
+						if (opaque.depth === 0) opaque = null;
+					}
+					return;
+				}
+				if (cappedAt) {
+					if (name === cappedAt.tagName) {
+						cappedAt.depth--;
+						if (cappedAt.depth === 0) {
+							const endOffset = contentStart + parser.endIndex + 1;
+							const open = spans.at(-1);
+							if (open) {
+								open.end = isGenuineClose(html, endOffset, name) ? endOffset : open.start;
+							}
+							cappedAt = null;
+						}
+					}
+					return;
+				}
+				const frame = stack.pop();
+				if (!frame) return;
+			},
+		},
+		{ decodeEntities: false },
+	);
+	parser.end(html.slice(contentStart, contentEnd));
+
+	// A capped span whose genuine close was never confirmed (malformed
+	// markup) collapses to a zero-length span at its own start — excise()
+	// treats start === end as a no-op slice, so nothing is corrupted, and
+	// that one candidate is simply not removed, the same safety trade-off
+	// extractLandmarks/removeContentBlocks make for unclosed tags.
+	return spans.filter((span) => span.end > span.start);
+}
+
+/**
+ * Excises the deepest content inside `options.landmark` (currently only
+ * `'main'`/`role="main"` is supported — see `ContentDepthLandmark`'s JSDoc),
+ * keeping up to `options.maxDepth` levels of nesting and returning what's
+ * left.
+ *
+ * Built for the same real-crawl finding {@link ./remove-content-blocks.js |
+ * removeContentBlocks} addresses — freeform CMS-block content dominating a
+ * page's token set and defeating structural similarity — but without
+ * needing the caller to know their CMS's own block-marker attribute.
+ * `<main>` is HTML5-standard, so this works without any per-site
+ * configuration at all. Confirmed on two unrelated real crawls (302 and
+ * ~4,100 pages): once nesting depth inside `<main>` passes a threshold
+ * (3, on both), the number of distinct structural clusters explodes (14x
+ * and 9x, respectively) — the "skeleton" (which template a page uses) lives
+ * in the shallow levels; the free-edited content that varies page-to-page
+ * lives deeper. See {@link ./detect-content-depth-cap.js |
+ * detectContentDepthCap} to find that threshold automatically instead of
+ * hardcoding `maxDepth`.
+ *
+ * `<main>`'s own opening/closing tags (and their attributes, e.g. a class
+ * that itself differs between a list-page and a detail-page `<main>`) are
+ * always kept — only what's *between* them past `maxDepth` is excised, for
+ * the same reason `extractLandmarks` never adds a placeholder: the tag
+ * itself is real structural signal, not something to erase.
+ *
+ * A page with no `<main>` and no `role="main"` element has nothing to cap;
+ * `remainderHtml` is returned unchanged, matching this package's convention
+ * for "nothing to do" (see `extractLandmarks`, `removeContentBlocks`).
+ * @param html
+ * @param options
+ * @example
+ * ```ts
+ * capContentDepth(
+ * 	'<body><main><div><div><div><div>too deep</div></div></div></div></main></body>',
+ * 	{ landmark: 'main', maxDepth: 2 },
+ * );
+ * // { remainderHtml: '<body><main><div><div></div></div></main></body>' }
+ * ```
+ */
+export function capContentDepth(
+	html: string,
+	options: CapContentDepthOptions,
+): CapContentDepthResult {
+	if (!(Number.isInteger(options.maxDepth) && options.maxDepth >= 0)) {
+		throw new RangeError(
+			`capContentDepth: maxDepth must be a non-negative integer, got ${options.maxDepth}`,
+		);
+	}
+
+	const content = findShallowestLandmarkContent(html, options.landmark);
+	if (!content) {
+		return { remainderHtml: html };
+	}
+
+	const spans = collectDeepSpans(
+		html,
+		content.contentStart,
+		content.contentEnd,
+		options.maxDepth,
+	);
+	return { remainderHtml: excise(html, spans) };
+}

--- a/packages/@d-zero/page-cluster/src/detect-content-depth-cap.spec.ts
+++ b/packages/@d-zero/page-cluster/src/detect-content-depth-cap.spec.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from 'vitest';
+
+import { detectContentDepthCap } from './detect-content-depth-cap.js';
+
+describe('detectContentDepthCap', () => {
+	test('finds the depth just before cluster count explodes: identical structure up to depth 3, unique content at depth 4', () => {
+		// Depths 1-3 all fold to a single cluster (the wrapper up to <div> is
+		// identical across every page); depth 4 introduces a page-unique
+		// <span class="unique-N">, fragmenting all 20 pages apart.
+		const pages = Array.from(
+			{ length: 20 },
+			(_, i) =>
+				`<body><main><section><article><div><span class="unique-${i}">content</span></div></article></section></main></body>`,
+		);
+
+		expect(detectContentDepthCap(pages, { candidateDepths: [1, 2, 3, 4, 5] })).toBe(3);
+	});
+
+	test('pages with no distinguishing content at any depth (no knee) return the largest candidate depth, deliberately not capping', () => {
+		const pages = Array.from(
+			{ length: 10 },
+			() => '<body><main><section><article>same</article></section></main></body>',
+		);
+
+		expect(detectContentDepthCap(pages, { candidateDepths: [1, 2, 3, 4] })).toBe(4);
+	});
+
+	test('an empty page list returns the largest candidate depth', () => {
+		expect(detectContentDepthCap([], { candidateDepths: [1, 2, 3] })).toBe(3);
+	});
+
+	test('minKneeRatio raises the bar for what counts as a knee, so a milder jump is no longer recognized', () => {
+		const pages = Array.from(
+			{ length: 20 },
+			(_, i) =>
+				`<body><main><section><article><div><span class="unique-${i}">content</span></div></article></section></main></body>`,
+		);
+
+		// The default threshold (1.5x) recognizes the 20x jump at depth 4.
+		const withDefault = detectContentDepthCap(pages, {
+			candidateDepths: [1, 2, 3, 4, 5],
+		});
+		expect(withDefault).toBe(3);
+
+		// An unreasonably high bar (100x) rejects even that jump, so no depth
+		// is capped.
+		const withHighBar = detectContentDepthCap(pages, {
+			candidateDepths: [1, 2, 3, 4, 5],
+			minKneeRatio: 100,
+		});
+		expect(withHighBar).toBe(5);
+	});
+
+	test('rejects an empty candidateDepths list', () => {
+		expect(() => detectContentDepthCap([], { candidateDepths: [] })).toThrow(RangeError);
+	});
+
+	test('rejects a candidateDepths list that is not strictly ascending', () => {
+		expect(() => detectContentDepthCap([], { candidateDepths: [3, 1, 2] })).toThrow(
+			RangeError,
+		);
+		expect(() => detectContentDepthCap([], { candidateDepths: [1, 1, 2] })).toThrow(
+			RangeError,
+		);
+	});
+
+	test.each([1, 0, -1, Number.NaN])(
+		'rejects an invalid minKneeRatio (%s)',
+		(minKneeRatio) => {
+			expect(() =>
+				detectContentDepthCap([], { candidateDepths: [1, 2], minKneeRatio }),
+			).toThrow(RangeError);
+		},
+	);
+
+	test('forwards TokenizeOptions/ResolveStructuralClusterKeysOptions to every sweep, and a jump exactly at minKneeRatio still counts as a knee', () => {
+		// pages 0/1 share every tag/structure and differ only in an
+		// emotion-style noise class ("css-XXXXXX") on their deepest element;
+		// page 2 is structurally unrelated to either and stays its own
+		// cluster at every depth.
+		const pages = [
+			'<body><main><section><p class="css-1x2y3z">a</p></section></main></body>',
+			'<body><main><section><p class="css-9z8y7x">a</p></section></main></body>',
+			'<body><main><em>different</em></main></body>',
+		];
+
+		// At maxDepth 1, capContentDepth excises the <p> (and its class)
+		// entirely on both page 0 and 1, so they're identical regardless of
+		// filterNoiseClasses: cluster count is 2 ({0,1}, {2}) either way.
+		// At maxDepth 2, <p> survives with its class:
+		// - filterNoiseClasses: true (the default) strips the noise class, so
+		//   0 and 1 are still identical -> cluster count stays 2 -> ratio 1,
+		//   no knee -> falls through to the largest candidate depth.
+		expect(detectContentDepthCap(pages, { candidateDepths: [1, 2] })).toBe(2);
+
+		// - filterNoiseClasses: false keeps the class, so 0 and 1 now differ
+		//   -> cluster count becomes 3 -> ratio 3/2 = 1.5, exactly the default
+		//   minKneeRatio. If this ratio were rejected (the pre-fix `>`
+		//   boundary bug) or the option weren't forwarded to the sweep's own
+		//   tokenize() calls, this would still return 2.
+		expect(
+			detectContentDepthCap(pages, {
+				candidateDepths: [1, 2],
+				filterNoiseClasses: false,
+			}),
+		).toBe(1);
+	});
+});

--- a/packages/@d-zero/page-cluster/src/detect-content-depth-cap.ts
+++ b/packages/@d-zero/page-cluster/src/detect-content-depth-cap.ts
@@ -36,6 +36,50 @@ export type DetectContentDepthCapOptions = TokenizeOptions &
 	};
 
 /**
+ * Validates the `candidateDepths`/`minKneeRatio` parts of
+ * {@link DetectContentDepthCapOptions} without running the sweep itself.
+ * {@link detectContentDepthCap} always calls this on its own, so a direct
+ * caller never needs to; it's exported only so a caller that invokes
+ * `detectContentDepthCap` conditionally (e.g. once per block, skipped
+ * entirely for blocks too small to matter — see
+ * {@link ./resolve-page-cluster-keys.js | resolvePageClusterKeys}'s
+ * `autoCapMainDepth`) can still fail fast on a bad option even when that
+ * per-call skip means the sweep itself might never run for a given input
+ * (e.g. an empty page list has no blocks at all).
+ * @param options
+ * @example
+ * ```ts
+ * // Fails fast on a bad option even though nothing here would otherwise
+ * // call detectContentDepthCap yet (e.g. blocks haven't been computed).
+ * validateDetectContentDepthCapOptions({ minKneeRatio: 1 }); // throws RangeError
+ * ```
+ */
+export function validateDetectContentDepthCapOptions(
+	options?: DetectContentDepthCapOptions,
+): void {
+	const candidateDepths = options?.candidateDepths ?? [1, 2, 3, 4, 5, 6, 8, 10];
+	const minKneeRatio = options?.minKneeRatio ?? 1.5;
+
+	if (candidateDepths.length === 0) {
+		throw new RangeError('detectContentDepthCap: candidateDepths must not be empty');
+	}
+	let previousDepth = -Infinity;
+	for (const depth of candidateDepths) {
+		if (depth <= previousDepth) {
+			throw new RangeError(
+				`detectContentDepthCap: candidateDepths must be in strictly ascending order, got ${JSON.stringify(candidateDepths)}`,
+			);
+		}
+		previousDepth = depth;
+	}
+	if (!(Number.isFinite(minKneeRatio) && minKneeRatio > 1)) {
+		throw new RangeError(
+			`detectContentDepthCap: minKneeRatio must be a finite number greater than 1, got ${minKneeRatio}`,
+		);
+	}
+}
+
+/**
  * Finds the depth just before {@link ./cap-content-depth.js | capContentDepth}
  * ("`maxDepth`") would start throwing away real structural signal, by trying
  * each of `options.candidateDepths` in turn and looking for the first big
@@ -71,16 +115,23 @@ export type DetectContentDepthCapOptions = TokenizeOptions &
  * This calls {@link ./resolve-structural-cluster-keys.js |
  * resolveStructuralClusterKeys} once per candidate depth (each an O(n²)
  * comparison over `htmlList`), so cost scales with both `htmlList.length`
- * and `candidateDepths.length`. Measured on a real 4,085-page single-section
- * corpus: ~4s per candidate depth, ~30s total for the default 8 depths.
- * Measured via {@link ./resolve-page-cluster-keys.js | resolvePageClusterKeys}'s
- * `autoCapMainDepth` option on a real 8,936-page whole-site corpus (this
- * function runs once, globally, across all of it before blocking): ~5m50s
- * total, versus ~16s for the same corpus without `autoCapMainDepth` —
- * cutting that corpus's final cluster count from 1,972 to 283. Sampling
- * `htmlList` down before calling this (accepting a less precise knee
- * estimate) is the natural next step if this cost becomes a problem, but
- * isn't implemented here without real evidence it's needed.
+ * and `candidateDepths.length`. Measured standalone on a real 4,085-page
+ * single-block corpus: ~4s per candidate depth, ~30s total for the default 8
+ * depths. {@link ./resolve-page-cluster-keys.js | resolvePageClusterKeys}'s
+ * `autoCapMainDepth` option calls this once *per block* rather than once
+ * globally (different blocks can have different knees — see that option's
+ * own JSDoc for why this matters, not just for cost) — measured end to end on
+ * a real 8,936-page whole-site corpus (32 blocks, largest ~4,082 pages):
+ * ~119s total with `autoCapMainDepth` versus ~18s without it, cutting that
+ * corpus's final cluster count from 1,972 to 134. Partitioning the O(n²) cost
+ * across blocks rather than paying it once over the whole corpus is itself
+ * why this got *cheaper* than an earlier global-sweep design that measured
+ * ~5m50s for the same corpus (the sum of each block's `memberCount²` is far
+ * below `htmlList.length²` once a corpus splits into more than a couple of
+ * blocks). Sampling a single block's `htmlList` down before calling this
+ * (accepting a less precise knee estimate) is the natural next step if one
+ * particular block's cost becomes a problem, but isn't implemented here
+ * without real evidence it's needed.
  * @param htmlList
  * @param options
  * @example
@@ -95,27 +146,10 @@ export function detectContentDepthCap(
 	htmlList: readonly string[],
 	options?: DetectContentDepthCapOptions,
 ): number {
+	validateDetectContentDepthCapOptions(options);
 	const landmark = options?.landmark ?? 'main';
 	const candidateDepths = options?.candidateDepths ?? [1, 2, 3, 4, 5, 6, 8, 10];
 	const minKneeRatio = options?.minKneeRatio ?? 1.5;
-
-	if (candidateDepths.length === 0) {
-		throw new RangeError('detectContentDepthCap: candidateDepths must not be empty');
-	}
-	let previousDepth = -Infinity;
-	for (const depth of candidateDepths) {
-		if (depth <= previousDepth) {
-			throw new RangeError(
-				`detectContentDepthCap: candidateDepths must be in strictly ascending order, got ${JSON.stringify(candidateDepths)}`,
-			);
-		}
-		previousDepth = depth;
-	}
-	if (!(Number.isFinite(minKneeRatio) && minKneeRatio > 1)) {
-		throw new RangeError(
-			`detectContentDepthCap: minKneeRatio must be a finite number greater than 1, got ${minKneeRatio}`,
-		);
-	}
 
 	const clusterCounts = candidateDepths.map((maxDepth) => {
 		const tokenSets = htmlList.map((html) => {

--- a/packages/@d-zero/page-cluster/src/detect-content-depth-cap.ts
+++ b/packages/@d-zero/page-cluster/src/detect-content-depth-cap.ts
@@ -1,0 +1,151 @@
+import type { ContentDepthLandmark } from './cap-content-depth.js';
+import type { ResolveStructuralClusterKeysOptions } from './resolve-structural-cluster-keys.js';
+import type { TokenizeOptions } from './types.js';
+
+import { capContentDepth } from './cap-content-depth.js';
+import { resolveStructuralClusterKeys } from './resolve-structural-cluster-keys.js';
+import { tokenize } from './tokenize.js';
+
+/**
+ * @see detectContentDepthCap
+ */
+export type DetectContentDepthCapOptions = TokenizeOptions &
+	ResolveStructuralClusterKeysOptions & {
+		/** Forwarded to {@link ./cap-content-depth.js | capContentDepth}. Defaults to `'main'`. */
+		landmark?: ContentDepthLandmark;
+		/**
+		 * Depths to try, in strictly ascending order (`RangeError` otherwise —
+		 * the knee-detection loop below assumes each depth is deeper than the
+		 * last). Defaults to `[1, 2, 3, 4, 5, 6, 8, 10]` — chosen to cover the
+		 * range confirmed on real crawl data (the knee landed at 3 on both
+		 * corpora checked) with a few extra steps past it to confirm the
+		 * explosion is sustained, without trying every single depth up to an
+		 * arbitrary ceiling.
+		 */
+		candidateDepths?: readonly number[];
+		/**
+		 * The minimum cluster-count ratio between two consecutive candidate
+		 * depths (`clusterCount[i] / clusterCount[i-1]`) required to call that
+		 * jump "the knee." Must be a finite number greater than 1 (`RangeError`
+		 * otherwise — a ratio at or below 1 means "no growth," which can never
+		 * meaningfully gate a knee). Defaults to `1.5` (a 50% jump). Below this,
+		 * growth is treated as gradual/expected rather than evidence of a
+		 * freeform-content boundary, and no cap is recommended.
+		 */
+		minKneeRatio?: number;
+	};
+
+/**
+ * Finds the depth just before {@link ./cap-content-depth.js | capContentDepth}
+ * ("`maxDepth`") would start throwing away real structural signal, by trying
+ * each of `options.candidateDepths` in turn and looking for the first big
+ * jump in resulting cluster count.
+ *
+ * Confirmed on two unrelated real crawls (302 and ~4,100 pages, sharing no
+ * code or template lineage): the number of distinct
+ * {@link ./resolve-structural-cluster-keys.js | resolveStructuralClusterKeys}
+ * clusters stays roughly flat (or grows gently) as `maxDepth` increases,
+ * then jumps sharply (14x and 9x respectively) at one specific depth — the
+ * point past which comparisons start seeing freeform, page-to-page-varying
+ * editorial content instead of shared template structure. That depth landed
+ * at 3 on both corpora, but this function doesn't hardcode that: it
+ * re-derives it per corpus, so a differently-nested template doesn't get
+ * the wrong number silently baked in.
+ *
+ * Returns the *last* candidate depth before the biggest qualifying jump
+ * (`options.minKneeRatio` or steeper) — i.e. the depth to actually cap
+ * at, already chosen so the jump lands past it. If no jump in
+ * `candidateDepths` clears `minKneeRatio` (growth looks gradual, or
+ * `htmlList` is too small/uniform to tell), the *largest* candidate depth is
+ * returned — deliberately not capping rather than guessing.
+ *
+ * Forwards `options`' `TokenizeOptions`/`ResolveStructuralClusterKeysOptions`
+ * fields (e.g. `filterNoiseClasses`, `similarityThreshold`) to every sweep's
+ * `tokenize`/`resolveStructuralClusterKeys` call, so the knee is detected
+ * against the same tokenization and clustering configuration
+ * {@link ./resolve-page-cluster-keys.js | resolvePageClusterKeys} actually
+ * clusters with afterward — passing a different configuration here than
+ * downstream would pick a cap tuned for a comparison that's never actually
+ * performed.
+ *
+ * This calls {@link ./resolve-structural-cluster-keys.js |
+ * resolveStructuralClusterKeys} once per candidate depth (each an O(n²)
+ * comparison over `htmlList`), so cost scales with both `htmlList.length`
+ * and `candidateDepths.length`. Measured on a real 4,085-page single-section
+ * corpus: ~4s per candidate depth, ~30s total for the default 8 depths.
+ * Measured via {@link ./resolve-page-cluster-keys.js | resolvePageClusterKeys}'s
+ * `autoCapMainDepth` option on a real 8,936-page whole-site corpus (this
+ * function runs once, globally, across all of it before blocking): ~5m50s
+ * total, versus ~16s for the same corpus without `autoCapMainDepth` —
+ * cutting that corpus's final cluster count from 1,972 to 283. Sampling
+ * `htmlList` down before calling this (accepting a less precise knee
+ * estimate) is the natural next step if this cost becomes a problem, but
+ * isn't implemented here without real evidence it's needed.
+ * @param htmlList
+ * @param options
+ * @example
+ * ```ts
+ * const maxDepth = detectContentDepthCap(pages.map((p) => p.html));
+ * const tokenSets = pages.map(
+ * 	(p) => new Set(tokenize(capContentDepth(p.html, { landmark: 'main', maxDepth }).remainderHtml).tokens),
+ * );
+ * ```
+ */
+export function detectContentDepthCap(
+	htmlList: readonly string[],
+	options?: DetectContentDepthCapOptions,
+): number {
+	const landmark = options?.landmark ?? 'main';
+	const candidateDepths = options?.candidateDepths ?? [1, 2, 3, 4, 5, 6, 8, 10];
+	const minKneeRatio = options?.minKneeRatio ?? 1.5;
+
+	if (candidateDepths.length === 0) {
+		throw new RangeError('detectContentDepthCap: candidateDepths must not be empty');
+	}
+	let previousDepth = -Infinity;
+	for (const depth of candidateDepths) {
+		if (depth <= previousDepth) {
+			throw new RangeError(
+				`detectContentDepthCap: candidateDepths must be in strictly ascending order, got ${JSON.stringify(candidateDepths)}`,
+			);
+		}
+		previousDepth = depth;
+	}
+	if (!(Number.isFinite(minKneeRatio) && minKneeRatio > 1)) {
+		throw new RangeError(
+			`detectContentDepthCap: minKneeRatio must be a finite number greater than 1, got ${minKneeRatio}`,
+		);
+	}
+
+	const clusterCounts = candidateDepths.map((maxDepth) => {
+		const tokenSets = htmlList.map((html) => {
+			const capped = capContentDepth(html, { landmark, maxDepth }).remainderHtml;
+			return new Set(tokenize(capped, options).tokens);
+		});
+		return new Set(resolveStructuralClusterKeys(tokenSets, options)).size;
+	});
+
+	// bestRatio starts below any possible ratio (rather than at minKneeRatio
+	// itself) so a jump that exactly *meets* minKneeRatio still qualifies —
+	// this option's own JSDoc only calls growth "gradual" (i.e. rejected)
+	// when it's *below* the threshold, not at or above it.
+	let bestRatio = -Infinity;
+	let kneeIndex = -1;
+	for (let i = 1; i < clusterCounts.length; i++) {
+		const previous = clusterCounts[i - 1];
+		const current = clusterCounts[i];
+		if (previous === undefined || current === undefined || previous === 0) {
+			continue;
+		}
+		const ratio = current / previous;
+		if (ratio >= minKneeRatio && ratio > bestRatio) {
+			bestRatio = ratio;
+			kneeIndex = i;
+		}
+	}
+
+	if (kneeIndex === -1) {
+		return candidateDepths.at(-1) ?? 0;
+	}
+	return candidateDepths[kneeIndex - 1] ?? 0;
+}

--- a/packages/@d-zero/page-cluster/src/escape-reg-exp.ts
+++ b/packages/@d-zero/page-cluster/src/escape-reg-exp.ts
@@ -1,0 +1,13 @@
+/**
+ * Escapes regex metacharacters in `text` so it can be interpolated into a
+ * `RegExp` literally. Needed because a tag name reaching
+ * {@link ./is-genuine-close.js | isGenuineClose} is not guaranteed to be a
+ * plain HTML tag name: htmlparser2 accepts characters like `(`/`[` inside a
+ * tag name (`<div(foo role="banner">` parses with tag name `"div(foo"`),
+ * which would otherwise either throw (an unbalanced `(` is an invalid regex)
+ * or silently change what the regex matches.
+ * @param text
+ */
+export function escapeRegExp(text: string): string {
+	return text.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/packages/@d-zero/page-cluster/src/excise.ts
+++ b/packages/@d-zero/page-cluster/src/excise.ts
@@ -1,0 +1,28 @@
+import { mergeSpans } from './merge-spans.js';
+
+/**
+ * Excises `spans` (merged via {@link ./merge-spans.js | mergeSpans}) from
+ * `html`, returning what's left. No placeholder is left in a span's place: a
+ * placeholder string would itself become a token once the remainder is
+ * tokenized, reintroducing exactly the kind of synthetic signal callers of
+ * this function exist to remove.
+ * @param html
+ * @param spans
+ */
+export function excise(
+	html: string,
+	spans: readonly { start: number; end: number }[],
+): string {
+	if (spans.length === 0) {
+		return html;
+	}
+	const merged = mergeSpans(spans);
+	let remainder = '';
+	let cursor = 0;
+	for (const span of merged) {
+		remainder += html.slice(cursor, span.start);
+		cursor = span.end;
+	}
+	remainder += html.slice(cursor);
+	return remainder;
+}

--- a/packages/@d-zero/page-cluster/src/extract-landmarks.ts
+++ b/packages/@d-zero/page-cluster/src/extract-landmarks.ts
@@ -1,5 +1,7 @@
 import { Parser } from 'htmlparser2';
 
+import { excise } from './excise.js';
+import { isGenuineClose } from './is-genuine-close.js';
 import { isOpaqueTagName } from './opaque-tags.js';
 
 /**
@@ -82,73 +84,6 @@ function matchLandmarkTypes(tagName: string, role: string | undefined): Landmark
 		types.push(byRole);
 	}
 	return types;
-}
-
-/**
- * Merges a set of (possibly overlapping or nested) `[start, end)` spans into
- * the smallest equivalent set of disjoint spans, sorted by start offset.
- * Landmark spans commonly nest in real markup (a site nav living inside the
- * header, e.g. `<header><nav>...</nav></header>`) — merging first means the
- * later excision pass never has to reason about overlap.
- * @param spans
- */
-function mergeSpans(
-	spans: readonly { start: number; end: number }[],
-): { start: number; end: number }[] {
-	const sorted = [...spans].toSorted((a, b) => a.start - b.start);
-	const merged: { start: number; end: number }[] = [];
-	for (const span of sorted) {
-		const last = merged.at(-1);
-		if (last && span.start <= last.end) {
-			last.end = Math.max(last.end, span.end);
-		} else {
-			merged.push({ ...span });
-		}
-	}
-	return merged;
-}
-
-/**
- * Escapes regex metacharacters in `text` so it can be interpolated into a
- * `RegExp` literally. Needed because `tagName` reaching {@link isGenuineClose}
- * is not guaranteed to be a plain HTML tag name: htmlparser2 accepts
- * characters like `(`/`[` inside a tag name (`<div(foo role="banner">`
- * parses with tag name `"div(foo"`), which would otherwise either throw
- * (an unbalanced `(` is an invalid regex) or silently change what the regex
- * matches.
- * @param text
- */
-function escapeRegExp(text: string): string {
-	return text.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-/**
- * Whether `html` actually contains a literal closing tag for `tagName`
- * ending at `endOffset`. htmlparser2 fires `onclosetag` not only for real
- * closing tags but also when it force-closes a still-open ancestor to
- * resolve a mismatch (e.g. `<header>H<main>...</main></body>` with no
- * `</header>` ever written) — and in that forced case it reports the
- * force-closed element's `endIndex` as wherever the *other*, unrelated
- * closing tag that triggered the cascade happens to sit, not any position
- * derived from `<header>` itself (confirmed by direct htmlparser2 event
- * tracing: both the synthetic `header` close and the real `body` close
- * report the identical `endIndex`, because there is no real `</header>` in
- * the source for htmlparser2 to anchor a distinct position to). Trusting
- * that offset would slice a candidate spanning all the way to wherever the
- * unrelated tag ends, silently swallowing real content into
- * `remainderHtml`'s missing half. Checking that the text immediately
- * preceding `endOffset` actually spells the expected closing tag catches
- * exactly this: a genuine close always ends with it; a forced one ends with
- * whatever unrelated tag forced it instead.
- * @param html
- * @param endOffset
- * @param tagName
- */
-function isGenuineClose(html: string, endOffset: number, tagName: string): boolean {
-	const windowStart = Math.max(0, endOffset - tagName.length - 3);
-	return new RegExp(`</\\s*${escapeRegExp(tagName)}\\s*>$`, 'i').test(
-		html.slice(windowStart, endOffset),
-	);
 }
 
 /**
@@ -334,17 +269,7 @@ export function extractLandmarks(html: string): ExtractLandmarksResult {
 		winnerSpans.push({ start: winner.startOffset, end: winner.endOffset });
 	}
 
-	if (winnerSpans.length > 0) {
-		const merged = mergeSpans(winnerSpans);
-		let remainder = '';
-		let cursor = 0;
-		for (const span of merged) {
-			remainder += html.slice(cursor, span.start);
-			cursor = span.end;
-		}
-		remainder += html.slice(cursor);
-		result.remainderHtml = remainder;
-	}
+	result.remainderHtml = excise(html, winnerSpans);
 
 	return result;
 }

--- a/packages/@d-zero/page-cluster/src/extract-landmarks.ts
+++ b/packages/@d-zero/page-cluster/src/extract-landmarks.ts
@@ -1,8 +1,5 @@
-import { Parser } from 'htmlparser2';
-
 import { excise } from './excise.js';
-import { isGenuineClose } from './is-genuine-close.js';
-import { isOpaqueTagName } from './opaque-tags.js';
+import { findShallowestElements } from './find-shallowest-elements.js';
 
 /**
  * The four structural regions this module knows how to carve out of a page.
@@ -45,19 +42,6 @@ const ROLE_TO_TYPE: Readonly<Record<string, LandmarkType>> = {
 	contentinfo: 'footer',
 	navigation: 'nav',
 	complementary: 'aside',
-};
-
-type Frame = {
-	tagName: string;
-	matchedTypes: readonly LandmarkType[];
-	startOffset: number;
-};
-
-type Candidate = {
-	type: LandmarkType;
-	depth: number;
-	startOffset: number;
-	endOffset: number;
 };
 
 /**
@@ -141,132 +125,14 @@ function matchLandmarkTypes(tagName: string, role: string | undefined): Landmark
  * ```
  */
 export function extractLandmarks(html: string): ExtractLandmarksResult {
-	const stack: Frame[] = [];
-	const candidates: Candidate[] = [];
-	// Only the *same* tag name nested inside itself (`<svg><svg>...`) counts
-	// as self-nesting; a different opaque tag opening/closing while already
-	// inside one (e.g. `<svg><script>...</script></svg>`, valid SVG
-	// scripting) fires its own open/close events but must not perturb this
-	// counter — same rationale and shape as `OpaqueRegion` in
-	// `run-tokenizer.ts`.
-	let opaque: { tagName: string; depth: number } | null = null;
-	let bodyDone = false;
-	let ignoredBodyOpens = 0;
-
-	const parser = new Parser(
-		{
-			onopentag(name, attribs) {
-				if (opaque) {
-					if (name === opaque.tagName) {
-						opaque.depth++;
-					}
-					return;
-				}
-
-				if (stack.length === 0) {
-					if (name === 'body' && !bodyDone) {
-						// <body role="banner"> is a real (if unusual) way to mark
-						// the whole page as its own header landmark; matched the
-						// same way any other role-bearing element is, rather than
-						// hardcoding matchedTypes to [] as if body could never
-						// carry a landmark role itself.
-						stack.push({
-							tagName: name,
-							matchedTypes: matchLandmarkTypes(name, attribs.role || undefined),
-							startOffset: parser.startIndex,
-						});
-					}
-					// Ignore everything else outside <body> (head, a second
-					// top-level <body>, ...) — same as run-tokenizer.ts.
-					return;
-				}
-
-				if (name === 'body') {
-					ignoredBodyOpens++;
-					return;
-				}
-
-				if (isOpaqueTagName(name)) {
-					opaque = { tagName: name, depth: 1 };
-					return;
-				}
-
-				stack.push({
-					tagName: name,
-					matchedTypes: matchLandmarkTypes(name, attribs.role || undefined),
-					startOffset: parser.startIndex,
-				});
-			},
-			onclosetag(name) {
-				if (opaque) {
-					if (name === opaque.tagName) {
-						opaque.depth--;
-						if (opaque.depth === 0) {
-							opaque = null;
-						}
-					}
-					return;
-				}
-
-				if (name === 'body' && ignoredBodyOpens > 0) {
-					ignoredBodyOpens--;
-					return;
-				}
-
-				if (stack.length === 0) {
-					return;
-				}
-
-				const frame = stack.pop();
-				if (!frame) {
-					return;
-				}
-				const depth = stack.length;
-				const endOffset = parser.endIndex + 1;
-				// Discard rather than trust a candidate whose close was forced by
-				// an unrelated tag (see isGenuineClose) — safety against
-				// corrupting remainderHtml outweighs completeness of landmark
-				// detection for malformed markup.
-				if (
-					frame.matchedTypes.length > 0 &&
-					isGenuineClose(html, endOffset, frame.tagName)
-				) {
-					for (const type of frame.matchedTypes) {
-						candidates.push({ type, depth, startOffset: frame.startOffset, endOffset });
-					}
-				}
-				if (stack.length === 0) {
-					bodyDone = true;
-				}
-			},
-		},
-		{ decodeEntities: false },
-	);
-	parser.end(html);
+	const matches = findShallowestElements(html, matchLandmarkTypes);
 
 	const result: ExtractLandmarksResult = { remainderHtml: html };
 	const winnerSpans: { start: number; end: number }[] = [];
 
-	for (const type of ['header', 'footer', 'nav', 'aside'] as const) {
-		const typeCandidates = candidates.filter((c) => c.type === type);
-		if (typeCandidates.length === 0) {
-			continue;
-		}
-		let winner = typeCandidates[0];
-		for (const candidate of typeCandidates) {
-			if (
-				winner === undefined ||
-				candidate.depth < winner.depth ||
-				(candidate.depth === winner.depth && candidate.startOffset < winner.startOffset)
-			) {
-				winner = candidate;
-			}
-		}
-		if (!winner) {
-			continue;
-		}
-		result[type] = html.slice(winner.startOffset, winner.endOffset);
-		winnerSpans.push({ start: winner.startOffset, end: winner.endOffset });
+	for (const match of matches) {
+		result[match.type] = html.slice(match.startOffset, match.endOffset);
+		winnerSpans.push({ start: match.startOffset, end: match.endOffset });
 	}
 
 	result.remainderHtml = excise(html, winnerSpans);

--- a/packages/@d-zero/page-cluster/src/filter-first-party-stylesheet-hrefs.spec.ts
+++ b/packages/@d-zero/page-cluster/src/filter-first-party-stylesheet-hrefs.spec.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from 'vitest';
+
+import { filterFirstPartyStylesheetHrefs } from './filter-first-party-stylesheet-hrefs.js';
+
+describe('filterFirstPartyStylesheetHrefs', () => {
+	test('matches the exact output documented in the JSDoc @example', () => {
+		// Kept in sync with filterFirstPartyStylesheetHrefs's @example: if this
+		// ever fails, the JSDoc example is out of date and must be corrected
+		// alongside the implementation, not the other way around.
+		const result = filterFirstPartyStylesheetHrefs([
+			{ stylesheetHrefs: ['https://example.com/a.css', 'https://example.com/b.css'] },
+			{
+				stylesheetHrefs: [
+					'https://example.com/a.css',
+					'https://fonts.googleapis.com/css?family=x',
+				],
+			},
+		]);
+		expect(result).toStrictEqual([
+			{ stylesheetHrefs: ['https://example.com/a.css', 'https://example.com/b.css'] },
+			{ stylesheetHrefs: ['https://example.com/a.css'] },
+		]);
+	});
+
+	test('an empty page list returns an empty array', () => {
+		expect(filterFirstPartyStylesheetHrefs([])).toEqual([]);
+	});
+
+	test('a batch where every page loads no stylesheets is returned unchanged', () => {
+		const pages = [{ stylesheetHrefs: [] }, { stylesheetHrefs: [] }];
+		expect(filterFirstPartyStylesheetHrefs(pages)).toStrictEqual(pages);
+	});
+
+	test('a single distinctive third-party href on an otherwise first-party page is dropped, not merely deduplicated', () => {
+		const result = filterFirstPartyStylesheetHrefs([
+			{ stylesheetHrefs: ['https://example.com/a.css'] },
+			{
+				stylesheetHrefs: [
+					'https://example.com/a.css',
+					'https://www.youtube.com/s/player.css',
+				],
+			},
+		]);
+		expect(result[1]?.stylesheetHrefs).toEqual(['https://example.com/a.css']);
+	});
+
+	test('a tie between two equally common origins keeps the first one encountered and drops the other', () => {
+		const result = filterFirstPartyStylesheetHrefs([
+			{ stylesheetHrefs: ['https://a.example.com/x.css'] },
+			{ stylesheetHrefs: ['https://b.example.com/y.css'] },
+		]);
+		expect(result[0]?.stylesheetHrefs).toEqual(['https://a.example.com/x.css']);
+		expect(result[1]?.stylesheetHrefs).toEqual([]);
+	});
+
+	test('unparsable hrefs are dropped and never treated as an origin', () => {
+		const result = filterFirstPartyStylesheetHrefs([
+			{ stylesheetHrefs: ['https://example.com/a.css', 'not a url'] },
+			{ stylesheetHrefs: ['https://example.com/a.css'] },
+		]);
+		expect(result[0]?.stylesheetHrefs).toEqual(['https://example.com/a.css']);
+	});
+
+	test('a third-party host referenced by two <link> tags on the same page does not outvote a first-party host referenced by one <link> tag per page', () => {
+		// Dominance is measured by how many *pages* reference a host at least
+		// once, not by how many hrefs reference it in total — otherwise a page
+		// embedding two third-party font requests could outvote the site's own
+		// single first-party stylesheet.
+		const result = filterFirstPartyStylesheetHrefs([
+			{
+				stylesheetHrefs: [
+					'https://example.com/site.css',
+					'https://fonts.googleapis.com/css?family=a',
+					'https://fonts.googleapis.com/css?family=b',
+				],
+			},
+			{ stylesheetHrefs: ['https://example.com/site.css'] },
+		]);
+		expect(result[0]?.stylesheetHrefs).toEqual(['https://example.com/site.css']);
+		expect(result[1]?.stylesheetHrefs).toEqual(['https://example.com/site.css']);
+	});
+
+	test('the same first-party host served over http and https is treated as one host, not two competing hosts', () => {
+		const result = filterFirstPartyStylesheetHrefs([
+			{ stylesheetHrefs: ['http://example.com/a.css'] },
+			{ stylesheetHrefs: ['https://example.com/a.css'] },
+			{
+				stylesheetHrefs: ['https://cdn-evil.com/x.css', 'https://cdn-evil.com/y.css'],
+			},
+		]);
+		expect(result[0]?.stylesheetHrefs).toEqual(['http://example.com/a.css']);
+		expect(result[1]?.stylesheetHrefs).toEqual(['https://example.com/a.css']);
+		expect(result[2]?.stylesheetHrefs).toEqual([]);
+	});
+
+	test('fields other than stylesheetHrefs are preserved unchanged', () => {
+		const result = filterFirstPartyStylesheetHrefs([
+			{
+				paths: ['news', '1'],
+				stylesheetHrefs: [
+					'https://example.com/a.css',
+					'https://fonts.googleapis.com/css',
+				],
+			},
+			{ paths: ['news', '2'], stylesheetHrefs: ['https://example.com/a.css'] },
+		]);
+		expect(result[0]).toStrictEqual({
+			paths: ['news', '1'],
+			stylesheetHrefs: ['https://example.com/a.css'],
+		});
+	});
+});

--- a/packages/@d-zero/page-cluster/src/filter-first-party-stylesheet-hrefs.ts
+++ b/packages/@d-zero/page-cluster/src/filter-first-party-stylesheet-hrefs.ts
@@ -1,0 +1,126 @@
+/**
+ * Reads the host (not the full origin — see `filterFirstPartyStylesheetHrefs`'s
+ * JSDoc for why) out of `href`, or `undefined` if it isn't a parseable
+ * absolute URL. `stylesheetHrefs` is already expected to be absolute (see
+ * {@link ./derive-stylesheet-group-key.js | deriveStylesheetGroupKey}'s own
+ * JSDoc) — this is defensive, not a normalization step.
+ * @param href
+ */
+function tryGetHost(href: string): string | undefined {
+	try {
+		return new URL(href).host;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Narrows every page's `stylesheetHrefs` down to just the hrefs whose host
+ * matches the single most common host across the whole batch (the site's own
+ * first-party domain), dropping every other host.
+ *
+ * Confirmed on real crawl data (302 pages): a handful of articles embedding
+ * a YouTube video pulled in `youtube.com`'s own player stylesheet plus a
+ * per-embed tracking URL that resembles a stylesheet reference; other
+ * articles embedding a particular widget pulled in two extra
+ * `fonts.googleapis.com` URLs beyond the site's usual one. Both are
+ * incidental to whatever third-party content a page happens to embed, not
+ * evidence of which template the page uses — but
+ * {@link ./resolve-blocking-group-keys.js | resolveBlockingGroupKeys}'s
+ * document-frequency filtering has no way to tell "rare because it's a
+ * genuinely distinctive template" apart from "rare because almost no other
+ * page happens to embed this same third party," so it let these through as
+ * if they were real template signals, splitting a handful of otherwise-
+ * identical pages (confirmed via direct comparison: 100% token overlap with
+ * their section's main cluster) away from where they belonged. Filtering to
+ * first-party hrefs before blocking removes that false signal at the
+ * source, rather than trying to recognize its effects downstream.
+ *
+ * Determining "first-party" from the batch's own href distribution (rather
+ * than, say, comparing each href's host against each page's own URL) means
+ * this needs no extra per-page input beyond what
+ * {@link ./resolve-blocking-group-keys.js | resolveBlockingGroupKeys} already
+ * takes — but it inherits that same function's "roughly homogeneous batch"
+ * precondition (see `computeDocumentFrequency`'s own JSDoc): a batch that
+ * mixes pages from more than one site in one call has no single genuine
+ * first-party host to find, and this function has no way to detect that
+ * it's been handed one — it will still confidently pick *a* dominant host
+ * (whichever site contributes more stylesheet-bearing pages) and silently
+ * strip every other site's real first-party hrefs. Splitting a
+ * multi-site/section batch into homogeneous groups before calling this is
+ * the caller's responsibility, same as it already is for
+ * `resolveBlockingGroupKeys`.
+ *
+ * The dominant host is picked by how many *pages* reference it at least
+ * once, not by how many stylesheet `<link>` tags reference it — a page
+ * loading one first-party stylesheet plus two third-party font requests
+ * must not let the font host outvote the actual first-party one just for
+ * appearing on more `<link>` tags. Compared by `host` (hostname + port),
+ * not the full origin (which also includes the scheme): the same first-party
+ * site served over both `http:` and `https:` (mid-migration, or a stray
+ * unresolved protocol-relative URL) is still one site, not two competing
+ * "hosts" splitting its own vote.
+ *
+ * The trade-off: a site that legitimately serves its own stylesheets from
+ * more than one first-party host (e.g. a CDN subdomain alongside the main
+ * domain) will have its non-dominant host's hrefs dropped too, same as any
+ * genuinely-third-party host — not yet observed on real data, but a known
+ * limitation of picking a single dominant host rather than a set.
+ *
+ * A batch where no page has any stylesheet href at all (or none of the
+ * hrefs are parseable absolute URLs) has no host to detect; every page's
+ * `stylesheetHrefs` is returned unchanged in that case, matching this
+ * function's job of narrowing signal, not fabricating it.
+ * @param pages
+ * @example
+ * ```ts
+ * filterFirstPartyStylesheetHrefs([
+ * 	{ stylesheetHrefs: ['https://example.com/a.css', 'https://example.com/b.css'] },
+ * 	{ stylesheetHrefs: ['https://example.com/a.css', 'https://fonts.googleapis.com/css?family=x'] },
+ * ]);
+ * // [
+ * // 	{ stylesheetHrefs: ['https://example.com/a.css', 'https://example.com/b.css'] },
+ * // 	{ stylesheetHrefs: ['https://example.com/a.css'] }, // fonts.googleapis.com dropped
+ * // ]
+ * ```
+ */
+export function filterFirstPartyStylesheetHrefs<
+	T extends { stylesheetHrefs: readonly string[] },
+>(pages: readonly T[]): T[] {
+	const pageHrefHosts = pages.map((page) => ({
+		page,
+		hrefHosts: page.stylesheetHrefs.map((href) => ({ href, host: tryGetHost(href) })),
+	}));
+
+	const hostPageCounts = new Map<string, number>();
+	for (const { hrefHosts } of pageHrefHosts) {
+		const distinctHosts = new Set(
+			hrefHosts
+				.map(({ host }) => host)
+				.filter((host): host is string => host !== undefined),
+		);
+		for (const host of distinctHosts) {
+			hostPageCounts.set(host, (hostPageCounts.get(host) ?? 0) + 1);
+		}
+	}
+
+	let dominantHost: string | undefined;
+	let dominantCount = 0;
+	for (const [host, count] of hostPageCounts) {
+		if (count > dominantCount) {
+			dominantHost = host;
+			dominantCount = count;
+		}
+	}
+
+	if (dominantHost === undefined) {
+		return [...pages];
+	}
+
+	return pageHrefHosts.map(({ page, hrefHosts }) => ({
+		...page,
+		stylesheetHrefs: hrefHosts
+			.filter(({ host }) => host === dominantHost)
+			.map(({ href }) => href),
+	}));
+}

--- a/packages/@d-zero/page-cluster/src/find-shallowest-elements.ts
+++ b/packages/@d-zero/page-cluster/src/find-shallowest-elements.ts
@@ -1,0 +1,166 @@
+import { Parser } from 'htmlparser2';
+
+import { isGenuineClose } from './is-genuine-close.js';
+import { isOpaqueTagName } from './opaque-tags.js';
+
+/**
+ * One winning element for type `T`: the shallowest (fewest ancestors since
+ * `<body>`) genuinely-closed match, ties broken by document order. Both the
+ * whole-element span (`startOffset`/`endOffset`) and the inner-content span
+ * (`contentStart`/`contentEnd`, excluding the element's own opening/closing
+ * tags) are always computed — {@link ./extract-landmarks.js | extractLandmarks}
+ * only needs the former, {@link ./cap-content-depth.js | capContentDepth}
+ * only needs the latter, and computing both is cheap enough (two
+ * `indexOf`/`lastIndexOf` calls) that carrying the unused half costs nothing
+ * a caller need worry about.
+ */
+export type ShallowestElementMatch<T extends string> = {
+	type: T;
+	startOffset: number;
+	endOffset: number;
+	contentStart: number;
+	contentEnd: number;
+};
+
+type Frame<T extends string> = {
+	tagName: string;
+	matchedTypes: readonly T[];
+	startOffset: number;
+};
+
+type Candidate<T extends string> = {
+	type: T;
+	depth: number;
+	startOffset: number;
+	endOffset: number;
+	contentStart: number;
+	contentEnd: number;
+};
+
+/**
+ * Shared walk behind {@link ./extract-landmarks.js | extractLandmarks} (which
+ * matches four landmark types per element in one pass) and
+ * {@link ./cap-content-depth.js | capContentDepth} (which matches a single
+ * landmark). Both need the identical "shallowest genuinely-closed match
+ * wins" search — same `<body>`-scoping, same opaque-tag skip, same malformed-
+ * markup discard via {@link ./is-genuine-close.js | isGenuineClose} — so a
+ * fix to one (e.g. the body-scoping edge case already fixed once in
+ * `extractLandmarks`) can't silently fail to apply to the other.
+ *
+ * Only the first `<body>` is in scope, and nothing inside an opaque tag
+ * (`script`/`style`/`noscript`/`svg`) is searched — see
+ * `extractLandmarks`/`capContentDepth`'s own JSDoc for why.
+ * @param html
+ * @param matchTypes Given an element's tag name and `role` attribute (already
+ * normalized: an empty/absent `role` arrives as `undefined`), returns every
+ * type `T` that element matches. Returning more than one lets a single
+ * element (e.g. `<header role="navigation">`) win more than one type at
+ * once.
+ */
+export function findShallowestElements<T extends string>(
+	html: string,
+	matchTypes: (tagName: string, role: string | undefined) => readonly T[],
+): ShallowestElementMatch<T>[] {
+	const stack: Frame<T>[] = [];
+	const candidates: Candidate<T>[] = [];
+	let opaque: { tagName: string; depth: number } | null = null;
+	let bodyDone = false;
+	let ignoredBodyOpens = 0;
+
+	const parser = new Parser(
+		{
+			onopentag(name, attribs) {
+				if (opaque) {
+					if (name === opaque.tagName) opaque.depth++;
+					return;
+				}
+				if (stack.length === 0) {
+					if (name === 'body' && !bodyDone) {
+						stack.push({
+							tagName: name,
+							matchedTypes: matchTypes(name, attribs.role || undefined),
+							startOffset: parser.startIndex,
+						});
+					}
+					return;
+				}
+				if (name === 'body') {
+					ignoredBodyOpens++;
+					return;
+				}
+				if (isOpaqueTagName(name)) {
+					opaque = { tagName: name, depth: 1 };
+					return;
+				}
+				stack.push({
+					tagName: name,
+					matchedTypes: matchTypes(name, attribs.role || undefined),
+					startOffset: parser.startIndex,
+				});
+			},
+			onclosetag(name) {
+				if (opaque) {
+					if (name === opaque.tagName) {
+						opaque.depth--;
+						if (opaque.depth === 0) opaque = null;
+					}
+					return;
+				}
+				if (name === 'body' && ignoredBodyOpens > 0) {
+					ignoredBodyOpens--;
+					return;
+				}
+				if (stack.length === 0) return;
+				const frame = stack.pop();
+				if (!frame) return;
+				const depth = stack.length;
+				const endOffset = parser.endIndex + 1;
+				if (
+					frame.matchedTypes.length > 0 &&
+					isGenuineClose(html, endOffset, frame.tagName)
+				) {
+					const contentStart = html.indexOf('>', frame.startOffset) + 1;
+					const contentEnd = html.lastIndexOf('<', endOffset - 1);
+					for (const type of frame.matchedTypes) {
+						candidates.push({
+							type,
+							depth,
+							startOffset: frame.startOffset,
+							endOffset,
+							contentStart,
+							contentEnd,
+						});
+					}
+				}
+				if (stack.length === 0) bodyDone = true;
+			},
+		},
+		{ decodeEntities: false },
+	);
+	parser.end(html);
+
+	const winners = new Map<T, Candidate<T>>();
+	for (const candidate of candidates) {
+		const current = winners.get(candidate.type);
+		if (
+			current === undefined ||
+			candidate.depth < current.depth ||
+			(candidate.depth === current.depth && candidate.startOffset < current.startOffset)
+		) {
+			winners.set(candidate.type, candidate);
+		}
+	}
+	// `depth` (Candidate's own tie-break field) is deliberately not part of
+	// ShallowestElementMatch: it's an internal selection detail, not
+	// something either caller (extractLandmarks, capContentDepth) uses once
+	// the winner is chosen.
+	return [...winners.values()].map(
+		({ type, startOffset, endOffset, contentStart, contentEnd }) => ({
+			type,
+			startOffset,
+			endOffset,
+			contentStart,
+			contentEnd,
+		}),
+	);
+}

--- a/packages/@d-zero/page-cluster/src/is-genuine-close.ts
+++ b/packages/@d-zero/page-cluster/src/is-genuine-close.ts
@@ -1,0 +1,34 @@
+import { escapeRegExp } from './escape-reg-exp.js';
+
+/**
+ * Whether `html` actually contains a literal closing tag for `tagName`
+ * ending at `endOffset`. htmlparser2 fires `onclosetag` not only for real
+ * closing tags but also when it force-closes a still-open ancestor to
+ * resolve a mismatch (e.g. `<header>H<main>...</main></body>` with no
+ * `</header>` ever written) — and in that forced case it reports the
+ * force-closed element's `endIndex` as wherever the *other*, unrelated
+ * closing tag that triggered the cascade happens to sit, not any position
+ * derived from the matched element itself (confirmed by direct htmlparser2
+ * event tracing: both the synthetic close and the real `body` close report
+ * the identical `endIndex`, because there is no real closing tag in the
+ * source for htmlparser2 to anchor a distinct position to). Trusting that
+ * offset would slice a candidate spanning all the way to wherever the
+ * unrelated tag ends, silently swallowing real content into the caller's
+ * remainder HTML. Checking that the text immediately preceding `endOffset`
+ * actually spells the expected closing tag catches exactly this: a genuine
+ * close always ends with it; a forced one ends with whatever unrelated tag
+ * forced it instead.
+ * @param html
+ * @param endOffset
+ * @param tagName
+ */
+export function isGenuineClose(
+	html: string,
+	endOffset: number,
+	tagName: string,
+): boolean {
+	const windowStart = Math.max(0, endOffset - tagName.length - 3);
+	return new RegExp(`</\\s*${escapeRegExp(tagName)}\\s*>$`, 'i').test(
+		html.slice(windowStart, endOffset),
+	);
+}

--- a/packages/@d-zero/page-cluster/src/merge-spans.ts
+++ b/packages/@d-zero/page-cluster/src/merge-spans.ts
@@ -1,0 +1,23 @@
+/**
+ * Merges a set of (possibly overlapping or nested) `[start, end)` spans into
+ * the smallest equivalent set of disjoint spans, sorted by start offset.
+ * Matched spans commonly nest in real markup (e.g. a site nav living inside
+ * the header, `<header><nav>...</nav></header>`) — merging first means the
+ * later excision pass never has to reason about overlap.
+ * @param spans
+ */
+export function mergeSpans(
+	spans: readonly { start: number; end: number }[],
+): { start: number; end: number }[] {
+	const sorted = [...spans].toSorted((a, b) => a.start - b.start);
+	const merged: { start: number; end: number }[] = [];
+	for (const span of sorted) {
+		const last = merged.at(-1);
+		if (last && span.start <= last.end) {
+			last.end = Math.max(last.end, span.end);
+		} else {
+			merged.push({ ...span });
+		}
+	}
+	return merged;
+}

--- a/packages/@d-zero/page-cluster/src/reassign-orphan-block-keys.spec.ts
+++ b/packages/@d-zero/page-cluster/src/reassign-orphan-block-keys.spec.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from 'vitest';
+
+import { reassignOrphanBlockKeys } from './reassign-orphan-block-keys.js';
+import { resolveBlockingGroupKeys } from './resolve-blocking-group-keys.js';
+
+describe('reassignOrphanBlockKeys', () => {
+	test('matches the exact output documented in the JSDoc @example', () => {
+		// Kept in sync with reassignOrphanBlockKeys's @example: if this ever
+		// fails, the JSDoc example is out of date and must be corrected
+		// alongside the implementation, not the other way around.
+		const pages = [
+			{ paths: ['news', '1'], stylesheetHrefs: ['https://example.com/a.css'] },
+			{ paths: ['news', '2'], stylesheetHrefs: ['https://example.com/a.css'] },
+			{ paths: ['news', '3'], stylesheetHrefs: [] },
+			{ paths: ['about'], stylesheetHrefs: ['https://example.com/b.css'] },
+		];
+		const blockKeys = resolveBlockingGroupKeys(pages);
+		expect(blockKeys[0]).toMatch(/^css:/);
+		expect(blockKeys[2]).toBe('path:news');
+
+		const result = reassignOrphanBlockKeys(pages, blockKeys);
+
+		expect(result[0]).toBe('orphan-merge:news');
+		expect(result[1]).toBe('orphan-merge:news');
+		expect(result[2]).toBe('orphan-merge:news');
+		expect(result[3]).toBe('path:about');
+	});
+
+	test('a css: block spanning more than one path key ("unconfined") is left unchanged even when an orphan shares one of its path keys', () => {
+		// c.css keeps a.css's document frequency below the common-href
+		// threshold (2/3 instead of 2/2 = 100%), so a.css stays distinctive
+		// enough to form a css: block on its own — see
+		// resolve-blocking-group-keys.spec.ts's own tests for this same pattern.
+		const pages = [
+			{ paths: ['news'], stylesheetHrefs: ['https://example.com/a.css'] },
+			{ paths: ['about'], stylesheetHrefs: ['https://example.com/a.css'] },
+			{ paths: ['news', '2'], stylesheetHrefs: [] },
+			{ paths: ['contact'], stylesheetHrefs: ['https://example.com/c.css'] },
+		];
+		const blockKeys = resolveBlockingGroupKeys(pages);
+		expect(blockKeys[0]).toMatch(/^css:/);
+		expect(blockKeys[0]).toBe(blockKeys[1]);
+		expect(blockKeys[2]).toBe('path:news');
+
+		expect(reassignOrphanBlockKeys(pages, blockKeys)).toEqual(blockKeys);
+	});
+
+	test('multiple css: blocks confined to the same path key are all merged together with the orphan', () => {
+		const pages = [
+			{ paths: ['news', '1'], stylesheetHrefs: ['https://example.com/a.css'] },
+			{ paths: ['news', '2'], stylesheetHrefs: ['https://example.com/a.css'] },
+			{ paths: ['news', '3'], stylesheetHrefs: ['https://example.com/b.css'] },
+			{ paths: ['news', '4'], stylesheetHrefs: ['https://example.com/b.css'] },
+			{ paths: ['news', '5'], stylesheetHrefs: [] },
+		];
+		const blockKeys = resolveBlockingGroupKeys(pages);
+		expect(blockKeys[0]).toMatch(/^css:/);
+		expect(blockKeys[2]).toMatch(/^css:/);
+		expect(blockKeys[0]).not.toBe(blockKeys[2]);
+
+		const result = reassignOrphanBlockKeys(pages, blockKeys);
+
+		expect(new Set(result)).toEqual(new Set(['orphan-merge:news']));
+	});
+
+	test('an orphan with no confined css: block sharing its path key is left unchanged', () => {
+		const pages = [
+			{ paths: ['news'], stylesheetHrefs: [] },
+			{ paths: ['about'], stylesheetHrefs: ['https://example.com/a.css'] },
+			{ paths: ['about'], stylesheetHrefs: ['https://example.com/a.css'] },
+		];
+		const blockKeys = ['path:news', 'css:x', 'css:x'];
+
+		expect(reassignOrphanBlockKeys(pages, blockKeys)).toEqual(blockKeys);
+	});
+
+	test('a confined css: block with no orphan sharing its path key is left unchanged', () => {
+		// c.css dilutes a.css's document frequency below the common-href
+		// threshold (2/3 instead of 2/2 = 100%), so a.css actually forms a css:
+		// key here — without it, resolveBlockingGroupKeys would filter a.css out
+		// as non-discriminative chrome and never produce a css: key at all,
+		// making this test pass without ever exercising the branch it names.
+		const pages = [
+			{ paths: ['news', '1'], stylesheetHrefs: ['https://example.com/a.css'] },
+			{ paths: ['news', '2'], stylesheetHrefs: ['https://example.com/a.css'] },
+			{ paths: ['contact'], stylesheetHrefs: ['https://example.com/c.css'] },
+		];
+		const blockKeys = resolveBlockingGroupKeys(pages);
+		expect(blockKeys[0]).toMatch(/^css:/);
+
+		expect(reassignOrphanBlockKeys(pages, blockKeys)).toEqual(blockKeys);
+	});
+
+	test('a non-orphan page sharing the orphan-affected path key (a real, non-discriminative stylesheet, not missing data) is not folded into the merged pool', () => {
+		// common.css is loaded by every stylesheet-bearing page (4/4 = 100%), so
+		// it is filtered out as non-discriminative chrome. Page 3 loads nothing
+		// else, so it falls back to path:news for a genuine reason (no
+		// distinctive stylesheet), not because its stylesheet data is missing —
+		// `stylesheetHrefs.length` is 1, not 0, so it is not an orphan. It must
+		// not be pulled into the same pool as the orphan and the confined css:
+		// block: doing so could change which of them the block's own members
+		// end up matched with (complete-linkage's min-linkage aggregation lets
+		// an unrelated third point in the comparison pool change whether two
+		// *other* points clear the similarity threshold together), which this
+		// function has no evidence to justify.
+		const pages = [
+			{
+				paths: ['news', '1'],
+				stylesheetHrefs: ['https://example.com/a.css', 'https://example.com/common.css'],
+			},
+			{
+				paths: ['news', '2'],
+				stylesheetHrefs: ['https://example.com/a.css', 'https://example.com/common.css'],
+			},
+			{ paths: ['news', '3'], stylesheetHrefs: [] },
+			{ paths: ['news', '4'], stylesheetHrefs: ['https://example.com/common.css'] },
+			{ paths: ['other', '1'], stylesheetHrefs: ['https://example.com/common.css'] },
+		];
+		const blockKeys = resolveBlockingGroupKeys(pages);
+		expect(blockKeys[0]).toMatch(/^css:/);
+		expect(blockKeys[2]).toBe('path:news');
+		expect(blockKeys[3]).toBe('path:news');
+
+		const result = reassignOrphanBlockKeys(pages, blockKeys);
+
+		expect(result[0]).toBe('orphan-merge:news');
+		expect(result[2]).toBe('orphan-merge:news');
+		expect(result[3]).toBe('path:news');
+	});
+
+	test('pathDepth is forwarded to derivePathGroupKey so confinement and orphan path keys are computed consistently with resolveBlockingGroupKeys', () => {
+		const pages = [
+			{ paths: ['dept-a', 'news', '1'], stylesheetHrefs: ['https://example.com/a.css'] },
+			{ paths: ['dept-a', 'news', '2'], stylesheetHrefs: ['https://example.com/a.css'] },
+			{ paths: ['dept-a', 'news', '3'], stylesheetHrefs: [] },
+			{ paths: ['dept-b'], stylesheetHrefs: ['https://example.com/b.css'] },
+		];
+		const blockKeys = resolveBlockingGroupKeys(pages, { pathDepth: 2 });
+		expect(blockKeys[2]).toBe('path:dept-a/news');
+
+		const result = reassignOrphanBlockKeys(pages, blockKeys, 2);
+
+		expect(new Set(result.slice(0, 3))).toEqual(new Set(['orphan-merge:dept-a/news']));
+	});
+
+	test('an empty page list returns an empty array', () => {
+		expect(reassignOrphanBlockKeys([], [])).toEqual([]);
+	});
+
+	test('rejects an invalid pathDepth eagerly, even with an empty page list', () => {
+		expect(() => reassignOrphanBlockKeys([], [], 0)).toThrow(RangeError);
+	});
+
+	test('a batch with no css: keys at all is returned unchanged', () => {
+		const pages = [
+			{ paths: ['news'], stylesheetHrefs: [] },
+			{ paths: ['about'], stylesheetHrefs: [] },
+		];
+		const blockKeys = ['path:news', 'path:about'];
+
+		expect(reassignOrphanBlockKeys(pages, blockKeys)).toEqual(blockKeys);
+	});
+});

--- a/packages/@d-zero/page-cluster/src/reassign-orphan-block-keys.ts
+++ b/packages/@d-zero/page-cluster/src/reassign-orphan-block-keys.ts
@@ -1,0 +1,176 @@
+import type { PageBlockingSignals } from './resolve-blocking-group-keys.js';
+
+import { derivePathGroupKey } from './derive-path-group-key.js';
+
+/**
+ * Prefix distinguishing a reassigned key from the `css:`/`path:` keys
+ * {@link ./resolve-blocking-group-keys.js | resolveBlockingGroupKeys} itself
+ * produces, so the two families can never collide.
+ */
+const REASSIGNED_KEY_PREFIX = 'orphan-merge:';
+
+/**
+ * Reads `values[index]`, throwing instead of returning `undefined`. Every
+ * call site here indexes `pages`/`pathKeys`/`blockKeys` with a position
+ * derived from one of those same arrays' own `.entries()` or `.map()`, so the
+ * thrown branch is unreachable in practice; it exists to satisfy
+ * `noUncheckedIndexedAccess` without a non-null assertion (same rationale as
+ * `requireIndex` in `resolve-page-cluster-keys.ts` and
+ * `resolve-structural-cluster-keys.ts`, each kept as an independent copy for
+ * the same reason those two are).
+ * @param values
+ * @param index
+ */
+function requireIndex<T>(values: ArrayLike<T>, index: number): T {
+	const value = values[index];
+	if (value === undefined) {
+		throw new Error('reassignOrphanBlockKeys: index out of bounds');
+	}
+	return value;
+}
+
+/**
+ * Rewrites the `path:`-fallback key of an "orphan" page — one with no
+ * stylesheet references recorded at all — to match a same-URL-section `css:`
+ * key, when one exists that is itself confined to that same section.
+ *
+ * {@link ./resolve-blocking-group-keys.js | resolveBlockingGroupKeys} commits
+ * every page to exactly one key: a page with zero stylesheet references can
+ * never produce a `css:` candidate, so it always falls back to `path:`, even
+ * when every other page of the same template loaded a distinctive stylesheet
+ * and landed on a shared `css:` key instead. That function's own JSDoc notes
+ * a literal OR-merge (letting a page carry both candidates) is deliberately
+ * deferred — but a literal OR-merge would not even apply here, since an
+ * orphan never had a `css:` candidate to OR with in the first place. This is
+ * a narrower, targeted fix for that specific gap, confirmed against a crawl
+ * (nitpicker) where a subset of same-template pages were missing stylesheet
+ * data entirely (a crawl-completeness gap, not a `resolveBlockingGroupKeys`
+ * logic error) and fragmented away from the rest of their template's `css:`
+ * block as a result.
+ *
+ * A `css:` block is only treated as a merge target when *every* one of its
+ * members shares the orphan's `derivePathGroupKey` value ("confined" to that
+ * section) — a `css:` block spanning multiple sections (e.g. a shared
+ * cross-department template) is left untouched, since there is no single
+ * section to merge it into. Non-orphan pages sharing the orphan's `path:` key
+ * (pages with a stylesheet set that was genuinely non-discriminative, not
+ * merely unrecorded) are deliberately left out of the rewritten key: complete-
+ * linkage clustering's min-linkage aggregation means a third point entering a
+ * comparison pool can change whether two *other* points end up merged (e.g.
+ * two pages at a pairwise similarity just above threshold can fail to merge
+ * once a third, more tightly-matching point joins the pool and "uses up" one
+ * of them first) — see this function's spec for a worked example. Folding in
+ * only the confirmed orphans, not the whole `path:` bucket, keeps this
+ * function from perturbing clustering decisions for pages it has no evidence
+ * about.
+ *
+ * Does not itself compare page content: it only decides which pages should
+ * be pooled together for {@link ./resolve-structural-cluster-keys.js |
+ * resolveStructuralClusterKeys} to adjudicate (via
+ * {@link ./resolve-page-cluster-keys.js | resolvePageClusterKeys}'s existing
+ * per-key grouping, unchanged) — an orphan folded into a `css:` block's pool
+ * still ends up in its own singleton cluster if its content doesn't actually
+ * match.
+ *
+ * A known, accepted trade-off: "confined" is checked against `pathKey` alone
+ * (the same coarse granularity `pathDepth` already gives `path:` keys), so
+ * multiple genuinely-different-template `css:` blocks that merely happen to
+ * share one broad URL section (e.g. everything under a large sub-site's
+ * top-level segment) get pooled into the *same* `resolveStructuralClusterKeys`
+ * call as each other, not just alongside the orphan that triggered the merge.
+ * Confirmed on real crawl data (8,936 pages): this correctly reunited an
+ * orphan with a 1,008-page same-template cluster it had been split from, and
+ * the corpus's cluster count improved net (1,984 → 1,972) — but as a side
+ * effect, 15 small clusters *unrelated* to any orphan (all inside one very
+ * large, already-confined `css:` block spanning a whole sub-site) came out
+ * differently than they would have without this option, because the extra
+ * pages pooled alongside them changed the NN-chain merge order (the same
+ * mechanism described above, just triggered by the pooling itself rather
+ * than by admitting a non-orphan page). A companion real-site run (302 pages)
+ * showed zero change. Narrowing "confined" to reduce this blast radius (e.g.
+ * preferring the `css:` block closest in size to the orphan count when
+ * several share a `pathKey`) is possible future work, not yet justified
+ * without more real-corpus evidence of it mattering in practice.
+ * @param pages
+ * @param blockKeys
+ * @param pathDepth
+ * @example
+ * ```ts
+ * const pages = [
+ * 	{ paths: ['news', '1'], stylesheetHrefs: ['https://example.com/a.css'] },
+ * 	{ paths: ['news', '2'], stylesheetHrefs: ['https://example.com/a.css'] },
+ * 	{ paths: ['news', '3'], stylesheetHrefs: [] }, // same template, but crawl missed its <link>
+ * 	{ paths: ['about'], stylesheetHrefs: ['https://example.com/b.css'] },
+ * ];
+ * const blockKeys = resolveBlockingGroupKeys(pages);
+ * // ['css:<hash of a.css>', 'css:<hash of a.css>', 'path:news', 'path:about']
+ * reassignOrphanBlockKeys(pages, blockKeys);
+ * // ['orphan-merge:news', 'orphan-merge:news', 'orphan-merge:news', 'path:about']
+ * ```
+ */
+export function reassignOrphanBlockKeys(
+	pages: readonly PageBlockingSignals[],
+	blockKeys: readonly string[],
+	pathDepth?: number,
+): string[] {
+	// Eagerly delegate pathDepth validation to derivePathGroupKey, instead of
+	// only discovering an invalid option once some page's data happens to
+	// reach that branch below — mirrors resolveBlockingGroupKeys's own eager
+	// `derivePathGroupKey([], pathDepth)` call, so this function fails fast
+	// on the same invalid input even when `pages` is empty.
+	derivePathGroupKey([], pathDepth);
+
+	const pathKeys = pages.map((page) => derivePathGroupKey(page.paths, pathDepth));
+	const isOrphan = (index: number): boolean =>
+		requireIndex(blockKeys, index).startsWith('path:') &&
+		requireIndex(pages, index).stylesheetHrefs.length === 0;
+
+	const cssMemberIndicesByKey = new Map<string, number[]>();
+	for (const [index, blockKey] of blockKeys.entries()) {
+		if (blockKey.startsWith('css:')) {
+			const indices = cssMemberIndicesByKey.get(blockKey);
+			if (indices) {
+				indices.push(index);
+			} else {
+				cssMemberIndicesByKey.set(blockKey, [index]);
+			}
+		}
+	}
+
+	// A css: block is a merge target for pathKey `p` only when every one of
+	// its members shares `p` — collected as a single confined pathKey per
+	// block (or left unset if the block spans more than one).
+	const confinedPathKeyByCssKey = new Map<string, string>();
+	for (const [cssKey, indices] of cssMemberIndicesByKey) {
+		const candidatePathKey = requireIndex(pathKeys, requireIndex(indices, 0));
+		if (indices.every((index) => requireIndex(pathKeys, index) === candidatePathKey)) {
+			confinedPathKeyByCssKey.set(cssKey, candidatePathKey);
+		}
+	}
+
+	const pathKeysWithConfinedCssBlock = new Set(confinedPathKeyByCssKey.values());
+
+	const orphanPathKeys = new Set<string>();
+	for (const index of blockKeys.keys()) {
+		const pathKey = requireIndex(pathKeys, index);
+		if (isOrphan(index) && pathKeysWithConfinedCssBlock.has(pathKey)) {
+			orphanPathKeys.add(pathKey);
+		}
+	}
+
+	if (orphanPathKeys.size === 0) {
+		return [...blockKeys];
+	}
+
+	return blockKeys.map((blockKey, index) => {
+		const pathKey = requireIndex(pathKeys, index);
+		if (!orphanPathKeys.has(pathKey)) {
+			return blockKey;
+		}
+
+		const isConfinedCssMember = confinedPathKeyByCssKey.get(blockKey) === pathKey;
+		return isOrphan(index) || isConfinedCssMember
+			? `${REASSIGNED_KEY_PREFIX}${pathKey}`
+			: blockKey;
+	});
+}

--- a/packages/@d-zero/page-cluster/src/remove-content-blocks.spec.ts
+++ b/packages/@d-zero/page-cluster/src/remove-content-blocks.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'vitest';
+
+import { removeContentBlocks } from './remove-content-blocks.js';
+
+describe('removeContentBlocks', () => {
+	test('matches the exact output documented in the JSDoc @example', () => {
+		// Kept in sync with removeContentBlocks's @example: if this ever fails,
+		// the JSDoc example is out of date and must be corrected alongside the
+		// implementation, not the other way around.
+		const result = removeContentBlocks(
+			'<body><main><div data-bgb="wysiwyg">free text</div><div data-bgb="image1">...</div></main></body>',
+			{ blockAttribute: 'data-bgb' },
+		);
+		expect(result).toStrictEqual({ remainderHtml: '<body><main></main></body>' });
+	});
+
+	test('a page with no matching blocks returns an unchanged remainderHtml', () => {
+		const html = '<body><main>only content</main></body>';
+		expect(removeContentBlocks(html, { blockAttribute: 'data-bgb' })).toStrictEqual({
+			remainderHtml: html,
+		});
+	});
+
+	test('multiple non-nested blocks are all removed', () => {
+		const html =
+			'<body><div data-bgb="a">A</div><p>kept</p><div data-bgb="b">B</div></body>';
+		const result = removeContentBlocks(html, { blockAttribute: 'data-bgb' });
+		expect(result.remainderHtml).toBe('<body><p>kept</p></body>');
+	});
+
+	test('a block nested inside another matching block is removed as a single merged span', () => {
+		const html =
+			'<body><div data-bgb="outer">O<div data-bgb="inner">I</div></div><p>kept</p></body>';
+		const result = removeContentBlocks(html, { blockAttribute: 'data-bgb' });
+		expect(result.remainderHtml).toBe('<body><p>kept</p></body>');
+	});
+
+	test('an element with the block attribute set to an empty string still matches (presence, not value, is what counts)', () => {
+		const html = '<body><div data-bgb="">B</div><p>kept</p></body>';
+		const result = removeContentBlocks(html, { blockAttribute: 'data-bgb' });
+		expect(result.remainderHtml).toBe('<body><p>kept</p></body>');
+	});
+
+	test('a different attribute value than blockAttribute is left untouched', () => {
+		const html = '<body><div data-other="x">X</div></body>';
+		expect(removeContentBlocks(html, { blockAttribute: 'data-bgb' })).toStrictEqual({
+			remainderHtml: html,
+		});
+	});
+
+	test('content outside <body> is left untouched even if it carries the block attribute', () => {
+		const html = '<html><head data-bgb="x">H</head><body><main>M</main></body></html>';
+		const result = removeContentBlocks(html, { blockAttribute: 'data-bgb' });
+		expect(result.remainderHtml).toBe(html);
+	});
+
+	test('a second top-level <body> (malformed markup) is ignored, same as extractLandmarks', () => {
+		const html =
+			'<body><main data-bgb="x">M</main></body><body><div data-bgb="y">Y</div></body>';
+		const result = removeContentBlocks(html, { blockAttribute: 'data-bgb' });
+		expect(result.remainderHtml).toBe(
+			'<body></body><body><div data-bgb="y">Y</div></body>',
+		);
+	});
+
+	test('a matching attribute inside an opaque tag (svg) is not searched', () => {
+		const html = '<body><svg><rect data-bgb="x"></rect></svg><p>kept</p></body>';
+		const result = removeContentBlocks(html, { blockAttribute: 'data-bgb' });
+		expect(result.remainderHtml).toBe(html);
+	});
+
+	test('an opaque tag (svg) that is itself the block root (carries the attribute directly) is removed', () => {
+		const html = '<body><svg data-bgb="chart">chart markup</svg><p>kept</p></body>';
+		const result = removeContentBlocks(html, { blockAttribute: 'data-bgb' });
+		expect(result.remainderHtml).toBe('<body><p>kept</p></body>');
+	});
+
+	test('<body> itself carrying the block attribute is not removed (unlike extractLandmarks, the whole page can never be "a content block")', () => {
+		const html = '<body data-bgb="page-type"><main>keep me</main></body>';
+		const result = removeContentBlocks(html, { blockAttribute: 'data-bgb' });
+		expect(result.remainderHtml).toBe(html);
+	});
+
+	test('an unclosed matching element is discarded rather than corrupting the remainder', () => {
+		// No closing </div> for the data-bgb element before <p> arrives —
+		// htmlparser2 force-closes it at a position that doesn't correspond to
+		// any real closing tag for it, so isGenuineClose rejects the candidate.
+		const html = '<body><div data-bgb="x">X<p>kept</p></body>';
+		const result = removeContentBlocks(html, { blockAttribute: 'data-bgb' });
+		expect(result.remainderHtml).toBe(html);
+	});
+});

--- a/packages/@d-zero/page-cluster/src/remove-content-blocks.ts
+++ b/packages/@d-zero/page-cluster/src/remove-content-blocks.ts
@@ -1,0 +1,200 @@
+import { Parser } from 'htmlparser2';
+
+import { excise } from './excise.js';
+import { isGenuineClose } from './is-genuine-close.js';
+import { isOpaqueTagName } from './opaque-tags.js';
+
+/**
+ * @see removeContentBlocks
+ */
+export type RemoveContentBlocksOptions = {
+	/**
+	 * The HTML attribute name that marks one instance of a freeform,
+	 * block-editor-authored content region (e.g. a WYSIWYG CMS's own
+	 * per-block marker attribute). No default: unlike
+	 * {@link ./extract-landmarks.js | extractLandmarks}'s tag names and ARIA
+	 * roles, there is no cross-site standard for this — every CMS/page
+	 * builder invents its own convention, so the caller must name theirs.
+	 */
+	blockAttribute: string;
+};
+
+/**
+ * Result of {@link ./remove-content-blocks.js | removeContentBlocks}.
+ */
+export type RemoveContentBlocksResult = {
+	remainderHtml: string;
+};
+
+type Frame = {
+	tagName: string;
+	hasBlockAttribute: boolean;
+	startOffset: number;
+};
+
+/**
+ * Removes every element in `html` carrying `options.blockAttribute`,
+ * including its full subtree, and returns what's left.
+ *
+ * Built for a specific real-crawl finding: two pages built from the same
+ * article template, but authored with a different mix of freeform CMS
+ * content blocks (e.g. one page uses a "wysiwyg" block then two "image"
+ * blocks, another uses a "title" block then one "image" block), tokenize to
+ * almost entirely disjoint leaf paths — each block's own internal markup
+ * differs, and that difference dominates the page's whole token set. This
+ * defeats {@link ./resolve-structural-cluster-keys.js |
+ * resolveStructuralClusterKeys}'s frequency-based chrome/content split
+ * (`deriveComparisonSets`), which only recognizes tokens common to *nearly
+ * every* page in a block as chrome; a block-editor region varies too much
+ * page-to-page to ever clear that bar, yet contributes no genuine
+ * template-identifying signal either. Confirmed on a real corpus (302
+ * pages): removing these regions before tokenizing cut structural-cluster
+ * count from 192 to 32 (with {@link ./extract-landmarks.js | extractLandmarks}
+ * and blocking-key fixes already applied) — the single largest lever found
+ * for that corpus.
+ *
+ * Unlike `extractLandmarks`, every matching element is removed (there is no
+ * "one instance per type" — a page can have any number of content blocks),
+ * and matching is by a single caller-supplied attribute rather than a fixed
+ * tag/role vocabulary — see `RemoveContentBlocksOptions.blockAttribute`'s
+ * JSDoc for why. `remainderHtml` drops each matched region's markup
+ * entirely (no placeholder), for the same reason `extractLandmarks` does:
+ * a placeholder string would itself become a token once tokenized.
+ *
+ * Only the first `<body>` is in scope and opaque tags
+ * (`script`/`style`/`svg`/`noscript`) are not searched inside, matching
+ * `extractLandmarks`'s and `tokenize()`'s own contracts. A candidate whose
+ * closing tag can't be confirmed as genuine (see `isGenuineClose`) is
+ * discarded rather than trusted, for the same safety reason `extractLandmarks`
+ * discards one.
+ * @param html
+ * @param options
+ * @example
+ * ```ts
+ * removeContentBlocks(
+ * 	'<body><main><div data-bgb="wysiwyg">free text</div><div data-bgb="image1">...</div></main></body>',
+ * 	{ blockAttribute: 'data-bgb' },
+ * );
+ * // { remainderHtml: '<body><main></main></body>' }
+ * ```
+ */
+export function removeContentBlocks(
+	html: string,
+	options: RemoveContentBlocksOptions,
+): RemoveContentBlocksResult {
+	const { blockAttribute } = options;
+	const stack: Frame[] = [];
+	const spans: { start: number; end: number }[] = [];
+	// Same rationale and shape as extractLandmarks's own `opaque` tracking:
+	// a different opaque tag opening/closing while already inside one must
+	// not perturb this counter. Also tracks whether the opaque tag itself
+	// (its own attributes, not any descendant's) carries `blockAttribute` —
+	// an opaque tag can be a content block's own root (e.g. an inline `<svg>`
+	// chart authored as one block), and diving into its children to look for
+	// the attribute would be pointless (they're never searched for landmarks
+	// or blocks either) but the opaque root itself must still be checked.
+	let opaque: {
+		tagName: string;
+		depth: number;
+		matched: boolean;
+		startOffset: number;
+	} | null = null;
+	let bodyDone = false;
+	let ignoredBodyOpens = 0;
+
+	const parser = new Parser(
+		{
+			onopentag(name, attribs) {
+				if (opaque) {
+					if (name === opaque.tagName) {
+						opaque.depth++;
+					}
+					return;
+				}
+
+				if (stack.length === 0) {
+					if (name === 'body' && !bodyDone) {
+						// The whole page can never itself be "a content block" —
+						// unlike extractLandmarks's ARIA-role matching (a
+						// standardized vocabulary under which `<body role="banner">`
+						// is a legitimate whole-page landmark), `blockAttribute` is
+						// an arbitrary caller-chosen name that could collide with an
+						// unrelated attribute a CMS/theme happens to stamp onto
+						// `<body>` (a page-type marker, a `body_class()`-style hook).
+						// Treating that as a match would silently empty the page's
+						// entire remainderHtml.
+						stack.push({
+							tagName: name,
+							hasBlockAttribute: false,
+							startOffset: parser.startIndex,
+						});
+					}
+					// Ignore everything else outside <body>, same as
+					// extractLandmarks/run-tokenizer.ts.
+					return;
+				}
+
+				if (name === 'body') {
+					ignoredBodyOpens++;
+					return;
+				}
+
+				if (isOpaqueTagName(name)) {
+					opaque = {
+						tagName: name,
+						depth: 1,
+						matched: attribs[blockAttribute] !== undefined,
+						startOffset: parser.startIndex,
+					};
+					return;
+				}
+
+				stack.push({
+					tagName: name,
+					hasBlockAttribute: attribs[blockAttribute] !== undefined,
+					startOffset: parser.startIndex,
+				});
+			},
+			onclosetag(name) {
+				if (opaque) {
+					if (name === opaque.tagName) {
+						opaque.depth--;
+						if (opaque.depth === 0) {
+							const endOffset = parser.endIndex + 1;
+							if (opaque.matched && isGenuineClose(html, endOffset, opaque.tagName)) {
+								spans.push({ start: opaque.startOffset, end: endOffset });
+							}
+							opaque = null;
+						}
+					}
+					return;
+				}
+
+				if (name === 'body' && ignoredBodyOpens > 0) {
+					ignoredBodyOpens--;
+					return;
+				}
+
+				if (stack.length === 0) {
+					return;
+				}
+
+				const frame = stack.pop();
+				if (!frame) {
+					return;
+				}
+				const endOffset = parser.endIndex + 1;
+				if (frame.hasBlockAttribute && isGenuineClose(html, endOffset, frame.tagName)) {
+					spans.push({ start: frame.startOffset, end: endOffset });
+				}
+				if (stack.length === 0) {
+					bodyDone = true;
+				}
+			},
+		},
+		{ decodeEntities: false },
+	);
+	parser.end(html);
+
+	return { remainderHtml: excise(html, spans) };
+}

--- a/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys.spec.ts
+++ b/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys.spec.ts
@@ -265,4 +265,104 @@ describe('resolvePageClusterKeys', () => {
 
 		expect(result[2]).not.toBe(result[0]);
 	});
+
+	test('contentBlockAttribute removes freeform content-block markup before comparison, letting pages with a different mix of blocks still match', () => {
+		const pageA = {
+			paths: ['dept-a', '1'],
+			stylesheetHrefs: [],
+			html: '<body><article class="detail"><div data-block="title"><h2 class="t">Title</h2></div><div data-block="image"><img class="i" src="x"></div></article></body>',
+		};
+		const pageB = {
+			paths: ['dept-a', '2'],
+			stylesheetHrefs: [],
+			html: '<body><article class="detail"><div data-block="quote"><blockquote class="q">Q</blockquote></div></article></body>',
+		};
+
+		const withoutRemoval = resolvePageClusterKeys([pageA, pageB]);
+		expect(withoutRemoval[0]).not.toBe(withoutRemoval[1]);
+
+		const withRemoval = resolvePageClusterKeys([pageA, pageB], {
+			contentBlockAttribute: 'data-block',
+		});
+		expect(withRemoval[0]).toBe(withRemoval[1]);
+	});
+
+	test('omitting contentBlockAttribute (the default) skips content-block removal entirely', () => {
+		const pageA = {
+			paths: ['dept-a', '1'],
+			stylesheetHrefs: [],
+			html: '<body><article class="detail"><div data-block="title"><h2 class="t">Title</h2></div></article></body>',
+		};
+		const pageB = {
+			paths: ['dept-a', '2'],
+			stylesheetHrefs: [],
+			html: '<body><article class="detail"><div data-block="quote"><blockquote class="q">Q</blockquote></div></article></body>',
+		};
+
+		const result = resolvePageClusterKeys([pageA, pageB]);
+
+		expect(result[0]).not.toBe(result[1]);
+	});
+
+	test("a page whose only stylesheet was third-party becomes an orphan via restrictStylesheetsToFirstParty and is then reassigned by reassignOrphans into its section's css: block", () => {
+		const html = '<body><header>H</header><main><div class="card">C</div></main></body>';
+		const pages = [
+			{ paths: ['news', '1'], stylesheetHrefs: ['https://example.com/a.css'], html },
+			{ paths: ['news', '2'], stylesheetHrefs: ['https://example.com/a.css'], html },
+			{
+				paths: ['news', '3'],
+				stylesheetHrefs: ['https://fonts.googleapis.com/css?family=x'],
+				html,
+			},
+			{ paths: ['other'], stylesheetHrefs: ['https://example.com/b.css'], html },
+		];
+
+		const result = resolvePageClusterKeys(pages);
+
+		expect(result[2]).toBe(result[0]);
+	});
+
+	test('restrictStylesheetsToFirstParty (default true) prevents an incidental third-party stylesheet reference from splitting an otherwise-matching page into its own block', () => {
+		const html = '<body><header>H</header><main><div class="card">C</div></main></body>';
+		const pages = [
+			{ paths: ['news', '1'], stylesheetHrefs: ['https://example.com/a.css'], html },
+			{ paths: ['news', '2'], stylesheetHrefs: ['https://example.com/a.css'], html },
+			{
+				paths: ['news', '3'],
+				stylesheetHrefs: [
+					'https://example.com/a.css',
+					'https://fonts.googleapis.com/css?family=x',
+				],
+				html,
+			},
+			{ paths: ['other'], stylesheetHrefs: ['https://example.com/b.css'], html },
+		];
+
+		const result = resolvePageClusterKeys(pages);
+
+		expect(result[2]).toBe(result[0]);
+	});
+
+	test('restrictStylesheetsToFirstParty: false blocks on every stylesheet href unfiltered, letting the third-party reference split the page away', () => {
+		const html = '<body><header>H</header><main><div class="card">C</div></main></body>';
+		const pages = [
+			{ paths: ['news', '1'], stylesheetHrefs: ['https://example.com/a.css'], html },
+			{ paths: ['news', '2'], stylesheetHrefs: ['https://example.com/a.css'], html },
+			{
+				paths: ['news', '3'],
+				stylesheetHrefs: [
+					'https://example.com/a.css',
+					'https://fonts.googleapis.com/css?family=x',
+				],
+				html,
+			},
+			{ paths: ['other'], stylesheetHrefs: ['https://example.com/b.css'], html },
+		];
+
+		const result = resolvePageClusterKeys(pages, {
+			restrictStylesheetsToFirstParty: false,
+		});
+
+		expect(result[2]).not.toBe(result[0]);
+	});
 });

--- a/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys.spec.ts
+++ b/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys.spec.ts
@@ -237,4 +237,32 @@ describe('resolvePageClusterKeys', () => {
 		const b = result.at(-1);
 		expect(a).not.toBe(b);
 	});
+
+	test('reassignOrphans (default true) lets a page with no recorded stylesheets rejoin a same-section css: block', () => {
+		const html = '<body><header>H</header><main><div class="card">C</div></main></body>';
+		const pages = [
+			{ paths: ['news', '1'], stylesheetHrefs: ['https://example.com/a.css'], html },
+			{ paths: ['news', '2'], stylesheetHrefs: ['https://example.com/a.css'], html },
+			{ paths: ['news', '3'], stylesheetHrefs: [], html },
+			{ paths: ['other'], stylesheetHrefs: ['https://example.com/b.css'], html },
+		];
+
+		const result = resolvePageClusterKeys(pages);
+
+		expect(result[2]).toBe(result[0]);
+	});
+
+	test('reassignOrphans: false falls back to the raw resolveBlockingGroupKeys output, leaving the orphan on its own path: block', () => {
+		const html = '<body><header>H</header><main><div class="card">C</div></main></body>';
+		const pages = [
+			{ paths: ['news', '1'], stylesheetHrefs: ['https://example.com/a.css'], html },
+			{ paths: ['news', '2'], stylesheetHrefs: ['https://example.com/a.css'], html },
+			{ paths: ['news', '3'], stylesheetHrefs: [], html },
+			{ paths: ['other'], stylesheetHrefs: ['https://example.com/b.css'], html },
+		];
+
+		const result = resolvePageClusterKeys(pages, { reassignOrphans: false });
+
+		expect(result[2]).not.toBe(result[0]);
+	});
 });

--- a/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys.spec.ts
+++ b/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys.spec.ts
@@ -391,4 +391,51 @@ describe('resolvePageClusterKeys', () => {
 
 		expect(new Set(withoutCap).size).toBeGreaterThan(1);
 	});
+
+	test("autoCapMainDepth detects each block's own knee separately, so a small block is not left under-capped by a larger, differently-shaped block", () => {
+		// Block "dept-a" (40 pages, dominates a corpus-wide sweep): identical
+		// up to depth 3, page-unique content at depth 4 -> its own knee is 3.
+		const deptA = Array.from({ length: 40 }, (_, i) => ({
+			paths: ['dept-a', `${i}`],
+			stylesheetHrefs: [],
+			html: `<body><main><section><article><div><span class="unique-a-${i}">c</span></div></article></section></main></body>`,
+		}));
+		// Block "dept-b" (6 pages): identical up to depth 1, page-unique
+		// content at depth 2 -> its own knee is 1, much shallower than
+		// dept-a's. A single depth derived once across the whole corpus (the
+		// pre-per-block design) would be dominated by dept-a's larger,
+		// deeper-diverging shape and cap dept-b too deep, letting dept-b's
+		// own noise (which starts right at depth 2) leak straight through
+		// uncapped.
+		const deptB = Array.from({ length: 6 }, (_, i) => ({
+			paths: ['dept-b', `${i}`],
+			stylesheetHrefs: [],
+			html: `<body><main><article><span class="unique-b-${i}">c</span></article></main></body>`,
+		}));
+
+		const keys = resolvePageClusterKeys([...deptA, ...deptB], { autoCapMainDepth: true });
+		const deptAKeys = keys.slice(0, deptA.length);
+		const deptBKeys = keys.slice(deptA.length);
+
+		expect(new Set(deptAKeys).size).toBe(1);
+		expect(new Set(deptBKeys).size).toBe(1);
+	});
+
+	test('autoCapMainDepth validates its own options eagerly, even for an empty page list with no blocks to run the per-block sweep on', () => {
+		expect(() =>
+			resolvePageClusterKeys([], { autoCapMainDepth: true, candidateDepths: [3, 1] }),
+		).toThrow(RangeError);
+	});
+
+	test('autoCapMainDepth skips the knee-detection sweep for a singleton block, but still returns that page as its own cluster', () => {
+		const pages = [
+			{
+				paths: ['solo'],
+				stylesheetHrefs: [],
+				html: '<body><main><div>only page</div></main></body>',
+			},
+		];
+
+		expect(resolvePageClusterKeys(pages, { autoCapMainDepth: true })).toHaveLength(1);
+	});
 });

--- a/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys.spec.ts
+++ b/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys.spec.ts
@@ -365,4 +365,30 @@ describe('resolvePageClusterKeys', () => {
 
 		expect(result[2]).not.toBe(result[0]);
 	});
+
+	test('autoCapMainDepth: true merges pages whose only difference is content nested deep inside <main>, requiring no site-specific configuration', () => {
+		// Identical structure up to depth 3 inside <main>; a page-unique class
+		// at depth 4 fragments every page apart unless that depth is capped.
+		const pages = Array.from({ length: 20 }, (_, i) => ({
+			paths: ['dept-a', `${i}`],
+			stylesheetHrefs: [],
+			html: `<body><main><section><article><div><span class="unique-${i}">content</span></div></article></section></main></body>`,
+		}));
+
+		const withCap = resolvePageClusterKeys(pages, { autoCapMainDepth: true });
+
+		expect(new Set(withCap).size).toBe(1);
+	});
+
+	test('autoCapMainDepth (default false) leaves deep <main> content untouched, so the same pages stay fragmented', () => {
+		const pages = Array.from({ length: 20 }, (_, i) => ({
+			paths: ['dept-a', `${i}`],
+			stylesheetHrefs: [],
+			html: `<body><main><section><article><div><span class="unique-${i}">content</span></div></article></section></main></body>`,
+		}));
+
+		const withoutCap = resolvePageClusterKeys(pages);
+
+		expect(new Set(withoutCap).size).toBeGreaterThan(1);
+	});
 });

--- a/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys.ts
+++ b/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys.ts
@@ -2,6 +2,8 @@ import type { ResolveBlockingGroupKeysOptions } from './resolve-blocking-group-k
 import type { ResolveStructuralClusterKeysOptions } from './resolve-structural-cluster-keys.js';
 import type { TokenizeOptions } from './types.js';
 
+import { capContentDepth } from './cap-content-depth.js';
+import { detectContentDepthCap } from './detect-content-depth-cap.js';
 import { extractLandmarks } from './extract-landmarks.js';
 import { filterFirstPartyStylesheetHrefs } from './filter-first-party-stylesheet-hrefs.js';
 import { reassignOrphanBlockKeys } from './reassign-orphan-block-keys.js';
@@ -118,6 +120,40 @@ export type ResolvePageClusterKeysOptions = TokenizeOptions &
 		 * `resolveBlockingGroupKeys` already places on its own input.
 		 */
 		restrictStylesheetsToFirstParty?: boolean;
+		/**
+		 * Apply {@link ./detect-content-depth-cap.js | detectContentDepthCap}
+		 * once across all of `pages` (after `excludeLandmarks`/
+		 * `contentBlockAttribute`, before tokenizing) to find how many levels
+		 * of nesting inside `<main>`/`role="main"` to keep, then
+		 * {@link ./cap-content-depth.js | capContentDepth} each page at that
+		 * depth — a `contentBlockAttribute`-style fix for freeform-content
+		 * noise that needs no site-specific attribute name, since `<main>` is
+		 * an HTML5/ARIA standard. Defaults to `false`: unlike
+		 * `contentBlockAttribute` (which does nothing unless a matching
+		 * attribute is actually present), this discards real content whenever
+		 * a page has a `<main>`/`role="main"` at all, so it's opt-in until
+		 * validated on more than the two real corpora checked so far.
+		 *
+		 * Composes with `contentBlockAttribute` rather than replacing it: both
+		 * can be set at once — `removeContentBlocks` runs first, then
+		 * `capContentDepth` on what's left — for a site whose CMS marks *some*
+		 * blocks with a known attribute but still has other, unmarked
+		 * freeform depth the attribute alone doesn't catch.
+		 *
+		 * Confirmed on real crawl data this can outperform
+		 * `contentBlockAttribute` on its own, not just stand in for it when the
+		 * attribute is unknown: on a 302-page corpus, `autoCapMainDepth` alone
+		 * produced 20 final clusters versus 27 for
+		 * `contentBlockAttribute: 'data-bgb'` together with
+		 * `restrictStylesheetsToFirstParty` — the site's known CMS attribute
+		 * doesn't mark every source of freeform depth, but the `<main>`
+		 * boundary catches all of it uniformly. On a real 8,936-page whole-site
+		 * corpus, it cut final cluster count from 1,972 to 283, at a real cost
+		 * of ~5m50s versus ~16s without it (see
+		 * `detectContentDepthCap`'s JSDoc for why: it reruns structural
+		 * clustering once per candidate depth to find the cap).
+		 */
+		autoCapMainDepth?: boolean;
 	};
 
 /**
@@ -179,16 +215,28 @@ export function resolvePageClusterKeys(
 ): string[] {
 	const excludeLandmarks = options?.excludeLandmarks ?? true;
 	const contentBlockAttribute = options?.contentBlockAttribute;
-	const contentTokenSets = pages.map((page) => {
+	const preparedHtml = pages.map((page) => {
 		const landmarksExcised = excludeLandmarks
 			? extractLandmarks(page.html).remainderHtml
 			: page.html;
-		const html =
-			contentBlockAttribute === undefined
-				? landmarksExcised
-				: removeContentBlocks(landmarksExcised, { blockAttribute: contentBlockAttribute })
+		return contentBlockAttribute === undefined
+			? landmarksExcised
+			: removeContentBlocks(landmarksExcised, { blockAttribute: contentBlockAttribute })
+					.remainderHtml;
+	});
+
+	const autoCapMainDepth = options?.autoCapMainDepth ?? false;
+	const maxMainDepth = autoCapMainDepth
+		? detectContentDepthCap(preparedHtml, options)
+		: undefined;
+
+	const contentTokenSets = preparedHtml.map((html) => {
+		const capped =
+			maxMainDepth === undefined
+				? html
+				: capContentDepth(html, { landmark: 'main', maxDepth: maxMainDepth })
 						.remainderHtml;
-		return new Set(tokenize(html, options).tokens);
+		return new Set(tokenize(capped, options).tokens);
 	});
 
 	const restrictStylesheetsToFirstParty =

--- a/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys.ts
+++ b/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys.ts
@@ -3,6 +3,7 @@ import type { ResolveStructuralClusterKeysOptions } from './resolve-structural-c
 import type { TokenizeOptions } from './types.js';
 
 import { extractLandmarks } from './extract-landmarks.js';
+import { reassignOrphanBlockKeys } from './reassign-orphan-block-keys.js';
 import { resolveBlockingGroupKeys } from './resolve-blocking-group-keys.js';
 import { resolveStructuralClusterKeys } from './resolve-structural-cluster-keys.js';
 import { tokenize } from './tokenize.js';
@@ -70,6 +71,22 @@ export type ResolvePageClusterKeysOptions = TokenizeOptions &
 		 * the extra `extractLandmarks` pass adds.
 		 */
 		excludeLandmarks?: boolean;
+		/**
+		 * Apply {@link ./reassign-orphan-block-keys.js | reassignOrphanBlockKeys}
+		 * to the blocking keys before clustering, so a page with no recorded
+		 * stylesheets ("orphan" — often a crawl-completeness gap, not evidence
+		 * the page is actually template-less) can rejoin a same-URL-section
+		 * `css:` block instead of being stranded on its weaker `path:` fallback.
+		 * Defaults to `true`. Set to `false` to fall back to the raw
+		 * {@link ./resolve-blocking-group-keys.js | resolveBlockingGroupKeys}
+		 * output — kept available both because this is not yet broadly-
+		 * validated beyond the two real crawls checked so far, and because it
+		 * has a known trade-off documented on
+		 * {@link ./reassign-orphan-block-keys.js | reassignOrphanBlockKeys}
+		 * itself: pooling pages for comparison can change unrelated pages'
+		 * cluster outcomes too, not just the orphan's.
+		 */
+		reassignOrphans?: boolean;
 	};
 
 /**
@@ -99,6 +116,12 @@ export type ResolvePageClusterKeysOptions = TokenizeOptions &
  * were excluded, and re-merged correctly at `similarityThreshold: 0.6` — re-
  * tune per site after switching this on, the same as `similarityThreshold`
  * itself already needs.
+ *
+ * `reassignOrphans` only ever pools a `path:`-fallback orphan alongside a
+ * same-section `css:` block for `resolveStructuralClusterKeys` to compare —
+ * it never forces a merge itself. An orphan that turns out not to match
+ * anything in that pool (confirmed on real crawl data) correctly surfaces as
+ * its own singleton, the same as it would have without this option.
  * @param pages
  * @param options
  * @example
@@ -121,7 +144,11 @@ export function resolvePageClusterKeys(
 		return new Set(tokenize(html, options).tokens);
 	});
 
-	const blockKeys = resolveBlockingGroupKeys(pages, options);
+	const reassignOrphans = options?.reassignOrphans ?? true;
+	const rawBlockKeys = resolveBlockingGroupKeys(pages, options);
+	const blockKeys = reassignOrphans
+		? reassignOrphanBlockKeys(pages, rawBlockKeys, options?.pathDepth)
+		: rawBlockKeys;
 
 	const indicesByBlockKey = new Map<string, number[]>();
 	for (const [index, blockKey] of blockKeys.entries()) {

--- a/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys.ts
+++ b/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys.ts
@@ -3,7 +3,9 @@ import type { ResolveStructuralClusterKeysOptions } from './resolve-structural-c
 import type { TokenizeOptions } from './types.js';
 
 import { extractLandmarks } from './extract-landmarks.js';
+import { filterFirstPartyStylesheetHrefs } from './filter-first-party-stylesheet-hrefs.js';
 import { reassignOrphanBlockKeys } from './reassign-orphan-block-keys.js';
+import { removeContentBlocks } from './remove-content-blocks.js';
 import { resolveBlockingGroupKeys } from './resolve-blocking-group-keys.js';
 import { resolveStructuralClusterKeys } from './resolve-structural-cluster-keys.js';
 import { tokenize } from './tokenize.js';
@@ -87,6 +89,35 @@ export type ResolvePageClusterKeysOptions = TokenizeOptions &
 		 * cluster outcomes too, not just the orphan's.
 		 */
 		reassignOrphans?: boolean;
+		/**
+		 * Apply {@link ./remove-content-blocks.js | removeContentBlocks} to each
+		 * page's landmark-excised remainder before tokenizing, so a freeform
+		 * block-editor content area's page-to-page variation (which specific
+		 * mix of blocks an author used) never reaches the structural-similarity
+		 * comparison. No default — unlike `excludeLandmarks`/`reassignOrphans`,
+		 * this needs the caller's own block-editor attribute name (see
+		 * `removeContentBlocks`'s `blockAttribute` option), which this package
+		 * cannot guess. Omit to skip this step entirely.
+		 */
+		contentBlockAttribute?: string;
+		/**
+		 * Apply {@link ./filter-first-party-stylesheet-hrefs.js |
+		 * filterFirstPartyStylesheetHrefs} to `pages` before computing blocking
+		 * keys, so a page's incidental third-party embeds (e.g. a video
+		 * player's own stylesheet, extra web-font requests pulled in by a
+		 * widget) never get mistaken for a template-identifying signal by
+		 * {@link ./resolve-blocking-group-keys.js | resolveBlockingGroupKeys}.
+		 * Defaults to `true`. Set to `false` to block on every page's full,
+		 * unfiltered `stylesheetHrefs` — kept available for the same reason
+		 * `excludeLandmarks`'s escape hatch is: a real but not yet broadly-
+		 * validated behavioral change (confirmed so far on one real crawl).
+		 *
+		 * Inherits `filterFirstPartyStylesheetHrefs`'s "roughly homogeneous
+		 * batch" precondition (see that function's own JSDoc): `pages` should
+		 * be one site or one section, the same expectation
+		 * `resolveBlockingGroupKeys` already places on its own input.
+		 */
+		restrictStylesheetsToFirstParty?: boolean;
 	};
 
 /**
@@ -122,6 +153,14 @@ export type ResolvePageClusterKeysOptions = TokenizeOptions &
  * it never forces a merge itself. An orphan that turns out not to match
  * anything in that pool (confirmed on real crawl data) correctly surfaces as
  * its own singleton, the same as it would have without this option.
+ *
+ * `restrictStylesheetsToFirstParty` runs before `reassignOrphans`: a page
+ * whose only stylesheet reference was third-party becomes an orphan (no
+ * first-party stylesheet left) *because of* the filtering, and is then
+ * itself eligible for orphan reassignment — this is intentional, not an
+ * ordering accident, since the underlying reason both options exist is the
+ * same (a page's blocking key should reflect its template, not incidental
+ * third-party embeds or missing crawl data).
  * @param pages
  * @param options
  * @example
@@ -139,15 +178,29 @@ export function resolvePageClusterKeys(
 	options?: ResolvePageClusterKeysOptions,
 ): string[] {
 	const excludeLandmarks = options?.excludeLandmarks ?? true;
+	const contentBlockAttribute = options?.contentBlockAttribute;
 	const contentTokenSets = pages.map((page) => {
-		const html = excludeLandmarks ? extractLandmarks(page.html).remainderHtml : page.html;
+		const landmarksExcised = excludeLandmarks
+			? extractLandmarks(page.html).remainderHtml
+			: page.html;
+		const html =
+			contentBlockAttribute === undefined
+				? landmarksExcised
+				: removeContentBlocks(landmarksExcised, { blockAttribute: contentBlockAttribute })
+						.remainderHtml;
 		return new Set(tokenize(html, options).tokens);
 	});
 
+	const restrictStylesheetsToFirstParty =
+		options?.restrictStylesheetsToFirstParty ?? true;
+	const blockingPages = restrictStylesheetsToFirstParty
+		? filterFirstPartyStylesheetHrefs(pages)
+		: pages;
+
 	const reassignOrphans = options?.reassignOrphans ?? true;
-	const rawBlockKeys = resolveBlockingGroupKeys(pages, options);
+	const rawBlockKeys = resolveBlockingGroupKeys(blockingPages, options);
 	const blockKeys = reassignOrphans
-		? reassignOrphanBlockKeys(pages, rawBlockKeys, options?.pathDepth)
+		? reassignOrphanBlockKeys(blockingPages, rawBlockKeys, options?.pathDepth)
 		: rawBlockKeys;
 
 	const indicesByBlockKey = new Map<string, number[]>();

--- a/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys.ts
+++ b/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys.ts
@@ -3,7 +3,10 @@ import type { ResolveStructuralClusterKeysOptions } from './resolve-structural-c
 import type { TokenizeOptions } from './types.js';
 
 import { capContentDepth } from './cap-content-depth.js';
-import { detectContentDepthCap } from './detect-content-depth-cap.js';
+import {
+	detectContentDepthCap,
+	validateDetectContentDepthCapOptions,
+} from './detect-content-depth-cap.js';
 import { extractLandmarks } from './extract-landmarks.js';
 import { filterFirstPartyStylesheetHrefs } from './filter-first-party-stylesheet-hrefs.js';
 import { reassignOrphanBlockKeys } from './reassign-orphan-block-keys.js';
@@ -122,17 +125,46 @@ export type ResolvePageClusterKeysOptions = TokenizeOptions &
 		restrictStylesheetsToFirstParty?: boolean;
 		/**
 		 * Apply {@link ./detect-content-depth-cap.js | detectContentDepthCap}
-		 * once across all of `pages` (after `excludeLandmarks`/
-		 * `contentBlockAttribute`, before tokenizing) to find how many levels
-		 * of nesting inside `<main>`/`role="main"` to keep, then
-		 * {@link ./cap-content-depth.js | capContentDepth} each page at that
-		 * depth — a `contentBlockAttribute`-style fix for freeform-content
-		 * noise that needs no site-specific attribute name, since `<main>` is
-		 * an HTML5/ARIA standard. Defaults to `false`: unlike
-		 * `contentBlockAttribute` (which does nothing unless a matching
-		 * attribute is actually present), this discards real content whenever
-		 * a page has a `<main>`/`role="main"` at all, so it's opt-in until
-		 * validated on more than the two real corpora checked so far.
+		 * separately *within each block* (after `excludeLandmarks`/
+		 * `contentBlockAttribute`, after blocking, before that block's own
+		 * tokenizing) to find how many levels of nesting inside
+		 * `<main>`/`role="main"` to keep, then
+		 * {@link ./cap-content-depth.js | capContentDepth} each of that
+		 * block's pages at that depth — a `contentBlockAttribute`-style fix
+		 * for freeform-content noise that needs no site-specific attribute
+		 * name, since `<main>` is an HTML5/ARIA standard. Defaults to
+		 * `false`: unlike `contentBlockAttribute` (which does nothing unless
+		 * a matching attribute is actually present), this discards real
+		 * content whenever a page has a `<main>`/`role="main"` at all, so
+		 * it's opt-in until validated on more than the two real corpora
+		 * checked so far.
+		 *
+		 * Per-block rather than once across the whole corpus: different
+		 * blocks (different templates/sections) can have genuinely different
+		 * "skeleton depths." Confirmed on real crawl data: an 814-page block
+		 * whose own knee sits at depth 2 stayed at 189 clusters (barely moved
+		 * from 224 uncapped) when capped at depth 3 — the knee derived from
+		 * the *whole* 8,936-page corpus, dominated by two much larger blocks
+		 * whose own knee is 3. Re-deriving the knee for that block alone
+		 * brings it down to 46. A block too small for its knee-detection
+		 * sweep to find a reliable jump just falls through to
+		 * `detectContentDepthCap`'s own no-knee fallback (the largest
+		 * candidate depth, effectively "don't cap") — the same safe default
+		 * it already has for any input, now reached per-block instead of
+		 * corpus-wide. Skipped entirely (no cap) for a block of exactly 1
+		 * page — nothing to compare it against, so a knee sweep there could
+		 * only ever confirm what's already true.
+		 *
+		 * Trade-off of going per-block: a corpus-wide sweep's cluster-count
+		 * ratios are diluted by thousands of ordinary pages, so one
+		 * incidental outlier (e.g. a single page with an extra wrapper `div`
+		 * from a stray widget) barely moves them. A small block's sweep has
+		 * no such dilution — a similar outlier among only a handful of pages
+		 * can itself clear `minKneeRatio` and produce a too-shallow cap for
+		 * that block. Not yet observed on either real corpus checked so far
+		 * (both corpora's small blocks happened to be uniform enough that
+		 * this didn't come up), so no size-based guard is added speculatively;
+		 * revisit if real data surfaces it.
 		 *
 		 * Composes with `contentBlockAttribute` rather than replacing it: both
 		 * can be set at once — `removeContentBlocks` runs first, then
@@ -147,11 +179,9 @@ export type ResolvePageClusterKeysOptions = TokenizeOptions &
 		 * `contentBlockAttribute: 'data-bgb'` together with
 		 * `restrictStylesheetsToFirstParty` — the site's known CMS attribute
 		 * doesn't mark every source of freeform depth, but the `<main>`
-		 * boundary catches all of it uniformly. On a real 8,936-page whole-site
-		 * corpus, it cut final cluster count from 1,972 to 283, at a real cost
-		 * of ~5m50s versus ~16s without it (see
-		 * `detectContentDepthCap`'s JSDoc for why: it reruns structural
-		 * clustering once per candidate depth to find the cap).
+		 * boundary catches all of it uniformly. See `detectContentDepthCap`'s
+		 * JSDoc for the real cost/accuracy numbers this per-block sweep
+		 * measures on the same two corpora.
 		 */
 		autoCapMainDepth?: boolean;
 	};
@@ -225,20 +255,6 @@ export function resolvePageClusterKeys(
 					.remainderHtml;
 	});
 
-	const autoCapMainDepth = options?.autoCapMainDepth ?? false;
-	const maxMainDepth = autoCapMainDepth
-		? detectContentDepthCap(preparedHtml, options)
-		: undefined;
-
-	const contentTokenSets = preparedHtml.map((html) => {
-		const capped =
-			maxMainDepth === undefined
-				? html
-				: capContentDepth(html, { landmark: 'main', maxDepth: maxMainDepth })
-						.remainderHtml;
-		return new Set(tokenize(capped, options).tokens);
-	});
-
 	const restrictStylesheetsToFirstParty =
 		options?.restrictStylesheetsToFirstParty ?? true;
 	const blockingPages = restrictStylesheetsToFirstParty
@@ -261,9 +277,36 @@ export function resolvePageClusterKeys(
 		}
 	}
 
+	const autoCapMainDepth = options?.autoCapMainDepth ?? false;
+	if (autoCapMainDepth) {
+		// Validated here, eagerly, because it's otherwise only reached from
+		// inside the per-block loop below — which never runs at all for an
+		// empty `pages` (no blocks), silently skipping a bad option instead
+		// of failing fast the way a direct `detectContentDepthCap` call
+		// always does.
+		validateDetectContentDepthCapOptions(options);
+	}
+
 	const finalKeys: string[] = Array.from({ length: pages.length });
 	for (const [blockKey, indices] of indicesByBlockKey) {
-		const blockTokenSets = indices.map((index) => requireIndex(contentTokenSets, index));
+		const blockPreparedHtml = indices.map((index) => requireIndex(preparedHtml, index));
+		// A block of 1 can never produce more than one cluster regardless of
+		// how it's tokenized — nothing to compare it against — so detecting a
+		// knee and capping for it would only spend a full multi-depth sweep
+		// (see detectContentDepthCap's own cost notes) to arrive back at the
+		// same single-cluster result. Skipped rather than swept.
+		const maxMainDepth =
+			autoCapMainDepth && blockPreparedHtml.length > 1
+				? detectContentDepthCap(blockPreparedHtml, options)
+				: undefined;
+		const blockTokenSets = blockPreparedHtml.map((html) => {
+			const capped =
+				maxMainDepth === undefined
+					? html
+					: capContentDepth(html, { landmark: 'main', maxDepth: maxMainDepth })
+							.remainderHtml;
+			return new Set(tokenize(capped, options).tokens);
+		});
 		const localLabels = resolveStructuralClusterKeys(blockTokenSets, options);
 
 		for (const [position, index] of indices.entries()) {


### PR DESCRIPTION
## Summary
- Reassign orphan pages (no recorded stylesheets) to a same-URL-section `css:` block instead of leaving them on the weaker `path:` fallback (`reassignOrphanBlockKeys`, default on).
- Remove freeform CMS block-editor content and third-party stylesheet noise before structural comparison (`contentBlockAttribute`, opt-in; `restrictStylesheetsToFirstParty`, default on).
- Auto-detect a content-depth cap inside `<main>`/`role="main"` per block, as a zero-configuration alternative to `contentBlockAttribute` for sites without a known CMS block attribute (`autoCapMainDepth`, opt-in).
- Fix the depth-cap detection to run per-block rather than once globally, so a large block's shape no longer dictates the cap for every other block.

All four changes are validated against two real crawl corpora (302 and 8,936 pages), with before/after cluster-count numbers documented in each function's JSDoc. Real numbers on the 8,936-page corpus: final cluster count reduced from ~1,972 to 134 with `autoCapMainDepth` enabled, at a measured cost of ~119s vs ~18s without it.

## Test plan
- [x] `yarn lint`
- [x] `yarn build`
- [x] `yarn test` (1442 tests passing)
- [x] Validated against two real crawl corpora, including a targeted investigation of one remaining fragmentation case (documented as a known `similarityThreshold` tuning limitation, not a bug)
