### PR TITLE
feat(page-cluster): merge clusters sharing a rare landmark variant

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -16,6 +16,7 @@
 		"medoids",
 		"hrefs",
 		"Murtagh",
+		"unioned",
 
 		//
 		"gaxios",

--- a/packages/@d-zero/page-cluster/README.md
+++ b/packages/@d-zero/page-cluster/README.md
@@ -37,6 +37,8 @@ tokenize(html, {
 
 CMSのブロック属性名が分からない・サイトごとに違う場合は `autoCapMainDepth: true` を使う。`<main>`/`role="main"`という標準タグを起点に、構造クラスタ数が急増する直前の深さをブロックごとに実データから自動検出して打ち切るため、サイト固有の設定が一切不要（既定はfalse。実データ検証では`contentBlockAttribute`より良い結果になる場合もあった一方、計算コストが実測で数倍〜1桁台後半になる。倍率はコーパスのブロック構成に依存する）。詳細は `detectContentDepthCap()` のJSDocを参照。
 
+header/footer/nav/asideが一致するページ同士をさらに合流させたい場合は `mergeRareLandmarkClusters: true` を使う。ただし単純な一致判定は実データで過剰融合を招くことが分かっているため（header/footer/navは99%以上のページに存在し判別力を持たない）、コーパス全体で希少なランドマークバリアントが一致した場合に限り、より緩いコンテンツ類似度閾値（`landmarkGateSimilarityThreshold`）での合流を許可する（既定はfalse。実データでの検証は未実施で、合成フィクスチャでの単体・回帰テストのみ）。詳細・コスト特性は `mergeLandmarkAffinedClusters()` のJSDocを参照。
+
 ```ts
 import { resolvePageClusterKeys } from '@d-zero/page-cluster/resolve-page-cluster-keys';
 

--- a/packages/@d-zero/page-cluster/package.json
+++ b/packages/@d-zero/page-cluster/package.json
@@ -49,6 +49,10 @@
 			"import": "./dist/jaccard-similarity.js",
 			"types": "./dist/jaccard-similarity.d.ts"
 		},
+		"./merge-landmark-affined-clusters": {
+			"import": "./dist/merge-landmark-affined-clusters.js",
+			"types": "./dist/merge-landmark-affined-clusters.d.ts"
+		},
 		"./reassign-orphan-block-keys": {
 			"import": "./dist/reassign-orphan-block-keys.js",
 			"types": "./dist/reassign-orphan-block-keys.d.ts"

--- a/packages/@d-zero/page-cluster/src/merge-landmark-affined-clusters.spec.ts
+++ b/packages/@d-zero/page-cluster/src/merge-landmark-affined-clusters.spec.ts
@@ -1,0 +1,422 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+	mergeLandmarkAffinedClusters,
+	validateMergeLandmarkAffinedClustersOptions,
+} from './merge-landmark-affined-clusters.js';
+
+/**
+ * Builds a `<header>`/`<footer>`/`<nav>` fragment whose structural signature
+ * is driven entirely by `variant` (a distinct child element class), never by
+ * text — `tokenize()` discards visible text (see its own JSDoc), so two
+ * fragments distinguished only by text would tokenize identically and
+ * silently collapse into the same landmark variant. Same `variant` always
+ * produces the same signature; different `variant` values always produce
+ * different signatures.
+ * @param tag
+ * @param variant
+ */
+function landmark(tag: 'aside' | 'footer' | 'header' | 'nav', variant: string): string {
+	return `<${tag}><i class="variant-${variant}"></i></${tag}>`;
+}
+
+describe('mergeLandmarkAffinedClusters', () => {
+	test('an empty input returns an empty array', () => {
+		expect(mergeLandmarkAffinedClusters([], [], [])).toEqual([]);
+	});
+
+	test('matches the exact output documented in the JSDoc @example', () => {
+		// Kept in sync with mergeLandmarkAffinedClusters's @example: if this
+		// ever fails, the JSDoc example is out of date and must be corrected
+		// alongside the implementation, not the other way around.
+		const result = mergeLandmarkAffinedClusters(
+			['["css:a", "cluster:0"]', '["css:b", "cluster:0"]', 'path:other'],
+			[
+				{ header: '<header><i class="mark-a"></i></header>', remainderHtml: '' },
+				{ header: '<header><i class="mark-a"></i></header>', remainderHtml: '' },
+				{ header: '<header><b class="mark-b"></b></header>', remainderHtml: '' },
+			],
+			[new Set(['a', 'b']), new Set(['a', 'c']), new Set(['z'])],
+			{ landmarkRarityThreshold: 0.7, landmarkGateSimilarityThreshold: 0.3 },
+		);
+
+		expect(result[0]).toBe(result[1]);
+		expect(result[0]).toMatch(/^landmark-merge:/);
+		expect(result[2]).toBe('path:other');
+	});
+
+	test('a landmark shared by every page is never "rare", even at the most permissive threshold — regression test for the withdrawn prototype\'s over-merging failure', () => {
+		// The withdrawn earlier prototype of this mechanism merged clusters
+		// whenever landmarks matched, full stop — and on real crawl data,
+		// header/footer/nav matched on 99%+ of pages, so nearly every pair
+		// qualified. This pins that a landmark used by literally every
+		// compared page (ratio 1.0) can never be "rare" — the check is a
+		// strict `<`, so even the loosest legal threshold (1) rejects it.
+		const sharedHeader = { header: landmark('header', 'shared'), remainderHtml: '' };
+		const identicalContent = new Set(['a', 'b', 'c']);
+
+		const result = mergeLandmarkAffinedClusters(
+			['clusterA', 'clusterB'],
+			[sharedHeader, sharedHeader],
+			[identicalContent, identicalContent],
+			{ landmarkRarityThreshold: 1 },
+		);
+
+		expect(result).toEqual(['clusterA', 'clusterB']);
+	});
+
+	test('a rare, identical header lets two otherwise-distinct clusters merge once their content clears the looser gate threshold', () => {
+		// 41 pages: 2 share a header variant used by no one else (2/41 ≈
+		// 0.0488, under the default 0.05 rarity threshold); the other 39
+		// share one common, unrelated header (also exercises bucketing many
+		// structurally-identical landmark fragments into a single variant at
+		// once). The two rare-header pages' content is deliberately below
+		// the primary similarityThreshold (0.8) but above the default
+		// landmarkGateSimilarityThreshold (0.6): shared = 13 tokens, unique
+		// 4/3 tokens -> intersection 13, union 20, jaccard = 0.65.
+		const rareHeader = { header: landmark('header', 'rare'), remainderHtml: '' };
+		const commonHeader = { header: landmark('header', 'common'), remainderHtml: '' };
+		const shared = Array.from({ length: 13 }, (_, i) => `shared-${i}`);
+		const contentA = new Set([...shared, 'a1', 'a2', 'a3', 'a4']);
+		const contentB = new Set([...shared, 'b1', 'b2', 'b3']);
+		expect(
+			[...contentA].filter((token) => contentB.has(token)).length /
+				new Set([...contentA, ...contentB]).size,
+		).toBeCloseTo(0.65);
+
+		const clusterKeys = [
+			'clusterA',
+			'clusterB',
+			...Array.from({ length: 39 }, (_, i) => `filler-${i}`),
+		];
+		const landmarks = [
+			rareHeader,
+			rareHeader,
+			...Array.from({ length: 39 }, () => commonHeader),
+		];
+		const contentTokenSets = [
+			contentA,
+			contentB,
+			...Array.from({ length: 39 }, () => new Set(['z'])),
+		];
+
+		const result = mergeLandmarkAffinedClusters(clusterKeys, landmarks, contentTokenSets);
+
+		expect(result[0]).toBe(result[1]);
+		expect(result[0]).toMatch(/^landmark-merge:/);
+	});
+
+	test('two structurally similar (not byte-identical) headers are recognized as the same rare variant via fuzzy matching, not just exact-token-set deduplication', () => {
+		// 9 shared child elements + 1 differing one per page: jaccard = 9/11
+		// ≈ 0.818, above the default 0.8 similarityThreshold used for
+		// landmark-variant identity. These two headers are NOT byte-for-byte
+		// identical after tokenization, so exact-match bucketing alone would
+		// treat them as two separate, singleton-frequency variants with two
+		// different signature strings — which could never land in the same
+		// pageIndicesBySignature group, so no merge could ever happen
+		// regardless of how rare each individually is. A merge below can
+		// only happen if computeLandmarkStatus's fuzzy complete-linkage step
+		// actually unified them into one variant label first.
+		/**
+		 * Builds a header sharing 9 of its 10 children with any other call, differing only in `suffix`.
+		 * @param suffix
+		 */
+		function similarHeader(suffix: string) {
+			const shared = Array.from({ length: 9 }, (_, i) => `<i class="s-${i}"></i>`).join(
+				'',
+			);
+			return {
+				header: `<header>${shared}<i class="only-${suffix}"></i></header>`,
+				remainderHtml: '',
+			};
+		}
+		const commonHeader = { header: landmark('header', 'common'), remainderHtml: '' };
+		const pages = [
+			{
+				clusterKey: 'clusterA',
+				landmark: similarHeader('a'),
+				content: new Set(['shared-1', 'shared-2']),
+			},
+			{
+				clusterKey: 'clusterB',
+				landmark: similarHeader('b'),
+				content: new Set(['shared-1', 'shared-2', 'shared-3']),
+			},
+			...Array.from({ length: 18 }, (_, i) => ({
+				clusterKey: `filler-${i}`,
+				landmark: commonHeader,
+				content: new Set(['z']),
+			})),
+		];
+
+		const result = mergeLandmarkAffinedClusters(
+			pages.map((p) => p.clusterKey),
+			pages.map((p) => p.landmark),
+			pages.map((p) => p.content),
+			{ landmarkRarityThreshold: 0.15 },
+		);
+
+		expect(result[0]).toBe(result[1]);
+		expect(result[0]).toMatch(/^landmark-merge:/);
+	});
+
+	test('a page whose existing landmarks are a mix of rare and common contributes no evidence at all (the most conservative match rule)', () => {
+		// Header is rare (shared by exactly 2/10 pages, under the 0.25
+		// threshold used here) but footer is common to all 10 — the most
+		// conservative rule (every *existing* type must be rare) means the
+		// common footer disqualifies the page entirely, even though its
+		// header alone would have qualified.
+		const rareHeader = landmark('header', 'rare');
+		const commonFooter = landmark('footer', 'common');
+		const pages = Array.from({ length: 10 }, (_, i) => ({
+			clusterKey: i < 2 ? `cluster-${i}` : `filler-${i}`,
+			landmark: {
+				header: i < 2 ? rareHeader : landmark('header', `filler-${i}`),
+				footer: commonFooter,
+				remainderHtml: '',
+			},
+			content: new Set(['shared-a', 'shared-b', 'shared-c']),
+		}));
+
+		const result = mergeLandmarkAffinedClusters(
+			pages.map((p) => p.clusterKey),
+			pages.map((p) => p.landmark),
+			pages.map((p) => p.content),
+			{ landmarkRarityThreshold: 0.25 },
+		);
+
+		expect(result[0]).not.toBe(result[1]);
+	});
+
+	test('two pages sharing an identical rare header, but differing in whether a nav is present, do not merge', () => {
+		// Presence must match too, not just the variant: page 0 has a rare
+		// nav in addition to the rare header, page 1 has no nav at all — their
+		// signatures differ even though both share the exact same header.
+		const rareHeader = landmark('header', 'rare');
+		const rareNav = landmark('nav', 'rare');
+		const pages = Array.from({ length: 25 }, (_, i) => {
+			if (i === 0) {
+				return {
+					clusterKey: 'clusterA',
+					landmark: { header: rareHeader, nav: rareNav, remainderHtml: '' },
+				};
+			}
+			if (i === 1) {
+				return {
+					clusterKey: 'clusterB',
+					landmark: { header: rareHeader, remainderHtml: '' },
+				};
+			}
+			return {
+				clusterKey: `filler-${i}`,
+				landmark: { header: landmark('header', `filler-${i}`), remainderHtml: '' },
+			};
+		});
+
+		const result = mergeLandmarkAffinedClusters(
+			pages.map((p) => p.clusterKey),
+			pages.map((p) => p.landmark),
+			pages.map(() => new Set(['a', 'b', 'c'])),
+			{ landmarkRarityThreshold: 0.1 },
+		);
+
+		expect(result[0]).not.toBe(result[1]);
+	});
+
+	test('a page with no landmarks at all contributes no evidence and is never merged, even when its content is identical to another such page', () => {
+		const noLandmarks = { remainderHtml: '' };
+		const identicalContent = new Set(['x']);
+
+		const result = mergeLandmarkAffinedClusters(
+			['clusterA', 'clusterB'],
+			[noLandmarks, noLandmarks],
+			[identicalContent, identicalContent],
+		);
+
+		expect(result).toEqual(['clusterA', 'clusterB']);
+	});
+
+	test('the gated merge is complete-linkage, not single-linkage: a bridge cluster does not transitively merge two others that are dissimilar to each other', () => {
+		// Same similarity shape as resolve-structural-cluster-keys.spec.ts's
+		// own "refuses to chain A into C through a shared bridge B" test:
+		// sim(A,B) ≈ 0.667, sim(B,C) = 0.5, sim(A,C) = 0.25. All three share
+		// one rare header (3/10 = 0.3, rare at the 0.5 threshold used here);
+		// 7 filler pages share a different, common header (7/10 = 0.7, not
+		// rare at 0.5) so they contribute no competing evidence.
+		const rareHeader = { header: landmark('header', 'rare'), remainderHtml: '' };
+		const commonHeader = { header: landmark('header', 'common'), remainderHtml: '' };
+		const pages = [
+			{ clusterKey: 'clusterA', landmark: rareHeader, content: new Set(['a', 'b']) },
+			{ clusterKey: 'clusterB', landmark: rareHeader, content: new Set(['a', 'b', 'c']) },
+			{ clusterKey: 'clusterC', landmark: rareHeader, content: new Set(['a', 'c', 'd']) },
+			...Array.from({ length: 7 }, (_, i) => ({
+				clusterKey: `filler-${i}`,
+				landmark: commonHeader,
+				content: new Set(['z']),
+			})),
+		];
+
+		const result = mergeLandmarkAffinedClusters(
+			pages.map((p) => p.clusterKey),
+			pages.map((p) => p.landmark),
+			pages.map((p) => p.content),
+			{ landmarkRarityThreshold: 0.5, landmarkGateSimilarityThreshold: 0.5 },
+		);
+
+		expect(result[0]).toBe(result[1]);
+		expect(result[2]).not.toBe(result[0]);
+	});
+
+	test('a signature group whose pages already share one cluster key is left unchanged (no-op)', () => {
+		const rareHeader = { header: landmark('header', 'rare'), remainderHtml: '' };
+		const pages = [
+			{ clusterKey: 'sameCluster', landmark: rareHeader, content: new Set(['a']) },
+			{ clusterKey: 'sameCluster', landmark: rareHeader, content: new Set(['b']) },
+			...Array.from({ length: 18 }, (_, i) => ({
+				clusterKey: `filler-${i}`,
+				landmark: { header: landmark('header', `filler-${i}`), remainderHtml: '' },
+				content: new Set(['z']),
+			})),
+		];
+
+		const result = mergeLandmarkAffinedClusters(
+			pages.map((p) => p.clusterKey),
+			pages.map((p) => p.landmark),
+			pages.map((p) => p.content),
+			{ landmarkRarityThreshold: 0.15 },
+		);
+
+		expect(result[0]).toBe('sameCluster');
+		expect(result[1]).toBe('sameCluster');
+	});
+
+	test("a merge decision drawn from a small subset of two clusters' pages only re-keys those specific pages, not every page sharing the original cluster key (regression test for whole-cluster over-application of partial evidence)", () => {
+		// Only page 0 of clusterA and page 0 of clusterB carry the rare
+		// header and have content similar enough to clear the gate; the
+		// other 4 pages of each cluster have a common header and content
+		// disjoint from everything else. A correct implementation merges
+		// only the two evidence pages — not clusterA/clusterB's remaining 8
+		// pages, which never supplied any evidence at all.
+		const rareHeader = { header: landmark('header', 'rare'), remainderHtml: '' };
+		const otherHeader = { header: landmark('header', 'other'), remainderHtml: '' };
+
+		const clusterAPages = Array.from({ length: 5 }, (_, i) => ({
+			clusterKey: 'clusterA',
+			landmark: i === 0 ? rareHeader : otherHeader,
+			content: i === 0 ? new Set(['shared-1', 'shared-2']) : new Set([`a-only-${i}`]),
+		}));
+		const clusterBPages = Array.from({ length: 5 }, (_, i) => ({
+			clusterKey: 'clusterB',
+			landmark: i === 0 ? rareHeader : otherHeader,
+			content:
+				i === 0
+					? new Set(['shared-1', 'shared-2', 'shared-3'])
+					: new Set([`b-only-${i}`]),
+		}));
+		const fillers = Array.from({ length: 8 }, (_, i) => ({
+			clusterKey: `filler-${i}`,
+			landmark: otherHeader,
+			content: new Set([`filler-${i}`]),
+		}));
+		const pages = [...clusterAPages, ...clusterBPages, ...fillers];
+
+		const result = mergeLandmarkAffinedClusters(
+			pages.map((p) => p.clusterKey),
+			pages.map((p) => p.landmark),
+			pages.map((p) => p.content),
+			{ landmarkRarityThreshold: 0.15 },
+		);
+
+		expect(result[0]).toBe(result[5]);
+		expect(result[0]).toMatch(/^landmark-merge:/);
+		for (let i = 1; i < 5; i++) {
+			expect(result[i]).toBe('clusterA');
+		}
+		for (let i = 1; i < 5; i++) {
+			expect(result[5 + i]).toBe('clusterB');
+		}
+	});
+
+	test('validates its own options eagerly, even when called directly with non-empty input (not only reachable via a separate validate call)', () => {
+		expect(() =>
+			mergeLandmarkAffinedClusters(
+				['clusterA', 'clusterB'],
+				[{ remainderHtml: '' }, { remainderHtml: '' }],
+				[new Set(['a']), new Set(['a'])],
+				{ landmarkGateSimilarityThreshold: Number.NaN },
+			),
+		).toThrow(RangeError);
+	});
+
+	test('landmarkRarityThreshold controls the cutoff: a 6%-frequency variant is not rare at the default 5% but is at 10%', () => {
+		const rareHeader = { header: landmark('header', 'six-percent'), remainderHtml: '' };
+		const commonHeader = {
+			header: landmark('header', 'ninety-four-percent'),
+			remainderHtml: '',
+		};
+		const shared = Array.from({ length: 13 }, (_, i) => `shared-${i}`);
+		const contentA = new Set([...shared, 'a1', 'a2', 'a3', 'a4']);
+		const contentB = new Set([...shared, 'b1', 'b2', 'b3']);
+
+		const pages = [
+			{ clusterKey: 'clusterA', landmark: rareHeader, content: contentA },
+			{ clusterKey: 'clusterB', landmark: rareHeader, content: contentB },
+			...Array.from({ length: 4 }, (_, i) => ({
+				clusterKey: `rare-filler-${i}`,
+				landmark: rareHeader,
+				content: new Set(['z']),
+			})),
+			...Array.from({ length: 94 }, (_, i) => ({
+				clusterKey: `common-filler-${i}`,
+				landmark: commonHeader,
+				content: new Set(['z']),
+			})),
+		];
+		expect(pages).toHaveLength(100);
+
+		const atDefaultThreshold = mergeLandmarkAffinedClusters(
+			pages.map((p) => p.clusterKey),
+			pages.map((p) => p.landmark),
+			pages.map((p) => p.content),
+		);
+		expect(atDefaultThreshold[0]).not.toBe(atDefaultThreshold[1]);
+
+		const atLooserThreshold = mergeLandmarkAffinedClusters(
+			pages.map((p) => p.clusterKey),
+			pages.map((p) => p.landmark),
+			pages.map((p) => p.content),
+			{ landmarkRarityThreshold: 0.1 },
+		);
+		expect(atLooserThreshold[0]).toBe(atLooserThreshold[1]);
+	});
+});
+
+describe('validateMergeLandmarkAffinedClustersOptions', () => {
+	test('accepts no options at all (every default applies)', () => {
+		expect(() => validateMergeLandmarkAffinedClustersOptions()).not.toThrow();
+	});
+
+	test.each([
+		'similarityThreshold',
+		'landmarkRarityThreshold',
+		'landmarkGateSimilarityThreshold',
+	])('rejects %s outside [0, 1]', (field) => {
+		for (const value of [-0.1, 1.1, Number.NaN]) {
+			expect(() =>
+				validateMergeLandmarkAffinedClustersOptions({ [field]: value }),
+			).toThrow(RangeError);
+		}
+	});
+
+	test.each([
+		'similarityThreshold',
+		'landmarkRarityThreshold',
+		'landmarkGateSimilarityThreshold',
+	])('accepts %s at the boundary values 0 and 1', (field) => {
+		for (const value of [0, 1]) {
+			expect(() =>
+				validateMergeLandmarkAffinedClustersOptions({ [field]: value }),
+			).not.toThrow();
+		}
+	});
+});

--- a/packages/@d-zero/page-cluster/src/merge-landmark-affined-clusters.ts
+++ b/packages/@d-zero/page-cluster/src/merge-landmark-affined-clusters.ts
@@ -1,0 +1,700 @@
+import type { ExtractLandmarksResult, LandmarkType } from './extract-landmarks.js';
+import type { TokenizeOptions } from './types.js';
+
+import { jaccardSimilarity } from './jaccard-similarity.js';
+import { tokenize } from './tokenize.js';
+
+/**
+ * The four landmark types checked, in the fixed order every signature string
+ * built below iterates them in — order must be stable so two pages with the
+ * same set of matching-and-rare types always produce byte-identical
+ * signature strings.
+ */
+const LANDMARK_TYPES: readonly LandmarkType[] = ['header', 'footer', 'nav', 'aside'];
+
+const DEFAULT_SIMILARITY_THRESHOLD = 0.8;
+const DEFAULT_LANDMARK_RARITY_THRESHOLD = 0.05;
+const DEFAULT_LANDMARK_GATE_SIMILARITY_THRESHOLD = 0.6;
+
+/**
+ * Same technique and value as `BOUNDARY_EPSILON` in
+ * `resolve-structural-cluster-keys.ts` and `split-tokens-by-frequency.ts`,
+ * kept as an independent per-file copy by this package's convention (see
+ * `resolve-structural-cluster-keys.ts`'s own `BOUNDARY_EPSILON` JSDoc).
+ */
+const BOUNDARY_EPSILON = 1e-9;
+
+/**
+ * Prefix distinguishing a landmark-gated merge's key from every other key
+ * family this package produces (`css:`/`path:`/`orphan-merge:`/the
+ * `[blockKey, "cluster:N"]` JSON pairs `resolvePageClusterKeys` itself
+ * emits), so the families can never collide. Mirrors
+ * `reassign-orphan-block-keys.ts`'s `REASSIGNED_KEY_PREFIX`.
+ */
+const MERGED_KEY_PREFIX = 'landmark-merge:';
+
+/**
+ * @see mergeLandmarkAffinedClusters
+ */
+export type MergeLandmarkAffinedClustersOptions = TokenizeOptions & {
+	/**
+	 * Reused as the landmark-variant identity threshold inside
+	 * `computeLandmarkStatus`. Must be in `[0, 1]` (`RangeError` otherwise).
+	 * Defaults to `0.8`, matching `resolveStructuralClusterKeys`'s own
+	 * default — this file never calls that function, but the two thresholds
+	 * represent the same concept ("how much token overlap counts as the same
+	 * design").
+	 *
+	 * Deliberately not a separate, independent option: when
+	 * `resolvePageClusterKeys` forwards its caller's single `options` object
+	 * to both `resolveStructuralClusterKeys` (primary content clustering) and
+	 * this file (landmark-variant identity), the same `similarityThreshold`
+	 * value drives both, so loosening one to re-tune primary clustering (the
+	 * documented `excludeLandmarks`/`similarityThreshold` interaction on
+	 * `resolvePageClusterKeys`) also loosens landmark-variant matching. This
+	 * mirrors `resolve-landmark-variant-keys.ts`'s own precedent
+	 * (`resolveLandmarkVariantKeys` likewise forwards its caller's
+	 * `options.similarityThreshold` straight into
+	 * `resolveStructuralClusterKeys` with no landmark-specific override) and
+	 * keeps the option surface to the three fields this file actually adds.
+	 * Accepted as a known trade-off rather than split into its own knob until
+	 * real-corpus tuning shows the two thresholds genuinely need to diverge —
+	 * the same "starting heuristic, not yet corpus-validated" status this
+	 * option's own default already carries.
+	 */
+	similarityThreshold?: number;
+	/**
+	 * Upper bound, as a fraction of the whole corpus (`[0, 1]`), on how many
+	 * pages may share a given (landmark type, variant) pair before that
+	 * variant is considered too common to serve as evidence of a genuine
+	 * template affinity. Strictly `<` this fraction ("rare", not
+	 * "rare-or-equal"). `RangeError` outside `[0, 1]`. Defaults to `0.05` —
+	 * an unvalidated starting heuristic, the same status as
+	 * `similarityThreshold`'s own `0.8` default (see this file's JSDoc for
+	 * why real-corpus validation is out of scope for this change).
+	 */
+	landmarkRarityThreshold?: number;
+	/**
+	 * The secondary, looser complete-linkage content-similarity threshold
+	 * applied only to pages whose landmark signature already qualifies (see
+	 * `mergeLandmarkAffinedClusters`'s JSDoc). `RangeError` outside `[0, 1]`.
+	 * Defaults to `0.6` — the value a withdrawn earlier prototype of this
+	 * same mechanism proposed, and also the value
+	 * `resolvePageClusterKeys`'s own `excludeLandmarks` JSDoc cites as having
+	 * correctly re-merged a real 3-page block once landmarks were excluded
+	 * and the raw-token `similarityThreshold` (`0.8`) became too strict.
+	 */
+	landmarkGateSimilarityThreshold?: number;
+};
+
+/**
+ * Reads `values[index]`, throwing instead of returning `undefined`. Every
+ * call site here indexes with a position this function generated itself, so
+ * the thrown branch is unreachable in practice; it exists to satisfy
+ * `noUncheckedIndexedAccess` without a non-null assertion. Independent copy
+ * by this package's established convention — see
+ * `resolve-page-cluster-keys.ts`'s own `requireIndex` JSDoc.
+ * @param values
+ * @param index
+ */
+function requireIndex<T>(values: ArrayLike<T>, index: number): T {
+	const value = values[index];
+	if (value === undefined) {
+		throw new Error('mergeLandmarkAffinedClusters: index out of bounds');
+	}
+	return value;
+}
+
+/**
+ * Reads `map.get(key)`, throwing instead of returning `undefined`. Every
+ * call site here looks up a key this function (or its caller, in the same
+ * pass) just inserted, so the thrown branch is unreachable in practice — the
+ * `Map` analogue of `requireIndex` above.
+ * @param map
+ * @param key
+ */
+function requireMapValue<K, V>(map: ReadonlyMap<K, V>, key: K): V {
+	const value = map.get(key);
+	if (value === undefined) {
+		throw new Error('mergeLandmarkAffinedClusters: expected map entry missing');
+	}
+	return value;
+}
+
+/**
+ * Validates that `value` (one of this file's three `[0, 1]`-range options,
+ * `name` being its option name for the thrown message) is in range,
+ * throwing `RangeError` otherwise. Shared by
+ * `validateMergeLandmarkAffinedClustersOptions`'s three checks so their
+ * range and message format can never drift apart from each other.
+ * @param value
+ * @param name
+ */
+function requireThreshold(value: number, name: string): number {
+	if (!(value >= 0 && value <= 1)) {
+		throw new RangeError(
+			`mergeLandmarkAffinedClusters: ${name} must be between 0 and 1, got ${value}`,
+		);
+	}
+	return value;
+}
+
+/**
+ * Validates `similarityThreshold`/`landmarkRarityThreshold`/
+ * `landmarkGateSimilarityThreshold` without running
+ * `mergeLandmarkAffinedClusters` itself — exported so
+ * `resolvePageClusterKeys` can fail fast on bad options even when `pages` is
+ * empty (its own per-block loop never reaches this function at all in that
+ * case). Mirrors `detect-content-depth-cap.ts`'s
+ * `validateDetectContentDepthCapOptions` exact rationale and shape.
+ * @param options
+ * @example
+ * ```ts
+ * // Fails fast on a bad option even though nothing here would otherwise
+ * // call mergeLandmarkAffinedClusters yet (e.g. cluster keys haven't been
+ * // computed).
+ * validateMergeLandmarkAffinedClustersOptions({ landmarkRarityThreshold: -1 }); // throws RangeError
+ * ```
+ */
+export function validateMergeLandmarkAffinedClustersOptions(
+	options?: MergeLandmarkAffinedClustersOptions,
+): void {
+	requireThreshold(
+		options?.similarityThreshold ?? DEFAULT_SIMILARITY_THRESHOLD,
+		'similarityThreshold',
+	);
+	requireThreshold(
+		options?.landmarkRarityThreshold ?? DEFAULT_LANDMARK_RARITY_THRESHOLD,
+		'landmarkRarityThreshold',
+	);
+	requireThreshold(
+		options?.landmarkGateSimilarityThreshold ??
+			DEFAULT_LANDMARK_GATE_SIMILARITY_THRESHOLD,
+		'landmarkGateSimilarityThreshold',
+	);
+}
+
+/**
+ * Canonicalizes a token set into a string that is identical for two sets iff
+ * their members are identical — sorted so the (undefined) `Set` iteration
+ * order can never make two structurally-equal sets hash differently. Used
+ * only to bucket byte-for-byte-identical landmark token sets before
+ * clustering (see `computeLandmarkStatus`'s JSDoc); not a general-purpose
+ * set-hashing utility.
+ *
+ * `JSON.stringify` of the sorted array, not a plain joined string: a token
+ * itself can contain a space (`format-bracket.ts` splices an element's raw
+ * `role`/`type` attribute value in verbatim, e.g. `role="a b"` produces the
+ * literal token `header[role=a b]`), so a delimiter-joined string would let
+ * two genuinely different sets — e.g. `{"a b", "c"}` and `{"a", "b", "c"}` —
+ * collide on the identical joined string `"a b c"`. `JSON.stringify` escapes
+ * each array element as its own quoted string, so no element's content can
+ * ever be mistaken for the array's own structural delimiters. Matches this
+ * file's own `landmark-merge:` key construction (`JSON.stringify(sortedKeys)`),
+ * which relies on the same collision-safety for the same reason.
+ * @param tokens
+ */
+function canonicalizeTokenSet(tokens: ReadonlySet<string>): string {
+	return JSON.stringify([...tokens].toSorted());
+}
+
+/**
+ * Finds the representative (root) of `index`'s set, compressing every
+ * traversed link. Independent copy of
+ * `resolve-structural-cluster-keys.ts`'s own `find`, by the same convention
+ * as `requireIndex` above.
+ * @param parent
+ * @param index
+ */
+function find(parent: Int32Array, index: number): number {
+	let root = index;
+	while (requireIndex(parent, root) !== root) {
+		root = requireIndex(parent, root);
+	}
+	let current = index;
+	while (current !== root) {
+		const next = requireIndex(parent, current);
+		parent[current] = root;
+		current = next;
+	}
+	return root;
+}
+
+/**
+ * Complete-linkage merge of a small number of nodes (`nodeCount`) given a
+ * precomputed, symmetric `nodeCount`x`nodeCount` similarity matrix. Returns
+ * the resulting partition as groups of node indices.
+ *
+ * Deliberately not a shared import of `resolve-structural-cluster-keys.ts`'s
+ * NN-chain implementation, which is hard-wired to compute Jaccard similarity
+ * from token sets internally rather than accepting a precomputed matrix.
+ * Both call sites in this file (`computeLandmarkStatus`'s deduplicated
+ * landmark-variant buckets, and `mergeLandmarkAffinedClusters`'s
+ * rare-signature groups' distinct cluster keys) feed this function a
+ * `nodeCount` that is self-limited to a small size by construction — see
+ * `computeLandmarkStatus`'s own JSDoc for the cost analysis — so a
+ * brute-force repeated-best-pair merge (same reference shape as
+ * `resolve-structural-cluster-keys.spec.ts`'s differential-test helper) is
+ * used directly rather than re-implementing NN-chain a second time for a
+ * negligible input size.
+ * @param nodeCount
+ * @param similarity
+ * @param threshold
+ */
+function mergeSmallClustersByCompleteLinkage(
+	nodeCount: number,
+	similarity: Float64Array,
+	threshold: number,
+): number[][] {
+	let groups: number[][] = Array.from({ length: nodeCount }, (_, index) => [index]);
+	for (;;) {
+		let bestPair: [number, number] | undefined;
+		let bestScore = Number.NEGATIVE_INFINITY;
+		for (let i = 0; i < groups.length; i++) {
+			for (let j = i + 1; j < groups.length; j++) {
+				let minSimilarity = Number.POSITIVE_INFINITY;
+				for (const a of requireIndex(groups, i)) {
+					for (const b of requireIndex(groups, j)) {
+						minSimilarity = Math.min(
+							minSimilarity,
+							requireIndex(similarity, a * nodeCount + b),
+						);
+					}
+				}
+				if (minSimilarity > bestScore) {
+					bestScore = minSimilarity;
+					bestPair = [i, j];
+				}
+			}
+		}
+		if (!bestPair || bestScore < threshold - BOUNDARY_EPSILON) {
+			break;
+		}
+		const [i, j] = bestPair;
+		groups[i] = [...requireIndex(groups, i), ...requireIndex(groups, j)];
+		groups = groups.filter((_, index) => index !== j);
+	}
+	return groups;
+}
+
+type LandmarkStatus =
+	| { exists: false }
+	| { exists: true; rare: boolean; variantLabel: string };
+
+/**
+ * For one landmark type, determines each page's corpus-wide variant identity
+ * and whether that variant is rare (see `mergeLandmarkAffinedClusters`'s
+ * JSDoc for what "rare" gates). A page missing this landmark type reports
+ * `{ exists: false }` unconditionally — it never counts toward any variant's
+ * frequency and is never itself "rare" or "common".
+ *
+ * Does not call `resolveStructuralClusterKeys` (unlike
+ * `resolve-landmark-variant-keys.ts`'s own landmark-variant classification).
+ * That function unconditionally narrows its input via
+ * `deriveComparisonSets` once given 10+ items — stripping out tokens shared
+ * by 90%+ of the compared sets as "chrome" and comparing only what's left.
+ * That is the right behavior for comparing *whole pages* (shared chrome
+ * should not inflate similarity between otherwise-different content), but
+ * it is backwards for comparing *landmark fragments to each other*: the
+ * stable, shared bulk of a header's markup is exactly the signal that two
+ * pages have "the same header design", and stripping it out would leave
+ * only incidental per-page differences (e.g. a "current page" nav-highlight
+ * class) to compare on. This function therefore uses raw `jaccardSimilarity`
+ * directly instead.
+ *
+ * It also skips the O(n²) all-pairs comparison `resolveStructuralClusterKeys`
+ * would otherwise run across the *entire, unblocked* corpus (a real cost:
+ * estimated ~19s and ~640MB for a single such call over an 8,936-page corpus,
+ * extrapolated from `detectContentDepthCap`'s own measured ~4s/call over a
+ * 4,085-page block — four landmark types would multiply that to ~76s). Real
+ * sites near-universally reuse byte-identical (post-tokenization) landmark
+ * markup across pages of the same template, so pages are first bucketed by
+ * exact token-set equality (`canonicalizeTokenSet`, O(n)) before any
+ * similarity is computed at all; only the resulting *distinct* buckets
+ * (expected in the tens at most, even for a large real corpus) are compared
+ * pairwise and complete-linkage-merged. This is not an approximation:
+ * deduplicating identical items before a Jaccard-based complete-linkage
+ * clustering step, then broadcasting each surviving cluster's label back to
+ * every item in the buckets it absorbed, produces the same partition a full
+ * item-by-item comparison would (`jaccardSimilarity` of two identical sets is
+ * always `1`, so duplicates always land in the same cluster; a duplicate's
+ * similarity to every other item is by definition identical to its
+ * representative's). If a corpus instead has near-zero landmark reuse (every
+ * page's markup for this type is unique), bucket count approaches page
+ * count and this degrades toward the O(n²) cost it otherwise avoids — but
+ * that scenario also means there is no shared, rare landmark for this
+ * mechanism to find evidence in regardless, so the degenerate cost case and
+ * the case where this feature has nothing to contribute coincide.
+ * @param type
+ * @param landmarks
+ * @param similarityThreshold
+ * @param landmarkRarityThreshold
+ * @param options
+ */
+function computeLandmarkStatus(
+	type: LandmarkType,
+	landmarks: readonly ExtractLandmarksResult[],
+	similarityThreshold: number,
+	landmarkRarityThreshold: number,
+	options: MergeLandmarkAffinedClustersOptions | undefined,
+): LandmarkStatus[] {
+	const pageCount = landmarks.length;
+	const tokenSets: (ReadonlySet<string> | undefined)[] = landmarks.map((entry) => {
+		const region = entry[type];
+		return region === undefined
+			? undefined
+			: new Set(tokenize(`<body>${region}</body>`, options).tokens);
+	});
+
+	const bucketIndexByKey = new Map<string, number>();
+	const bucketRepresentatives: ReadonlySet<string>[] = [];
+	const bucketIndexOfPage: (number | undefined)[] = tokenSets.map((tokens) => {
+		if (tokens === undefined) {
+			return;
+		}
+		const key = canonicalizeTokenSet(tokens);
+		const existing = bucketIndexByKey.get(key);
+		if (existing !== undefined) {
+			return existing;
+		}
+		const index = bucketRepresentatives.length;
+		bucketRepresentatives.push(tokens);
+		bucketIndexByKey.set(key, index);
+		return index;
+	});
+
+	const bucketCount = bucketRepresentatives.length;
+	const similarity = new Float64Array(bucketCount * bucketCount);
+	for (let i = 0; i < bucketCount; i++) {
+		for (let j = i + 1; j < bucketCount; j++) {
+			const score = jaccardSimilarity(
+				requireIndex(bucketRepresentatives, i),
+				requireIndex(bucketRepresentatives, j),
+			);
+			similarity[i * bucketCount + j] = score;
+			similarity[j * bucketCount + i] = score;
+		}
+	}
+	const groups = mergeSmallClustersByCompleteLinkage(
+		bucketCount,
+		similarity,
+		similarityThreshold,
+	);
+
+	const groupLabelByBucketIndex = new Map<number, string>();
+	for (const [groupIndex, bucketIndices] of groups.entries()) {
+		for (const bucketIndex of bucketIndices) {
+			groupLabelByBucketIndex.set(bucketIndex, `variant:${groupIndex}`);
+		}
+	}
+
+	const variantLabelOfPage: (string | undefined)[] = bucketIndexOfPage.map(
+		(bucketIndex) =>
+			bucketIndex === undefined
+				? undefined
+				: requireMapValue(groupLabelByBucketIndex, bucketIndex),
+	);
+
+	const countByLabel = new Map<string, number>();
+	for (const label of variantLabelOfPage) {
+		if (label !== undefined) {
+			countByLabel.set(label, (countByLabel.get(label) ?? 0) + 1);
+		}
+	}
+
+	return variantLabelOfPage.map((label): LandmarkStatus => {
+		if (label === undefined) {
+			return { exists: false };
+		}
+		const ratio = requireMapValue(countByLabel, label) / pageCount;
+		return { exists: true, rare: ratio < landmarkRarityThreshold, variantLabel: label };
+	});
+}
+
+/**
+ * Re-keys the pages of two or more distinct
+ * {@link ./resolve-page-cluster-keys.js | resolvePageClusterKeys} clusters
+ * onto one shared key when every landmark type present on their pages is
+ * both *identical* and *rare* corpus-wide, and their actual content clears a
+ * secondary, looser similarity threshold.
+ *
+ * Reimplements a mechanism previously prototyped under this same name and
+ * withdrawn (no trace survives in commit history — this JSDoc is the only
+ * record). The withdrawn version merged clusters whenever their
+ * header/footer/nav/aside matched, full stop. Validated against two real
+ * crawl corpora (302 and 8,936 pages), that produced runaway over-merging:
+ * header/footer/nav were present on 99%+ of pages and typically reused
+ * site-wide unchanged (see `extractLandmarks`'s own JSDoc for that figure),
+ * so "landmarks match" was true for nearly every page pair and carried no
+ * discriminative power at all. This reimplementation only ever treats a
+ * landmark match as merge evidence when that specific landmark *variant* is
+ * itself uncommon corpus-wide (`landmarkRarityThreshold`) — the condition
+ * the withdrawn attempt lacked.
+ *
+ * The match requirement is deliberately the most conservative option
+ * considered: *every* landmark type actually present on a page must both
+ * match its counterpart's variant and be rare — a page with even one common
+ * ("everybody has this exact header") present type contributes no evidence
+ * at all, rather than partially qualifying. A looser rule (e.g. "at least
+ * one shared rare type is enough") was rejected because it reintroduces a
+ * version of the original failure mode: a page could ride a single
+ * incidentally-rare landmark into a merge despite otherwise-ordinary,
+ * ubiquitous chrome elsewhere on the same page.
+ *
+ * Frequency is counted corpus-wide, not per-block: a `resolveStructuralClusterKeys`
+ * cluster label (`cluster:N`) is only unique within the block it was computed
+ * in, but rarity here needs one consistent count across the whole input, the
+ * same reason `resolvePageClusterKeys` itself composes `[blockKey,
+ * localLabel]` via `JSON.stringify` rather than reusing bare labels across
+ * blocks.
+ *
+ * A page with none of the four landmark types present is excluded from
+ * consideration entirely (`existingCount === 0` below) — without this, every
+ * landmark-less page across the whole corpus would share one large,
+ * unbounded "no landmarks" group, defeating the self-limiting cost bound
+ * `landmarkRarityThreshold` is otherwise supposed to guarantee (see
+ * `computeLandmarkStatus`'s JSDoc for the cost analysis this depends on).
+ *
+ * Once pages are grouped by matching-and-rare landmark signature, only
+ * signature groups spanning two or more distinct existing cluster keys do
+ * any further work. Within such a group, the *content* token sets of the
+ * group's distinct cluster keys are complete-linkage-merged at
+ * `landmarkGateSimilarityThreshold` — looser than
+ * `resolveStructuralClusterKeys`'s own `similarityThreshold`, since the
+ * whole point of this mechanism is to bridge clusters whose *content*
+ * similarity alone fell just short of the primary threshold. Complete-linkage
+ * (not single-linkage) is used for the same reason
+ * `resolveStructuralClusterKeys` itself uses it: single-linkage's chaining
+ * would let one loosely-matching pair bridge two genuinely-unrelated
+ * clusters transitively.
+ *
+ * The resulting merge is applied at *page* granularity, not by blanket-
+ * reassigning every page of the involved cluster keys: only the specific
+ * pages that were actually pooled into the qualifying signature group (and,
+ * transitively, any other page unioned with them via a different signature
+ * group) move onto the shared key. A cluster's pages that never carried the
+ * rare landmark evidence keep their original key untouched, even if some
+ * other page sharing that same cluster key did qualify and merge elsewhere.
+ * This is deliberate, not an incidental restriction: applying a merge
+ * decision to *every* page of the involved cluster keys — evidenced by only
+ * a small subset of them — would extrapolate a coincidental pairing (e.g.
+ * one outlier page in each of two otherwise-unrelated clusters happening to
+ * share a rare seasonal-campaign header) into force-merging the clusters'
+ * entire, otherwise-dissimilar membership. That is the withdrawn prototype's
+ * over-merging failure mode reappearing through a different mechanism
+ * (whole-cluster application of a single-pair signal) rather than the
+ * landmark-commonality mechanism this file was reimplemented to fix — see
+ * this function's own regression test for a worked example.
+ *
+ * Merged pages are re-keyed to `landmark-merge:${JSON.stringify(sortedKeys)}`
+ * (`sortedKeys` being the *original* cluster keys the merged pages came
+ * from) — a fresh prefix that cannot collide with `css:`/`path:`/
+ * `orphan-merge:` or `resolvePageClusterKeys`'s own `[blockKey, "cluster:N"]`
+ * pairs (mirrors `reassign-orphan-block-keys.ts`'s `orphan-merge:` prefix).
+ * @param clusterKeys - one existing final key per page, same order/length as `landmarks`/`contentTokenSets`
+ * @param landmarks - `extractLandmarks(page.html)`'s full result per page (all four fields, not just `remainderHtml`)
+ * @param contentTokenSets - per-page content token sets to use for the secondary similarity gate. Should be independent of whichever landmark markup qualified the page as evidence (e.g. always landmark-excised), so this gate is a genuine second signal rather than re-counting the same landmark tokens already used to select the page — see `resolvePageClusterKeys`'s own call site for how it builds these
+ * @param options
+ * @example
+ * ```ts
+ * // tokenize() discards visible text (see its own JSDoc), so the two
+ * // header variants below must differ structurally (child element/class),
+ * // not merely in text, to compare as different landmark variants.
+ * mergeLandmarkAffinedClusters(
+ * 	['["css:a", "cluster:0"]', '["css:b", "cluster:0"]', 'path:other'],
+ * 	[
+ * 		{ header: '<header><i class="mark-a"></i></header>', remainderHtml: '' },
+ * 		{ header: '<header><i class="mark-a"></i></header>', remainderHtml: '' },
+ * 		{ header: '<header><b class="mark-b"></b></header>', remainderHtml: '' },
+ * 	],
+ * 	[new Set(['a', 'b']), new Set(['a', 'c']), new Set(['z'])],
+ * 	{ landmarkRarityThreshold: 0.7, landmarkGateSimilarityThreshold: 0.3 },
+ * );
+ * // pages 0 and 1 share an identical header used by only 2 of the 3 pages
+ * // (a 2/3 ≈ 0.667 corpus frequency, rare at threshold 0.7) and their
+ * // content clears 0.3, so they merge onto one landmark-merge: key; page 2
+ * // (a structurally different header) is left untouched
+ * ```
+ */
+export function mergeLandmarkAffinedClusters(
+	clusterKeys: readonly string[],
+	landmarks: readonly ExtractLandmarksResult[],
+	contentTokenSets: readonly ReadonlySet<string>[],
+	options?: MergeLandmarkAffinedClustersOptions,
+): string[] {
+	// Self-validates, unlike relying solely on a caller's separate
+	// validateMergeLandmarkAffinedClustersOptions call: mirrors
+	// detectContentDepthCap's own first line, and matters here because this
+	// function is directly importable via this package's
+	// `./merge-landmark-affined-clusters` subpath export, not only reachable
+	// through resolvePageClusterKeys's own eager pre-validation. Without
+	// this, an out-of-range or NaN threshold would silently defeat
+	// mergeSmallClustersByCompleteLinkage's stop condition
+	// (`bestScore < threshold - BOUNDARY_EPSILON` never becomes true against
+	// a negative or NaN threshold) and force-merge every candidate group
+	// into one, with no error raised.
+	validateMergeLandmarkAffinedClustersOptions(options);
+
+	if (clusterKeys.length === 0) {
+		return [];
+	}
+
+	const similarityThreshold =
+		options?.similarityThreshold ?? DEFAULT_SIMILARITY_THRESHOLD;
+	const landmarkRarityThreshold =
+		options?.landmarkRarityThreshold ?? DEFAULT_LANDMARK_RARITY_THRESHOLD;
+	const landmarkGateSimilarityThreshold =
+		options?.landmarkGateSimilarityThreshold ??
+		DEFAULT_LANDMARK_GATE_SIMILARITY_THRESHOLD;
+
+	const statusByType = new Map<LandmarkType, LandmarkStatus[]>(
+		LANDMARK_TYPES.map((type) => [
+			type,
+			computeLandmarkStatus(
+				type,
+				landmarks,
+				similarityThreshold,
+				landmarkRarityThreshold,
+				options,
+			),
+		]),
+	);
+
+	const signatures: (string | undefined)[] = clusterKeys.map((_, pageIndex) => {
+		let existingCount = 0;
+		let allRare = true;
+		const parts: string[] = [];
+		for (const type of LANDMARK_TYPES) {
+			const status = requireIndex(requireMapValue(statusByType, type), pageIndex);
+			if (!status.exists) {
+				continue;
+			}
+			existingCount++;
+			if (!status.rare) {
+				allRare = false;
+			}
+			parts.push(`${type}:${status.variantLabel}`);
+		}
+		return existingCount > 0 && allRare ? parts.join('|') : undefined;
+	});
+
+	const pageIndicesBySignature = new Map<string, number[]>();
+	for (const [pageIndex, signature] of signatures.entries()) {
+		if (signature === undefined) {
+			continue;
+		}
+		const indices = pageIndicesBySignature.get(signature);
+		if (indices) {
+			indices.push(pageIndex);
+		} else {
+			pageIndicesBySignature.set(signature, [pageIndex]);
+		}
+	}
+
+	// Page-level union-find, not cluster-key-level: a merge decision drawn
+	// from a signature group's (necessarily partial — only the pages that
+	// happened to land in that group) evidence must bind only the specific
+	// pages that supplied it. Unioning by cluster key instead would apply a
+	// single qualifying pair's evidence to every page sharing either
+	// cluster key, including pages with no evidence at all — see this
+	// function's own JSDoc "page granularity" section for why that
+	// reintroduces the withdrawn prototype's over-merging failure.
+	const parent = Int32Array.from({ length: clusterKeys.length }, (_, index) => index);
+
+	for (const pageIndices of pageIndicesBySignature.values()) {
+		const memberIndicesByClusterKey = new Map<string, number[]>();
+		for (const pageIndex of pageIndices) {
+			const clusterKey = requireIndex(clusterKeys, pageIndex);
+			const members = memberIndicesByClusterKey.get(clusterKey);
+			if (members) {
+				members.push(pageIndex);
+			} else {
+				memberIndicesByClusterKey.set(clusterKey, [pageIndex]);
+			}
+		}
+
+		const groupClusterKeys = [...memberIndicesByClusterKey.keys()];
+		if (groupClusterKeys.length <= 1) {
+			continue;
+		}
+
+		const groupMembers = groupClusterKeys.map((key) =>
+			requireMapValue(memberIndicesByClusterKey, key),
+		);
+
+		const k = groupClusterKeys.length;
+		const similarity = new Float64Array(k * k);
+		for (let i = 0; i < k; i++) {
+			for (let j = i + 1; j < k; j++) {
+				let minSimilarity = Number.POSITIVE_INFINITY;
+				for (const p of requireIndex(groupMembers, i)) {
+					for (const q of requireIndex(groupMembers, j)) {
+						const score = jaccardSimilarity(
+							requireIndex(contentTokenSets, p),
+							requireIndex(contentTokenSets, q),
+						);
+						minSimilarity = Math.min(minSimilarity, score);
+					}
+				}
+				similarity[i * k + j] = minSimilarity;
+				similarity[j * k + i] = minSimilarity;
+			}
+		}
+
+		const mergedGroups = mergeSmallClustersByCompleteLinkage(
+			k,
+			similarity,
+			landmarkGateSimilarityThreshold,
+		);
+		for (const group of mergedGroups) {
+			if (group.length <= 1) {
+				continue;
+			}
+			// Union only the specific evidence pages behind the cluster keys
+			// in this merged group — not every page that happens to share
+			// those keys elsewhere in the corpus (see this function's JSDoc).
+			const evidencePages = group.flatMap((clusterIndex) =>
+				requireIndex(groupMembers, clusterIndex),
+			);
+			const firstPage = requireIndex(evidencePages, 0);
+			for (let i = 1; i < evidencePages.length; i++) {
+				const rootA = find(parent, firstPage);
+				const rootB = find(parent, requireIndex(evidencePages, i));
+				if (rootA !== rootB) {
+					parent[rootB] = rootA;
+				}
+			}
+		}
+	}
+
+	const pageIndicesByRoot = new Map<number, number[]>();
+	for (let pageIndex = 0; pageIndex < clusterKeys.length; pageIndex++) {
+		const root = find(parent, pageIndex);
+		const indices = pageIndicesByRoot.get(root);
+		if (indices) {
+			indices.push(pageIndex);
+		} else {
+			pageIndicesByRoot.set(root, [pageIndex]);
+		}
+	}
+
+	const remap = new Map<number, string>();
+	for (const indices of pageIndicesByRoot.values()) {
+		const originalKeys = new Set(
+			indices.map((index) => requireIndex(clusterKeys, index)),
+		);
+		// A component every one of whose pages already shares one original
+		// cluster key never actually crossed a cluster boundary (the common
+		// case: most pages never entered any signature group at all, so
+		// their root is just themselves) — nothing to re-key.
+		if (originalKeys.size <= 1) {
+			continue;
+		}
+		const mergedKey = `${MERGED_KEY_PREFIX}${JSON.stringify([...originalKeys].toSorted())}`;
+		for (const index of indices) {
+			remap.set(index, mergedKey);
+		}
+	}
+
+	return clusterKeys.map((key, index) => remap.get(index) ?? key);
+}

--- a/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys.spec.ts
+++ b/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys.spec.ts
@@ -438,4 +438,146 @@ describe('resolvePageClusterKeys', () => {
 
 		expect(resolvePageClusterKeys(pages, { autoCapMainDepth: true })).toHaveLength(1);
 	});
+
+	test('mergeRareLandmarkClusters (default false) leaves two different blocks unmerged even when they share a rare header', () => {
+		// tokenize() discards visible text, so the two header variants below
+		// are distinguished by a child element's class, not by text.
+		const rareHeader = '<header><i class="mark-rare"></i></header>';
+		const commonHeader = '<header><i class="mark-common"></i></header>';
+		const sharedMainOpen =
+			'<main><div class="s1"></div><div class="s2"></div><div class="s3"></div>';
+		const pageA = {
+			paths: ['dept-a', '1'],
+			stylesheetHrefs: [],
+			html: `<body>${rareHeader}${sharedMainOpen}<div class="a1"></div></main></body>`,
+		};
+		const pageB = {
+			paths: ['dept-b', '1'],
+			stylesheetHrefs: [],
+			html: `<body>${rareHeader}${sharedMainOpen}<div class="b1"></div></main></body>`,
+		};
+		const fillers = Array.from({ length: 8 }, (_, i) => ({
+			paths: ['dept-c', `${i}`],
+			stylesheetHrefs: [],
+			html: `<body>${commonHeader}<main><div class="filler-${i}"></div></main></body>`,
+		}));
+
+		const result = resolvePageClusterKeys([pageA, pageB, ...fillers]);
+
+		expect(result[0]).not.toBe(result[1]);
+	});
+
+	test('mergeRareLandmarkClusters: true bridges two different blocks once their shared header is rare and their content clears the looser gate threshold', () => {
+		// tokenize() discards visible text, so the two header variants below
+		// are distinguished by a child element's class, not by text.
+		const rareHeader = '<header><i class="mark-rare"></i></header>';
+		const commonHeader = '<header><i class="mark-common"></i></header>';
+		const sharedMainOpen =
+			'<main><div class="s1"></div><div class="s2"></div><div class="s3"></div>';
+		const pageA = {
+			paths: ['dept-a', '1'],
+			stylesheetHrefs: [],
+			html: `<body>${rareHeader}${sharedMainOpen}<div class="a1"></div></main></body>`,
+		};
+		const pageB = {
+			paths: ['dept-b', '1'],
+			stylesheetHrefs: [],
+			html: `<body>${rareHeader}${sharedMainOpen}<div class="b1"></div></main></body>`,
+		};
+		const fillers = Array.from({ length: 8 }, (_, i) => ({
+			paths: ['dept-c', `${i}`],
+			stylesheetHrefs: [],
+			html: `<body>${commonHeader}<main><div class="filler-${i}"></div></main></body>`,
+		}));
+		const pages = [pageA, pageB, ...fillers];
+
+		const withoutMerge = resolvePageClusterKeys(pages);
+		expect(withoutMerge[0]).not.toBe(withoutMerge[1]);
+
+		const withMerge = resolvePageClusterKeys(pages, {
+			mergeRareLandmarkClusters: true,
+			landmarkRarityThreshold: 0.25,
+			landmarkGateSimilarityThreshold: 0.5,
+		});
+		expect(withMerge[0]).toBe(withMerge[1]);
+		expect(withMerge[0]).toMatch(/^landmark-merge:/);
+	});
+
+	test('mergeRareLandmarkClusters validates its own options eagerly, even for an empty page list with no blocks to run the merge step on', () => {
+		expect(() =>
+			resolvePageClusterKeys([], {
+				mergeRareLandmarkClusters: true,
+				landmarkRarityThreshold: -1,
+			}),
+		).toThrow(RangeError);
+	});
+
+	test('mergeRareLandmarkClusters still works when excludeLandmarks: false (extractLandmarks is computed independently for the gate)', () => {
+		// tokenize() discards visible text, so the two header variants below
+		// are distinguished by a child element's class, not by text.
+		const rareHeader = '<header><i class="mark-rare"></i></header>';
+		const commonHeader = '<header><i class="mark-common"></i></header>';
+		const pageA = {
+			paths: ['dept-a', '1'],
+			stylesheetHrefs: [],
+			html: `<body>${rareHeader}<main><div class="x"></div></main></body>`,
+		};
+		const pageB = {
+			paths: ['dept-b', '1'],
+			stylesheetHrefs: [],
+			html: `<body>${rareHeader}<main><div class="x"></div></main></body>`,
+		};
+		const fillers = Array.from({ length: 8 }, (_, i) => ({
+			paths: ['dept-c', `${i}`],
+			stylesheetHrefs: [],
+			html: `<body>${commonHeader}<main><div class="filler-${i}"></div></main></body>`,
+		}));
+
+		const result = resolvePageClusterKeys([pageA, pageB, ...fillers], {
+			excludeLandmarks: false,
+			mergeRareLandmarkClusters: true,
+			landmarkRarityThreshold: 0.25,
+			landmarkGateSimilarityThreshold: 0.5,
+		});
+
+		expect(result[0]).toBe(result[1]);
+	});
+
+	test("mergeRareLandmarkClusters does not let a shared landmark's own markup count as body-content evidence, even when excludeLandmarks: false (regression test for gate independence)", () => {
+		// A bulky 8-element rare header, identical on both pages, plus main
+		// content that is completely disjoint between the two pages. With
+		// excludeLandmarks: false, the *primary* clustering tokenizes raw
+		// HTML (header included) — but the merge gate must still judge
+		// similarity on landmark-excised content only. If the header's own
+		// tokens leaked into that judgment, shared header (8) vs disjoint
+		// content (2 + 2) would score 8/12 ≈ 0.667, clearing the 0.5 gate
+		// used here; on landmark-excised content alone the two pages share
+		// nothing (0/4 = 0), so they must not merge.
+		const rareHeader = `<header>${Array.from({ length: 8 }, (_, i) => `<i class="mark-${i}"></i>`).join('')}</header>`;
+		const commonHeader = '<header><i class="mark-common"></i></header>';
+		const pageA = {
+			paths: ['dept-a', '1'],
+			stylesheetHrefs: [],
+			html: `<body>${rareHeader}<main><div class="only-in-a-1"></div><div class="only-in-a-2"></div></main></body>`,
+		};
+		const pageB = {
+			paths: ['dept-b', '1'],
+			stylesheetHrefs: [],
+			html: `<body>${rareHeader}<main><div class="only-in-b-1"></div><div class="only-in-b-2"></div></main></body>`,
+		};
+		const fillers = Array.from({ length: 8 }, (_, i) => ({
+			paths: ['dept-c', `${i}`],
+			stylesheetHrefs: [],
+			html: `<body>${commonHeader}<main><div class="filler-${i}"></div></main></body>`,
+		}));
+
+		const result = resolvePageClusterKeys([pageA, pageB, ...fillers], {
+			excludeLandmarks: false,
+			mergeRareLandmarkClusters: true,
+			landmarkRarityThreshold: 0.25,
+			landmarkGateSimilarityThreshold: 0.5,
+		});
+
+		expect(result[0]).not.toBe(result[1]);
+	});
 });

--- a/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys.ts
+++ b/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys.ts
@@ -1,3 +1,4 @@
+import type { ExtractLandmarksResult } from './extract-landmarks.js';
 import type { ResolveBlockingGroupKeysOptions } from './resolve-blocking-group-keys.js';
 import type { ResolveStructuralClusterKeysOptions } from './resolve-structural-cluster-keys.js';
 import type { TokenizeOptions } from './types.js';
@@ -9,6 +10,10 @@ import {
 } from './detect-content-depth-cap.js';
 import { extractLandmarks } from './extract-landmarks.js';
 import { filterFirstPartyStylesheetHrefs } from './filter-first-party-stylesheet-hrefs.js';
+import {
+	mergeLandmarkAffinedClusters,
+	validateMergeLandmarkAffinedClustersOptions,
+} from './merge-landmark-affined-clusters.js';
 import { reassignOrphanBlockKeys } from './reassign-orphan-block-keys.js';
 import { removeContentBlocks } from './remove-content-blocks.js';
 import { resolveBlockingGroupKeys } from './resolve-blocking-group-keys.js';
@@ -35,6 +40,25 @@ function requireIndex<T>(values: ArrayLike<T>, index: number): T {
 		throw new Error('resolvePageClusterKeys: index out of bounds');
 	}
 	return value;
+}
+
+/**
+ * Narrows `landmarks` from `readonly ExtractLandmarksResult[] | undefined` to
+ * defined, throwing instead of asserting non-null. Always defined in
+ * practice at every call site below: both call sites are only reached when
+ * `excludeLandmarks || mergeRareLandmarkClusters` is true, exactly the
+ * condition under which `landmarks` is populated. Exists only to satisfy the
+ * type checker without a non-null assertion (same rationale as
+ * `requireIndex` above).
+ * @param landmarks
+ */
+function requireLandmarks(
+	landmarks: readonly ExtractLandmarksResult[] | undefined,
+): readonly ExtractLandmarksResult[] {
+	if (landmarks === undefined) {
+		throw new Error('resolvePageClusterKeys: landmarks were not computed');
+	}
+	return landmarks;
 }
 
 /**
@@ -184,6 +208,26 @@ export type ResolvePageClusterKeysOptions = TokenizeOptions &
 		 * measures on the same two corpora.
 		 */
 		autoCapMainDepth?: boolean;
+		/**
+		 * Re-key two or more otherwise-distinct clusters onto one shared key
+		 * when every landmark type present on their pages is both identical
+		 * and rare corpus-wide — see
+		 * {@link ./merge-landmark-affined-clusters.js | mergeLandmarkAffinedClusters}'s
+		 * JSDoc for the exact rule, the withdrawn earlier prototype this
+		 * reimplements, and why "rare" (not merely "identical") is required.
+		 * Defaults to `false`.
+		 *
+		 * Kept `false` by default: unlike `autoCapMainDepth`/
+		 * `restrictStylesheetsToFirstParty`, this has not been run against
+		 * real crawl data at all as of this change — only synthetic-fixture
+		 * unit/regression tests. See `mergeLandmarkAffinedClusters`'s JSDoc
+		 * for its cost profile before enabling this on a large corpus.
+		 */
+		mergeRareLandmarkClusters?: boolean;
+		/** Forwarded to {@link ./merge-landmark-affined-clusters.js | mergeLandmarkAffinedClusters} as-is. */
+		landmarkRarityThreshold?: number;
+		/** Forwarded to {@link ./merge-landmark-affined-clusters.js | mergeLandmarkAffinedClusters} as-is. */
+		landmarkGateSimilarityThreshold?: number;
 	};
 
 /**
@@ -244,10 +288,28 @@ export function resolvePageClusterKeys(
 	options?: ResolvePageClusterKeysOptions,
 ): string[] {
 	const excludeLandmarks = options?.excludeLandmarks ?? true;
+	const mergeRareLandmarkClusters = options?.mergeRareLandmarkClusters ?? false;
+	if (mergeRareLandmarkClusters) {
+		// Eager, same rationale as autoCapMainDepth's own eager validation
+		// below: this option's own validation is otherwise only reached from
+		// mergeLandmarkAffinedClusters's call at the very end of this
+		// function, which never runs at all for an empty `pages`.
+		validateMergeLandmarkAffinedClustersOptions(options);
+	}
+
+	// extractLandmarks parses the whole page once; excludeLandmarks needs
+	// remainderHtml and mergeRareLandmarkClusters needs the four landmark
+	// fields, so this computes it once up front whenever either is needed,
+	// rather than each option branch parsing independently.
+	const landmarks: readonly ExtractLandmarksResult[] | undefined =
+		excludeLandmarks || mergeRareLandmarkClusters
+			? pages.map((page) => extractLandmarks(page.html))
+			: undefined;
+
 	const contentBlockAttribute = options?.contentBlockAttribute;
-	const preparedHtml = pages.map((page) => {
+	const preparedHtml = pages.map((page, index) => {
 		const landmarksExcised = excludeLandmarks
-			? extractLandmarks(page.html).remainderHtml
+			? requireIndex(requireLandmarks(landmarks), index).remainderHtml
 			: page.html;
 		return contentBlockAttribute === undefined
 			? landmarksExcised
@@ -314,5 +376,30 @@ export function resolvePageClusterKeys(
 		}
 	}
 
-	return finalKeys;
+	if (!mergeRareLandmarkClusters) {
+		return finalKeys;
+	}
+	// Deliberately not a reuse of blockTokenSets (this function's own
+	// primary-clustering token sets): those follow excludeLandmarks (raw
+	// HTML, landmarks included, when false) and resolveStructuralClusterKeys
+	// narrows them further via its internal deriveComparisonSets once a
+	// block reaches 10+ pages. mergeLandmarkAffinedClusters's secondary
+	// content-similarity gate is meant to be independent corroboration
+	// alongside the landmark match already used to select these pages — if
+	// it reused landmark-inclusive tokens, a bulky shared rare header's own
+	// tokens could inflate two otherwise-unrelated pages' similarity past
+	// the gate, and if it reused the frequency-narrowed set, the gate would
+	// silently test different content than its own JSDoc describes. Always
+	// tokenizing each page's landmark-excised remainderHtml here keeps the
+	// gate's evidence independent of both.
+	const resolvedLandmarks = requireLandmarks(landmarks);
+	const mergeGateContentTokenSets = resolvedLandmarks.map(
+		(entry) => new Set(tokenize(entry.remainderHtml, options).tokens),
+	);
+	return mergeLandmarkAffinedClusters(
+		finalKeys,
+		resolvedLandmarks,
+		mergeGateContentTokenSets,
+		options,
+	);
 }


### PR DESCRIPTION
## Summary
- Reimplements the previously withdrawn "landmark-gated tertiary cluster" mechanism (`mergeRareLandmarkClusters`, default `false`) with the missing safeguard: a header/footer/nav/aside match only counts as merge evidence when that specific variant is rare corpus-wide (`landmarkRarityThreshold`), not merely identical — the withdrawn prototype merged on identity alone and over-merged on real crawl data since header/footer/nav are present on 99%+ of pages.
- New `merge-landmark-affined-clusters.ts` (`mergeLandmarkAffinedClusters()` / `validateMergeLandmarkAffinedClustersOptions()`), wired into `resolvePageClusterKeys()`. Re-keying happens at page granularity, not whole-cluster, so a coincidental match between a couple of outlier pages cannot drag their entire, otherwise-unrelated clusters together.
- README and package.json `exports` updated; new subpath `@d-zero/page-cluster/merge-landmark-affined-clusters`.

## Test plan
- [x] `yarn lint` — 0 errors
- [x] `yarn build` — all 28 packages build
- [x] `yarn test` — 1467/1467 pass (monorepo-wide)
- [x] Went through `/code-review xhigh` (9 confirmed/plausible findings fixed: missing self-validation, partial-evidence-applied-to-whole-cluster over-merge, landmark-markup leaking into the "independent" content gate, unsafe token-set canonicalization, broken JSDoc cross-references) and `/qa-engineer` (added a regression test for a previously-untested fuzzy landmark-variant-matching code path)
- [ ] Real-corpus validation (out of scope for this change — the crawl data used for the withdrawn prototype's original validation is not in this repository; ships with synthetic-fixture unit/regression tests only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
