### PR TITLE
feat(page-cluster)!: streaming API for large corpora

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -17,6 +17,8 @@
 		"hrefs",
 		"Murtagh",
 		"unioned",
+		"retags",
+		"Vitter",
 
 		//
 		"gaxios",

--- a/packages/@d-zero/page-cluster/src/merge-cross-block-clusters.spec.ts
+++ b/packages/@d-zero/page-cluster/src/merge-cross-block-clusters.spec.ts
@@ -4,6 +4,20 @@ import type { CrossBlockUnit } from './merge-cross-block-clusters.js';
 import { describe, expect, test } from 'vitest';
 
 import { mergeCrossBlockClusters } from './merge-cross-block-clusters.js';
+import { computePerPageLandmarkInstances } from './per-page-landmark-signatures.js';
+
+/**
+ * Converts an old-style per-member `ExtractLandmarksResult[]` fixture into
+ * the pre-tokenized `PerPageLandmarkInstance[][]` shape that `CrossBlockUnit`
+ * now stores. Every test in this file historically constructed landmark
+ * fixtures as full `ExtractLandmarksResult` objects; this shim funnels them
+ * through the same tokenization Stage B used to do at read time, keeping
+ * every existing test's semantics intact under the new field name.
+ * @param landmarks
+ */
+function toInstances(landmarks: readonly ExtractLandmarksResult[]) {
+	return computePerPageLandmarkInstances(landmarks);
+}
 
 const noLandmarks: ExtractLandmarksResult = {
 	header: [],
@@ -28,7 +42,7 @@ describe('mergeCrossBlockClusters', () => {
 		const unit: CrossBlockUnit = {
 			key: 'k1',
 			memberTokenSets: [new Set(['body>main>.card'])],
-			memberLandmarks: [noLandmarks],
+			memberLandmarkInstances: toInstances([noLandmarks]),
 		};
 		const result = mergeCrossBlockClusters([unit], {});
 		expect(result.get('k1')).toBe('k1');
@@ -39,12 +53,12 @@ describe('mergeCrossBlockClusters', () => {
 		const unit1: CrossBlockUnit = {
 			key: 'k1',
 			memberTokenSets: [tokens],
-			memberLandmarks: [noLandmarks],
+			memberLandmarkInstances: toInstances([noLandmarks]),
 		};
 		const unit2: CrossBlockUnit = {
 			key: 'k2',
 			memberTokenSets: [tokens],
-			memberLandmarks: [noLandmarks],
+			memberLandmarkInstances: toInstances([noLandmarks]),
 		};
 		const result = mergeCrossBlockClusters([unit1, unit2], {});
 		expect(result.get('k1')).toBe(result.get('k2'));
@@ -56,14 +70,14 @@ describe('mergeCrossBlockClusters', () => {
 			memberTokenSets: [
 				new Set(['body>main>article', 'body>main>article>h1', 'body>main>article>p']),
 			],
-			memberLandmarks: [noLandmarks],
+			memberLandmarkInstances: toInstances([noLandmarks]),
 		};
 		const unit2: CrossBlockUnit = {
 			key: 'k2',
 			memberTokenSets: [
 				new Set(['body>aside>section', 'body>aside>section>ul', 'body>footer>nav']),
 			],
-			memberLandmarks: [noLandmarks],
+			memberLandmarkInstances: toInstances([noLandmarks]),
 		};
 		const result = mergeCrossBlockClusters([unit1, unit2], {});
 		expect(result.get('k1')).toBe('k1');
@@ -85,7 +99,7 @@ describe('mergeCrossBlockClusters', () => {
 					'body>main>section.c-reports>ul.c-reports__list',
 				]),
 			],
-			memberLandmarks: [noLandmarks, noLandmarks],
+			memberLandmarkInstances: toInstances([noLandmarks, noLandmarks]),
 		};
 		const unit2: CrossBlockUnit = {
 			key: 'projects',
@@ -99,7 +113,7 @@ describe('mergeCrossBlockClusters', () => {
 					'body>main>section.c-projects>ul.c-projects__list',
 				]),
 			],
-			memberLandmarks: [noLandmarks, noLandmarks],
+			memberLandmarkInstances: toInstances([noLandmarks, noLandmarks]),
 		};
 		const result = mergeCrossBlockClusters([unit1, unit2], {});
 		expect(result.get('reports')).toBe(result.get('projects'));
@@ -113,14 +127,14 @@ describe('mergeCrossBlockClusters', () => {
 			memberTokenSets: [
 				new Set(['body>main>section.type-a', 'body>main>section.type-a>p']),
 			],
-			memberLandmarks: [noLandmarks],
+			memberLandmarkInstances: toInstances([noLandmarks]),
 		};
 		const unit2: CrossBlockUnit = {
 			key: 'solo-b',
 			memberTokenSets: [
 				new Set(['body>main>section.type-b', 'body>main>section.type-b>p']),
 			],
-			memberLandmarks: [noLandmarks],
+			memberLandmarkInstances: toInstances([noLandmarks]),
 		};
 		const result = mergeCrossBlockClusters([unit1, unit2], {});
 		expect(result.get('solo-a')).toBe('solo-a');
@@ -131,17 +145,17 @@ describe('mergeCrossBlockClusters', () => {
 		const unit1: CrossBlockUnit = {
 			key: 'a',
 			memberTokenSets: [new Set(['x'])],
-			memberLandmarks: [noLandmarks],
+			memberLandmarkInstances: toInstances([noLandmarks]),
 		};
 		const unit2: CrossBlockUnit = {
 			key: 'b',
 			memberTokenSets: [new Set(['y'])],
-			memberLandmarks: [noLandmarks],
+			memberLandmarkInstances: toInstances([noLandmarks]),
 		};
 		const unit3: CrossBlockUnit = {
 			key: 'c',
 			memberTokenSets: [new Set(['z'])],
-			memberLandmarks: [noLandmarks],
+			memberLandmarkInstances: toInstances([noLandmarks]),
 		};
 		const result = mergeCrossBlockClusters([unit1, unit2, unit3], {});
 		expect(result.has('a')).toBe(true);
@@ -154,12 +168,12 @@ describe('mergeCrossBlockClusters', () => {
 		const unit1: CrossBlockUnit = {
 			key: 'k1',
 			memberTokenSets: [tokens],
-			memberLandmarks: [noLandmarks],
+			memberLandmarkInstances: toInstances([noLandmarks]),
 		};
 		const unit2: CrossBlockUnit = {
 			key: 'k2',
 			memberTokenSets: [tokens],
-			memberLandmarks: [noLandmarks],
+			memberLandmarkInstances: toInstances([noLandmarks]),
 		};
 		const r1 = mergeCrossBlockClusters([unit1, unit2], {});
 		const r2 = mergeCrossBlockClusters([unit1, unit2], {});
@@ -172,12 +186,12 @@ describe('mergeCrossBlockClusters', () => {
 		const unit1: CrossBlockUnit = {
 			key: 'block-a',
 			memberTokenSets: [tokens],
-			memberLandmarks: [noLandmarks],
+			memberLandmarkInstances: toInstances([noLandmarks]),
 		};
 		const unit2: CrossBlockUnit = {
 			key: 'block-b',
 			memberTokenSets: [tokens],
-			memberLandmarks: [noLandmarks],
+			memberLandmarkInstances: toInstances([noLandmarks]),
 		};
 		const result = mergeCrossBlockClusters([unit1, unit2], {});
 		const rootKey = result.get('block-a')!;
@@ -193,12 +207,12 @@ describe('mergeCrossBlockClusters', () => {
 		const unit1: CrossBlockUnit = {
 			key: 'l1',
 			memberTokenSets: [tokens],
-			memberLandmarks: [landmarks],
+			memberLandmarkInstances: toInstances([landmarks]),
 		};
 		const unit2: CrossBlockUnit = {
 			key: 'l2',
 			memberTokenSets: [tokens],
-			memberLandmarks: [landmarks],
+			memberLandmarkInstances: toInstances([landmarks]),
 		};
 		const result = mergeCrossBlockClusters([unit1, unit2], {});
 		expect(result.get('l1')).toBe(result.get('l2'));
@@ -216,7 +230,7 @@ describe('mergeCrossBlockClusters shellQuorum (via mergeCrossBlockClusters exerc
 		const unit: CrossBlockUnit = {
 			key: 'k',
 			memberTokenSets: Array.from({ length: 5 }, () => tokens),
-			memberLandmarks: Array.from({ length: 5 }, () => landmarksAll),
+			memberLandmarkInstances: toInstances(Array.from({ length: 5 }, () => landmarksAll)),
 		};
 		// The clustering itself just needs to run without crashing to prove
 		// the histogram path works with a well-populated signature.
@@ -244,12 +258,12 @@ describe('mergeCrossBlockClusters shellQuorum (via mergeCrossBlockClusters exerc
 		const unitA: CrossBlockUnit = {
 			key: 'A',
 			memberTokenSets: Array.from({ length: 5 }, () => tokens),
-			memberLandmarks: landmarksList,
+			memberLandmarkInstances: toInstances(landmarksList),
 		};
 		const unitB: CrossBlockUnit = {
 			key: 'B',
 			memberTokenSets: Array.from({ length: 5 }, () => tokens),
-			memberLandmarks: landmarksList,
+			memberLandmarkInstances: toInstances(landmarksList),
 		};
 		const result = mergeCrossBlockClusters([unitA, unitB], {});
 		// Same tokens sets merge via fine stage (Jaccard = 1.0), independent
@@ -275,12 +289,12 @@ describe('mergeCrossBlockClusters shellQuorum (via mergeCrossBlockClusters exerc
 		const unitA: CrossBlockUnit = {
 			key: 'A',
 			memberTokenSets: Array.from({ length: 5 }, () => new Set(['body>main>.article'])),
-			memberLandmarks: landmarksList,
+			memberLandmarkInstances: toInstances(landmarksList),
 		};
 		const unitB: CrossBlockUnit = {
 			key: 'B',
 			memberTokenSets: Array.from({ length: 5 }, () => new Set(['body>aside>.widget'])),
-			memberLandmarks: landmarksList,
+			memberLandmarkInstances: toInstances(landmarksList),
 		};
 		const result = mergeCrossBlockClusters([unitA, unitB], {});
 		// Cores are disjoint and shells don't corroborate → A and B stay

--- a/packages/@d-zero/page-cluster/src/merge-cross-block-clusters.ts
+++ b/packages/@d-zero/page-cluster/src/merge-cross-block-clusters.ts
@@ -1,4 +1,4 @@
-import type { ExtractLandmarksResult } from './extract-landmarks.js';
+import type { PerPageLandmarkInstance } from './per-page-landmark-signatures.js';
 
 import { assignContainedClusters } from './assign-contained-clusters.js';
 import { autoCutThreshold } from './auto-cut-threshold.js';
@@ -9,17 +9,28 @@ import {
 } from './complete-linkage-dendrogram.js';
 import { computeDocumentFrequency } from './compute-document-frequency.js';
 import { jaccardSimilarity } from './jaccard-similarity.js';
-import { computePerPageLandmarkInstances } from './per-page-landmark-signatures.js';
+import { reservoirSample } from './reservoir-sample.js';
 import { shapeToken } from './shape-token.js';
 import { splitTokensByFrequency } from './split-tokens-by-frequency.js';
 
 /**
  * One cluster (post-Stage-A) entering cross-block comparison.
+ *
+ * ## Why `memberLandmarkInstances` rather than raw `ExtractLandmarksResult[]`
+ *
+ * Stage B never reads the full `ExtractLandmarksResult` — it only needs each
+ * member page's landmark instances (per-type, per-signature, per-token-set)
+ * for `shellQuorum`'s per-token page-frequency histogram. Callers pre-run
+ * {@link ./per-page-landmark-signatures.js | computePerPageLandmarkInstances}
+ * once at unit creation and hand Stage B the compact instance list instead
+ * of the ~10× larger raw landmark HTML strings. This is the single largest
+ * memory reduction the streaming path relies on: the difference between a
+ * 176k-page corpus fitting in an 8 GB heap and exhausting a 12 GB heap.
  */
 export type CrossBlockUnit = {
 	readonly key: string;
 	readonly memberTokenSets: readonly ReadonlySet<string>[];
-	readonly memberLandmarks: readonly ExtractLandmarksResult[];
+	readonly memberLandmarkInstances: readonly (readonly PerPageLandmarkInstance[])[];
 };
 
 /**
@@ -247,15 +258,14 @@ function l2Contained(xSig: Map<string, number>, ySig: Map<string, number>): bool
  * shell-corroboration jaccard between two landmark-less pages is 0 rather
  * than 1 (which it would be if we handed back a `<body></body>`-derived
  * `{body}` fallback set to both sides).
- * @param memberLandmarks
+ * @param perPageInstances
  */
 function shellQuorum(
-	memberLandmarks: readonly ExtractLandmarksResult[],
+	perPageInstances: readonly (readonly PerPageLandmarkInstance[])[],
 ): ReadonlySet<string> {
-	const pageCount = memberLandmarks.length;
+	const pageCount = perPageInstances.length;
 	if (pageCount === 0) return new Set();
 
-	const perPageInstances = computePerPageLandmarkInstances(memberLandmarks);
 	// Union all instance token sets per page (dedupe within page: a token
 	// present on both header and footer of the same page still counts once
 	// for that page's contribution).
@@ -316,28 +326,42 @@ function shellQuorum(
  * @param units Post-Stage-A clusters.
  * @param options Forwarded `similarityThreshold` (defaults to 0.8).
  * @param options.similarityThreshold
+ * @param options.capMembers
  */
 export function mergeCrossBlockClusters(
 	units: readonly CrossBlockUnit[],
-	options?: { similarityThreshold?: number },
+	options?: {
+		similarityThreshold?: number;
+		/**
+		 * Opt-in post-merge cap on a group's retained member count. When
+		 * set, each merged group is reservoir-sampled back down to this
+		 * cap after every merge so a chain of merges cannot balloon past
+		 * the per-unit cap Stage A applied at creation. Callers on the
+		 * streaming path pass the same value as `capMembers` used in
+		 * Stage A; the in-memory path omits it so validated corpora keep
+		 * full-membership merge behavior unchanged.
+		 */
+		capMembers?: number;
+	},
 ): Map<string, string> {
 	if (units.length <= 1) {
 		return new Map(units.map((u) => [u.key, u.key]));
 	}
 
 	const threshold = options?.similarityThreshold ?? CROSS_BLOCK_THRESHOLD;
+	const capMembers = options?.capMembers;
 
 	// Mutable group state: rootKey → combined member arrays
 	type GroupMembers = {
 		tokenSets: ReadonlySet<string>[];
-		landmarks: ExtractLandmarksResult[];
+		landmarkInstances: (readonly PerPageLandmarkInstance[])[];
 	};
 
 	const groups = new Map<string, GroupMembers>();
 	for (const unit of units) {
 		groups.set(unit.key, {
 			tokenSets: [...unit.memberTokenSets],
-			landmarks: [...unit.memberLandmarks],
+			landmarkInstances: [...unit.memberLandmarkInstances],
 		});
 	}
 
@@ -355,8 +379,23 @@ export function mergeCrossBlockClusters(
 			const rootG = groups.get(root);
 			if (!absorbedG || !rootG) continue;
 
-			rootG.tokenSets = [...rootG.tokenSets, ...absorbedG.tokenSets];
-			rootG.landmarks = [...rootG.landmarks, ...absorbedG.landmarks];
+			const mergedTokenSets = [...rootG.tokenSets, ...absorbedG.tokenSets];
+			const mergedLandmarkInstances = [
+				...rootG.landmarkInstances,
+				...absorbedG.landmarkInstances,
+			];
+			// Only down-sample when the caller explicitly opts in (streaming
+			// path). Same-index sampling keeps memberTokenSets[i] and
+			// landmarkInstances[i] parallel.
+			if (capMembers !== undefined && mergedTokenSets.length > capMembers) {
+				const indices = mergedTokenSets.map((_, i) => i);
+				const kept = reservoirSample(indices, capMembers, root);
+				rootG.tokenSets = kept.map((i) => mergedTokenSets[i]!);
+				rootG.landmarkInstances = kept.map((i) => mergedLandmarkInstances[i]!);
+			} else {
+				rootG.tokenSets = mergedTokenSets;
+				rootG.landmarkInstances = mergedLandmarkInstances;
+			}
 			groups.delete(absorbed);
 
 			for (const [origKey, cur] of keyToRoot) {
@@ -517,7 +556,7 @@ export function mergeCrossBlockClusters(
 
 		const getShell = (key: string): ReadonlySet<string> => {
 			if (!shellCache.has(key)) {
-				shellCache.set(key, shellQuorum(groups.get(key)?.landmarks ?? []));
+				shellCache.set(key, shellQuorum(groups.get(key)?.landmarkInstances ?? []));
 			}
 			return shellCache.get(key) ?? new Set();
 		};

--- a/packages/@d-zero/page-cluster/src/pass0-blocking.spec.ts
+++ b/packages/@d-zero/page-cluster/src/pass0-blocking.spec.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from 'vitest';
+
+import { groupIndicesByBlockKey, resolveBlockKeys } from './pass0-blocking.js';
+
+describe('resolveBlockKeys', () => {
+	test('returns one block key per input page in order', () => {
+		// Third page with a *different* stylesheet keeps a.css from being
+		// 100%-common, so its frequency stays below the common-href cutoff
+		// and it survives as a distinctive css: signal for the first two.
+		const keys = resolveBlockKeys([
+			{ paths: ['news', '1'], stylesheetHrefs: ['https://example.com/a.css'] },
+			{ paths: ['news', '2'], stylesheetHrefs: ['https://example.com/a.css'] },
+			{ paths: ['about'], stylesheetHrefs: ['https://example.com/b.css'] },
+		]);
+		expect(keys).toHaveLength(3);
+		expect(keys[0]).toBe(keys[1]);
+		expect(keys[0]).toMatch(/^css:/);
+		// b.css appears on only one page — below minCssGroupSize=2, so it
+		// falls back to path.
+		expect(keys[2]).toBe('path:about');
+	});
+
+	test('orphan (empty stylesheetHrefs) gets reassigned to same-section css block by default', () => {
+		const pages = [
+			{
+				paths: ['news', '1'],
+				stylesheetHrefs: ['https://example.com/a.css', 'https://example.com/shared.css'],
+			},
+			{
+				paths: ['news', '2'],
+				stylesheetHrefs: ['https://example.com/a.css', 'https://example.com/shared.css'],
+			},
+			{
+				paths: ['news', '3'],
+				stylesheetHrefs: ['https://example.com/shared.css'],
+			},
+			// Third-differently-styled page anchors the frequency filter so
+			// shared.css isn't 100% and a.css stays distinctive.
+			{
+				paths: ['about'],
+				stylesheetHrefs: ['https://example.com/b.css', 'https://example.com/shared.css'],
+			},
+			// Orphan (no stylesheets) in the news section — should join the
+			// news css: block via orphan reassignment.
+			{ paths: ['news', '4'], stylesheetHrefs: [] },
+		];
+		const keys = resolveBlockKeys(pages);
+		// reassignOrphanBlockKeys retags every member of the reassigned
+		// css: block with the orphan-merge: prefix so the block pool is
+		// visibly renamed once an orphan joins — the whole news section
+		// shares one orphan-merge: key rather than a mix.
+		expect(keys[0]).toMatch(/^orphan-merge:/);
+		expect(keys[0]).toBe(keys[4]);
+	});
+
+	test('reassignOrphans: false leaves orphan on path key', () => {
+		const pages = [
+			{
+				paths: ['news', '1'],
+				stylesheetHrefs: ['https://example.com/a.css', 'https://example.com/shared.css'],
+			},
+			{
+				paths: ['news', '2'],
+				stylesheetHrefs: ['https://example.com/a.css', 'https://example.com/shared.css'],
+			},
+			{
+				paths: ['about'],
+				stylesheetHrefs: ['https://example.com/b.css', 'https://example.com/shared.css'],
+			},
+			{ paths: ['news', '4'], stylesheetHrefs: [] },
+		];
+		const keys = resolveBlockKeys(pages, { reassignOrphans: false });
+		expect(keys[3]).toBe('path:news');
+	});
+
+	test('per-page host lets third-party fonts get filtered out before blocking', () => {
+		// Both pages load their site's own first-party stylesheet plus a
+		// third-party font. Without filtering, the font shows up as a
+		// distinctive shared href and can affect css: key generation.
+		// With `host` provided, direct comparison drops fonts.googleapis.com.
+		const pages = [
+			{
+				paths: ['a'],
+				host: 'example.com',
+				stylesheetHrefs: [
+					'https://example.com/a.css',
+					'https://fonts.googleapis.com/css?family=x',
+				],
+			},
+			{
+				paths: ['a'],
+				host: 'example.com',
+				stylesheetHrefs: [
+					'https://example.com/a.css',
+					'https://fonts.googleapis.com/css?family=x',
+				],
+			},
+		];
+		const keys = resolveBlockKeys(pages);
+		expect(keys[0]).toBe(keys[1]);
+	});
+
+	test('empty input returns empty array', () => {
+		expect(resolveBlockKeys([])).toEqual([]);
+	});
+});
+
+describe('groupIndicesByBlockKey', () => {
+	test('groups indices by key, preserving first-seen order of keys and input order within each', () => {
+		const groups = groupIndicesByBlockKey(['a', 'b', 'a', 'c', 'a', 'b']);
+		expect([...groups.keys()]).toEqual(['a', 'b', 'c']);
+		expect(groups.get('a')).toEqual([0, 2, 4]);
+		expect(groups.get('b')).toEqual([1, 5]);
+		expect(groups.get('c')).toEqual([3]);
+	});
+
+	test('empty input returns empty map', () => {
+		const groups = groupIndicesByBlockKey([]);
+		expect(groups.size).toBe(0);
+	});
+});

--- a/packages/@d-zero/page-cluster/src/pass0-blocking.ts
+++ b/packages/@d-zero/page-cluster/src/pass0-blocking.ts
@@ -1,0 +1,125 @@
+import type { ResolveBlockingGroupKeysOptions } from './resolve-blocking-group-keys.js';
+
+import { filterFirstPartyStylesheetHrefs } from './filter-first-party-stylesheet-hrefs.js';
+import { reassignOrphanBlockKeys } from './reassign-orphan-block-keys.js';
+import { resolveBlockingGroupKeys } from './resolve-blocking-group-keys.js';
+
+/**
+ * The corpus-wide, HTML-free inputs needed by
+ * {@link ./pass0-blocking.js | resolveBlockKeys}: the blocking signals plus
+ * the page's own URL host. The full `PageClusterSignals` type carries `html`
+ * on top of these, but Pass 0 deliberately does not read HTML — the whole
+ * point of extracting the blocking step is that it can be run before any
+ * per-page HTML is held in memory.
+ */
+export type Pass0PageSignals = {
+	readonly paths: readonly string[];
+	readonly stylesheetHrefs: readonly string[];
+	readonly host?: string;
+};
+
+/**
+ * @see resolveBlockKeys
+ */
+export type ResolveBlockKeysOptions = ResolveBlockingGroupKeysOptions & {
+	/**
+	 * Apply {@link ./reassign-orphan-block-keys.js | reassignOrphanBlockKeys}
+	 * to the blocking keys, so a page with no recorded stylesheets can rejoin
+	 * a same-URL-section `css:` block instead of being stranded on its weaker
+	 * `path:` fallback. Defaults to `true`.
+	 */
+	readonly reassignOrphans?: boolean;
+	/**
+	 * Apply {@link ./filter-first-party-stylesheet-hrefs.js |
+	 * filterFirstPartyStylesheetHrefs} to `pages` before computing blocking
+	 * keys, so a page's incidental third-party embeds do not contaminate the
+	 * blocking signal. Defaults to `true`.
+	 */
+	readonly restrictStylesheetsToFirstParty?: boolean;
+};
+
+/**
+ * Splits `resolvePageClusterKeys` into a size-flat first pass so the driver
+ * can decide per-block memory strategy before loading any page HTML. Runs the
+ * three corpus-wide, HTML-free stages of blocking in the same order the
+ * in-memory driver already uses — first-party stylesheet filtering, blocking-
+ * key derivation, orphan reassignment — and returns one final block key per
+ * input page in input order.
+ *
+ * ## Why extract this from resolvePageClusterKeys?
+ *
+ * The in-memory driver holds every page's `html`, `remainderHtml`,
+ * `landmarks[]`, and pre-Stage-A prepared HTML at once. At 176k pages × ~57
+ * KB average, that alone breaks a 17 GB RAM machine well before Stage A
+ * starts (measured: OS SIGKILL at ~15,000 pages, before the resolve phase
+ * even began). All three blocking stages, in contrast, depend only on
+ * `paths` / `stylesheetHrefs` / `host` — a few hundred bytes per page. Running
+ * them first, HTML-free, lets the downstream per-block clustering hold HTML
+ * for only one block's pages at a time.
+ *
+ * ## Preserves in-memory driver semantics exactly
+ *
+ * The output of this function is byte-identical to the block-key portion of
+ * the current `resolvePageClusterKeys` for the same input, because it reuses
+ * the same three underlying functions in the same order with the same
+ * defaults. That guarantee is load-bearing: the size-threshold-gated Pass 1
+ * that follows this function runs the current in-memory implementation
+ * unchanged for small blocks, and any drift in block-key computation between
+ * Pass 0 and Pass 1 would silently misroute pages between the two paths.
+ * @param pages
+ * @param options
+ * @example
+ * ```ts
+ * const blockKeys = resolveBlockKeys([
+ *   { paths: ['news', '1'], stylesheetHrefs: ['/a.css'], host: 'example.com' },
+ *   { paths: ['news', '2'], stylesheetHrefs: ['/a.css'], host: 'example.com' },
+ *   { paths: ['about'],     stylesheetHrefs: [],        host: 'example.com' },
+ * ]);
+ * // ['css:<hash>', 'css:<hash>', 'path:about']
+ * ```
+ */
+export function resolveBlockKeys(
+	pages: readonly Pass0PageSignals[],
+	options?: ResolveBlockKeysOptions,
+): string[] {
+	const restrictStylesheetsToFirstParty =
+		options?.restrictStylesheetsToFirstParty ?? true;
+	const blockingPages = restrictStylesheetsToFirstParty
+		? filterFirstPartyStylesheetHrefs(pages)
+		: pages;
+
+	const rawBlockKeys = resolveBlockingGroupKeys(blockingPages, options);
+	const reassignOrphans = options?.reassignOrphans ?? true;
+	return reassignOrphans
+		? reassignOrphanBlockKeys(blockingPages, rawBlockKeys, options?.pathDepth)
+		: rawBlockKeys;
+}
+
+/**
+ * Groups pages by their block key while preserving each block's members in
+ * input order. Returned as a `Map` so the caller can iterate blocks in
+ * insertion order (first-seen block first) — matching the order
+ * `resolvePageClusterKeys`'s own per-block loop already uses so cluster IDs
+ * assigned per block stay deterministic across in-memory and streaming
+ * paths.
+ * @param blockKeys
+ * @example
+ * ```ts
+ * const indices = groupIndicesByBlockKey(['a', 'b', 'a', 'c', 'a']);
+ * // Map { 'a' => [0, 2, 4], 'b' => [1], 'c' => [3] }
+ * ```
+ */
+export function groupIndicesByBlockKey(
+	blockKeys: readonly string[],
+): Map<string, number[]> {
+	const groups = new Map<string, number[]>();
+	for (const [index, blockKey] of blockKeys.entries()) {
+		const list = groups.get(blockKey);
+		if (list) {
+			list.push(index);
+		} else {
+			groups.set(blockKey, [index]);
+		}
+	}
+	return groups;
+}

--- a/packages/@d-zero/page-cluster/src/reservoir-sample.spec.ts
+++ b/packages/@d-zero/page-cluster/src/reservoir-sample.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'vitest';
+
+import { reservoirSample } from './reservoir-sample.js';
+
+describe('reservoirSample', () => {
+	test('returns the requested number of items', () => {
+		const items = Array.from({ length: 100 }, (_, i) => i);
+		const result = reservoirSample(items, 10, 'seed');
+		expect(result).toHaveLength(10);
+	});
+
+	test('is deterministic for the same seed', () => {
+		const items = Array.from({ length: 100 }, (_, i) => i);
+		const a = reservoirSample(items, 10, 'seed');
+		const b = reservoirSample(items, 10, 'seed');
+		expect(a).toEqual(b);
+	});
+
+	test('different seeds produce different samples on large inputs', () => {
+		const items = Array.from({ length: 100 }, (_, i) => i);
+		const a = reservoirSample(items, 10, 'block-a');
+		const b = reservoirSample(items, 10, 'block-b');
+		expect(a).not.toEqual(b);
+	});
+
+	test('preserves input order in the returned sample', () => {
+		const items = Array.from({ length: 100 }, (_, i) => i);
+		const result = reservoirSample(items, 10, 'seed');
+		for (let i = 1; i < result.length; i++) {
+			expect(result[i]).toBeGreaterThan(result[i - 1] as number);
+		}
+	});
+
+	test('sampleSize >= items.length returns the full list in original order without invoking the PRNG', () => {
+		const items = [7, 2, 5, 1];
+		const result = reservoirSample(items, 10, 'ignored-seed');
+		expect(result).toEqual(items);
+	});
+
+	test('sampleSize === items.length returns full list in original order', () => {
+		const items = [7, 2, 5, 1];
+		const result = reservoirSample(items, 4, 'ignored-seed');
+		expect(result).toEqual(items);
+	});
+
+	test('sampleSize 0 returns empty', () => {
+		const items = [1, 2, 3];
+		expect(reservoirSample(items, 0, 'x')).toEqual([]);
+	});
+
+	test('empty items returns empty', () => {
+		expect(reservoirSample([], 10, 'x')).toEqual([]);
+	});
+
+	test('numeric seed produces identical output to hashed string seed for the same underlying value (self-consistent)', () => {
+		const items = Array.from({ length: 100 }, (_, i) => i);
+		const withZero = reservoirSample(items, 5, 0);
+		const withZeroAgain = reservoirSample(items, 5, 0);
+		expect(withZero).toEqual(withZeroAgain);
+	});
+
+	test('rejects fractional or negative sampleSize', () => {
+		expect(() => reservoirSample([1, 2, 3], -1, 'x')).toThrow(RangeError);
+		expect(() => reservoirSample([1, 2, 3], 1.5, 'x')).toThrow(RangeError);
+	});
+});

--- a/packages/@d-zero/page-cluster/src/reservoir-sample.ts
+++ b/packages/@d-zero/page-cluster/src/reservoir-sample.ts
@@ -1,0 +1,108 @@
+/**
+ * Mulberry32 — a tiny, well-known 32-bit PRNG. Chosen because it fits in a
+ * closure, seeds from a single 32-bit integer (so the caller can derive it
+ * deterministically from something stable like a block key), and produces a
+ * uniform enough sequence for reservoir sampling. Not cryptographic; that is
+ * not what this file needs.
+ * @param seed
+ */
+function mulberry32(seed: number): () => number {
+	let state = seed >>> 0;
+	return () => {
+		state = (state + 0x6d_2b_79_f5) >>> 0;
+		let t = state;
+		t = Math.imul(t ^ (t >>> 15), t | 1);
+		t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+		return ((t ^ (t >>> 14)) >>> 0) / 4_294_967_296;
+	};
+}
+
+/**
+ * FNV-1a 32-bit hash of a string, used as the default seed source for
+ * {@link ./reservoir-sample.js | reservoirSample} when the caller passes a
+ * `string` seed. Small, dependency-free, and deterministic across runs and
+ * machines — the whole point of using it as a seed is that a block key like
+ * `"orphan-merge:news"` always samples the same subset of members.
+ * @param input
+ */
+function fnv1a32(input: string): number {
+	let hash = 0x81_1c_9d_c5;
+	for (let i = 0; i < input.length; i++) {
+		hash ^= input.codePointAt(i) ?? 0;
+		hash = Math.imul(hash, 0x01_00_01_93);
+	}
+	return hash >>> 0;
+}
+
+/**
+ * Runs Algorithm R (Vitter, 1985) — the standard one-pass reservoir sampling
+ * algorithm — to pick `sampleSize` items from `items`, deterministically for
+ * a given `seed`. Returns them in input order.
+ *
+ * ## Why deterministic
+ *
+ * `resolvePageClusterKeys`'s cluster keys must be reproducible: given the
+ * same input pages in the same order, subsequent runs must produce the same
+ * cluster keys, or downstream code that stores/compares them by value
+ * silently drifts across runs. `Math.random()` violates that outright.
+ * Reservoir sampling on top of a seedable PRNG (see {@link ./reservoir-sample.js | mulberry32})
+ * preserves determinism while retaining reservoir sampling's O(1)-space,
+ * one-pass memory profile — the whole point of using it in the first place
+ * (a block too large for full in-memory processing must not require
+ * per-page auxiliary state for sampling either).
+ *
+ * ## Seed handling
+ *
+ * A `number` seed is used as-is; a `string` seed is hashed via
+ * {@link ./reservoir-sample.js | fnv1a32} first so the caller can pass a
+ * stable identifier (e.g. a block key like `"orphan-merge:news"`) without
+ * having to compute a numeric hash itself. Different blocks get different
+ * samples by passing each block's key as the seed.
+ *
+ * ## Edge cases
+ *
+ * - `sampleSize <= 0` — returns `[]`.
+ * - `sampleSize >= items.length` — returns all of `items` in input order,
+ *   without invoking the PRNG. This matters for regression: a block small
+ *   enough to fit its whole membership in the sample must not have items
+ *   reordered by any sampling logic, so downstream cluster labels stay in
+ *   the same first-seen order as the in-memory path.
+ * @param items
+ * @param sampleSize
+ * @param seed
+ * @example
+ * ```ts
+ * const sample = reservoirSample([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], 3, 'block-a');
+ * // deterministic 3-item subset, always the same for seed 'block-a'
+ * ```
+ */
+export function reservoirSample<T>(
+	items: readonly T[],
+	sampleSize: number,
+	seed: number | string = 0,
+): T[] {
+	if (!(Number.isInteger(sampleSize) && sampleSize >= 0)) {
+		throw new RangeError(
+			`reservoirSample: sampleSize must be a non-negative integer, got ${sampleSize}`,
+		);
+	}
+	if (sampleSize === 0 || items.length === 0) return [];
+	if (sampleSize >= items.length) return [...items];
+
+	const numericSeed = typeof seed === 'string' ? fnv1a32(seed) : seed >>> 0;
+	const rand = mulberry32(numericSeed);
+
+	// Reservoir holds the picked positions (indices into `items`); we return
+	// items sorted by those positions to preserve input order in the result.
+	const reservoirIndices: number[] = Array.from({ length: sampleSize }, (_, i) => i);
+
+	for (let i = sampleSize; i < items.length; i++) {
+		const j = Math.floor(rand() * (i + 1));
+		if (j < sampleSize) {
+			reservoirIndices[j] = i;
+		}
+	}
+
+	reservoirIndices.sort((a, b) => a - b);
+	return reservoirIndices.map((position) => items[position] as T);
+}

--- a/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys-streaming.spec.ts
+++ b/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys-streaming.spec.ts
@@ -1,0 +1,125 @@
+import type { PageClusterSignals } from './resolve-page-cluster-keys.js';
+
+import { describe, expect, test } from 'vitest';
+
+import {
+	CORPUS_INLINE_THRESHOLD,
+	resolvePageClusterKeys,
+	resolvePageClusterKeysFromArray,
+	resolvePageClusterKeysInMemory,
+} from './resolve-page-cluster-keys.js';
+
+/**
+ * Builds a small `PageClusterSignals[]` fixture with three visible template
+ * families and a section split so the returned cluster keys will actually
+ * vary. Small enough to stay under `CORPUS_INLINE_THRESHOLD`.
+ */
+function buildTinyCorpus(): PageClusterSignals[] {
+	const pages: PageClusterSignals[] = [];
+	// news template A
+	for (let i = 0; i < 3; i++) {
+		pages.push({
+			paths: ['news', String(i)],
+			stylesheetHrefs: ['https://x.example.com/news.css'],
+			html: `<body><article><h1>News ${i}</h1><p>body</p></article><footer>f</footer></body>`,
+		});
+	}
+	// about page
+	pages.push(
+		{
+			paths: ['about'],
+			stylesheetHrefs: ['https://x.example.com/about.css'],
+			html: `<body><section><h1>About</h1><p>text</p></section><footer>f</footer></body>`,
+		},
+		{
+			paths: ['contact'],
+			stylesheetHrefs: ['https://x.example.com/contact.css'],
+			html: `<body><form><label>Name</label><input><button>Send</button></form></body>`,
+		},
+	);
+	return pages;
+}
+
+describe('resolvePageClusterKeys (async factory)', () => {
+	test('empty input returns empty result', async () => {
+		const keys = await resolvePageClusterKeys(() => []);
+		expect(keys).toEqual([]);
+	});
+
+	test('small corpus matches resolvePageClusterKeysInMemory exactly', async () => {
+		const pages = buildTinyCorpus();
+		const streamed = await resolvePageClusterKeys(() => pages);
+		const inMemory = resolvePageClusterKeysInMemory(pages);
+		expect(streamed).toEqual(inMemory);
+	});
+
+	test('async iterable factory works', async () => {
+		const pages = buildTinyCorpus();
+		/**
+		 *
+		 */
+		async function* asyncPages(): AsyncGenerator<PageClusterSignals> {
+			for (const page of pages) {
+				// An `await` on any expression suffices to make this a valid
+				// async generator per @typescript-eslint/require-await; passing
+				// a resolved Promise keeps behavior identical to a plain yield.
+				yield await Promise.resolve(page);
+			}
+		}
+		const streamed = await resolvePageClusterKeys(() => asyncPages());
+		const inMemory = resolvePageClusterKeysInMemory(pages);
+		expect(streamed).toEqual(inMemory);
+	});
+
+	test('single-shot factory (small corpus stays under threshold, factory invoked twice)', async () => {
+		let calls = 0;
+		const pages = buildTinyCorpus();
+		/**
+		 *
+		 */
+		function factory() {
+			calls++;
+			return pages;
+		}
+		await resolvePageClusterKeys(factory);
+		// Small corpus takes the in-memory path, which invokes the factory
+		// exactly twice (once for blocking signals, once for full pages).
+		expect(calls).toBe(2);
+	});
+
+	test('mergeRareLandmarkClusters is rejected in streaming mode', async () => {
+		const pages: PageClusterSignals[] = Array.from(
+			{ length: CORPUS_INLINE_THRESHOLD + 1 },
+			(_, i) => ({
+				paths: ['x', String(i)],
+				stylesheetHrefs: [],
+				html: `<body><section>${i}</section></body>`,
+			}),
+		);
+		await expect(
+			resolvePageClusterKeys(() => pages, { mergeRareLandmarkClusters: true }),
+		).rejects.toThrow(/mergeRareLandmarkClusters is not supported in streaming mode/);
+	});
+
+	test('mergeRareLandmarkClusters is allowed when the small-corpus path is taken', async () => {
+		const pages = buildTinyCorpus();
+		// Should not throw — small corpus routes to resolvePageClusterKeysInMemory
+		// which accepts mergeRareLandmarkClusters.
+		await expect(
+			resolvePageClusterKeys(() => pages, { mergeRareLandmarkClusters: true }),
+		).resolves.toBeInstanceOf(Array);
+	});
+});
+
+describe('resolvePageClusterKeysFromArray', () => {
+	test('produces the same result as resolvePageClusterKeysInMemory on the same input', async () => {
+		const pages = buildTinyCorpus();
+		const fromArray = await resolvePageClusterKeysFromArray(pages);
+		const inMemory = resolvePageClusterKeysInMemory(pages);
+		expect(fromArray).toEqual(inMemory);
+	});
+
+	test('empty input returns empty', async () => {
+		expect(await resolvePageClusterKeysFromArray([])).toEqual([]);
+	});
+});

--- a/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys.spec.ts
+++ b/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
-import { resolvePageClusterKeys } from './resolve-page-cluster-keys.js';
+import { resolvePageClusterKeysInMemory as resolvePageClusterKeys } from './resolve-page-cluster-keys.js';
 
 describe('resolvePageClusterKeys', () => {
 	test('an empty page list returns an empty array', () => {

--- a/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys.ts
+++ b/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys.ts
@@ -4,55 +4,131 @@ import type { ResolveBlockingGroupKeysOptions } from './resolve-blocking-group-k
 import type { ResolveStructuralClusterKeysOptions } from './resolve-structural-cluster-keys.js';
 import type { TokenizeOptions } from './types.js';
 
-import { assignContainedClusters } from './assign-contained-clusters.js';
 import { autoCutThreshold } from './auto-cut-threshold.js';
 import { capContentDepth } from './cap-content-depth.js';
-import { collapseAnonymousDivs } from './collapse-anonymous-divs.js';
-import {
-	completeLinkageDendrogram,
-	labelsAtThreshold,
-} from './complete-linkage-dendrogram.js';
-import {
-	deriveComparisonSets,
-	MIN_PAGE_COUNT_FOR_FREQUENCY_SPLIT,
-} from './derive-comparison-sets.js';
 import {
 	detectContentDepthCap,
 	validateDetectContentDepthCapOptions,
 } from './detect-content-depth-cap.js';
 import { extractLandmarks } from './extract-landmarks.js';
 import { filterFirstPartyStylesheetHrefs } from './filter-first-party-stylesheet-hrefs.js';
+import { jaccardSimilarity } from './jaccard-similarity.js';
 import { mergeCrossBlockClusters } from './merge-cross-block-clusters.js';
 import {
 	mergeLandmarkAffinedClusters,
 	validateMergeLandmarkAffinedClustersOptions,
 } from './merge-landmark-affined-clusters.js';
+import { groupIndicesByBlockKey, resolveBlockKeys } from './pass0-blocking.js';
 import { computePerPageLandmarkInstances } from './per-page-landmark-signatures.js';
-import { reassignOrphanBlockKeys } from './reassign-orphan-block-keys.js';
 import { removeContentBlocks } from './remove-content-blocks.js';
-import { resolveBlockingGroupKeys } from './resolve-blocking-group-keys.js';
+import { stageAPerBlock } from './stage-a-per-block.js';
 import { tokenize } from './tokenize.js';
 
 /**
- * Reads `values[index]`, throwing instead of returning `undefined`. Every
- * call site here indexes with a position this function generated itself
- * (an entry from `Map#entries()`/`Array#entries()` over an array it just
- * built), so the thrown branch is unreachable in practice; it exists to
- * satisfy `noUncheckedIndexedAccess` without a non-null assertion. Not
- * imported from `resolve-structural-cluster-keys.ts`'s own copy: that file's
- * `export`s are its intended public API surface, and this ~7-line generic
- * helper isn't worth carving an exception into that boundary for (same
- * rationale as `readDpValue` in `array-edit-distance.ts` being its own
- * independent copy rather than a shared import).
- * @param values
- * @param index
+ * FNV-1a 32-bit hash of a string, used to seed the per-block PRNG so
+ * reservoir sampling on the streaming path is deterministic for a given
+ * corpus (same input order → same sampled indices → same cluster keys).
+ * @param input
  */
-function requireIndex<T>(values: ArrayLike<T>, index: number): T {
-	const value = values[index];
-	if (value === undefined) {
-		throw new Error('resolvePageClusterKeys: index out of bounds');
+function fnv1a32(input: string): number {
+	let hash = 0x81_1c_9d_c5;
+	for (let i = 0; i < input.length; i++) {
+		hash ^= input.codePointAt(i) ?? 0;
+		hash = Math.imul(hash, 0x01_00_01_93);
 	}
-	return value;
+	return hash >>> 0;
+}
+
+/**
+ * Mulberry32 — small, well-known 32-bit PRNG. Kept independent per block
+ * (each block seeds from its own block key via {@link ./resolve-page-cluster-keys.js | fnv1a32})
+ * so different blocks sample independently.
+ * @param seed
+ */
+function makeSeededPrng(seed: number | string): () => number {
+	let state = (typeof seed === 'string' ? fnv1a32(seed) : seed) >>> 0;
+	return () => {
+		state = (state + 0x6d_2b_79_f5) >>> 0;
+		let t = state;
+		t = Math.imul(t ^ (t >>> 15), t | 1);
+		t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+		return ((t ^ (t >>> 14)) >>> 0) / 4_294_967_296;
+	};
+}
+
+/**
+ * Tokenizes a non-sample page using the block's learned parameters
+ * (`maxMainDepth` and local-signature reinjection set) and returns the
+ * key of the sample-derived cluster whose members it most closely matches
+ * by Jaccard similarity. Ties break in first-seen order (JS `Map`
+ * iteration). Falls back to a block-scoped singleton key when the block
+ * has no clusters at all (edge case: an empty sample, which shouldn't
+ * happen for a non-empty block but is defended against here).
+ * @param html
+ * @param assignment
+ * @param assignment.maxMainDepth
+ * @param assignment.localSignatures
+ * @param assignment.clustersByUnitKey
+ * @param excludeLandmarks
+ * @param contentBlockAttribute
+ * @param tokenizeOptions
+ * @param blockKey
+ */
+function assignPageToNearestCluster(
+	html: string,
+	assignment: {
+		readonly maxMainDepth: number | undefined;
+		readonly localSignatures: ReadonlySet<string>;
+		readonly clustersByUnitKey: ReadonlyMap<string, readonly ReadonlySet<string>[]>;
+	},
+	excludeLandmarks: boolean,
+	contentBlockAttribute: string | undefined,
+	tokenizeOptions: TokenizeOptions | undefined,
+	blockKey: string,
+): string {
+	const landmarkResult = extractLandmarks(html);
+	const landmarksExcised = excludeLandmarks ? landmarkResult.remainderHtml : html;
+	let prepared =
+		contentBlockAttribute === undefined
+			? landmarksExcised
+			: removeContentBlocks(landmarksExcised, { blockAttribute: contentBlockAttribute })
+					.remainderHtml;
+	if (assignment.maxMainDepth !== undefined) {
+		prepared = capContentDepth(prepared, {
+			landmark: 'main',
+			maxDepth: assignment.maxMainDepth,
+		}).remainderHtml;
+	}
+
+	const pageTokens = new Set(tokenize(prepared, tokenizeOptions).tokens);
+	// Reinject tokens for landmark instances whose signature matches the
+	// block's learned local-signature set (same rule the sample-side Stage
+	// A applied via computeLocalChromeArtifacts).
+	if (assignment.localSignatures.size > 0) {
+		const instances = computePerPageLandmarkInstances(
+			[landmarkResult],
+			tokenizeOptions,
+		)[0]!;
+		for (const inst of instances) {
+			if (!assignment.localSignatures.has(inst.signature)) continue;
+			for (const t of inst.tokens) pageTokens.add(t);
+		}
+	}
+
+	let bestKey: string | undefined;
+	let bestScore = -1;
+	for (const [unitKey, memberTokenSets] of assignment.clustersByUnitKey) {
+		let clusterBest = 0;
+		for (const memberTokens of memberTokenSets) {
+			const score = jaccardSimilarity(pageTokens, memberTokens);
+			if (score > clusterBest) clusterBest = score;
+		}
+		if (clusterBest > bestScore) {
+			bestScore = clusterBest;
+			bestKey = unitKey;
+		}
+	}
+	return bestKey ?? JSON.stringify([blockKey, 'cluster:unassigned']);
 }
 
 /**
@@ -104,12 +180,26 @@ function requireIndex<T>(values: ArrayLike<T>, index: number): T {
  * @param landmarks
  * @param tokenizeOptions
  */
-function computeLocalLandmarkTokens(
+/**
+ * Companion to {@link ./resolve-page-cluster-keys.js | computeLocalLandmarkTokens}
+ * that also returns the local-signature *set* the streaming path needs to
+ * reuse when tokenizing non-sample pages during Pass 1b. The in-memory path
+ * only cares about the per-page token sets (which pages carry which
+ * chrome-below-the-cut tokens); the streaming path additionally needs to
+ * apply the *same* "which signatures are local" verdict to pages that were
+ * not part of the sample the verdict was learned from.
+ * @param landmarks
+ * @param tokenizeOptions
+ */
+export function computeLocalChromeArtifacts(
 	landmarks: readonly ExtractLandmarksResult[],
 	tokenizeOptions: TokenizeOptions | undefined,
-): ReadonlySet<string>[] {
+): {
+	readonly localSignatures: ReadonlySet<string>;
+	readonly localTokensByPage: readonly ReadonlySet<string>[];
+} {
 	const pageCount = landmarks.length;
-	if (pageCount === 0) return [];
+	if (pageCount === 0) return { localSignatures: new Set(), localTokensByPage: [] };
 
 	const perPageInstances = computePerPageLandmarkInstances(landmarks, tokenizeOptions);
 
@@ -130,7 +220,12 @@ function computeLocalLandmarkTokens(
 			}
 		}
 	}
-	if (corpusHistogram.size === 0) return landmarks.map(() => new Set<string>());
+	if (corpusHistogram.size === 0) {
+		return {
+			localSignatures: new Set(),
+			localTokensByPage: landmarks.map(() => new Set<string>()),
+		};
+	}
 
 	const frequencies: number[] = [];
 	for (const entry of corpusHistogram.values()) {
@@ -146,10 +241,13 @@ function computeLocalLandmarkTokens(
 		}
 	}
 	if (localSignatures.size === 0) {
-		return landmarks.map(() => new Set<string>());
+		return {
+			localSignatures: new Set(),
+			localTokensByPage: landmarks.map(() => new Set<string>()),
+		};
 	}
 
-	return perPageInstances.map((instances) => {
+	const localTokensByPage = perPageInstances.map((instances) => {
 		const out = new Set<string>();
 		for (const inst of instances) {
 			if (!localSignatures.has(inst.signature)) continue;
@@ -157,16 +255,34 @@ function computeLocalLandmarkTokens(
 		}
 		return out;
 	});
+
+	return { localSignatures, localTokensByPage };
+}
+
+/**
+ * Reinjects each page's *local* (non-corpus-wide) landmark-instance tokens
+ * into its block token set for Stage A clustering, restoring exactly the
+ * structural signal that landmark excision removed for those pages while
+ * keeping global chrome removed (the whole point of `excludeLandmarks`).
+ *
+ * See {@link ./resolve-page-cluster-keys.js | computeLocalChromeArtifacts}
+ * for the underlying algorithm — this function is a thin wrapper that
+ * discards the local-signature set, exposed for callers that only need the
+ * per-page tokens (the in-memory driver's use case).
+ * @param landmarks
+ * @param tokenizeOptions
+ */
+export function computeLocalLandmarkTokens(
+	landmarks: readonly ExtractLandmarksResult[],
+	tokenizeOptions: TokenizeOptions | undefined,
+): ReadonlySet<string>[] {
+	return [...computeLocalChromeArtifacts(landmarks, tokenizeOptions).localTokensByPage];
 }
 
 /**
  * Per-page input to {@link ./resolve-page-cluster-keys.js | resolvePageClusterKeys}:
  * the blocking signals {@link ./resolve-blocking-group-keys.js | resolveBlockingGroupKeys}
- * needs, plus the page's raw HTML. Raw HTML (rather than a pre-tokenized
- * `Set`, as earlier versions of this type required) because
- * `resolvePageClusterKeys` now needs to decide *how* to tokenize each page
- * (see `excludeLandmarks` below) — a decision a caller handed a bare
- * `Set<string>` could no longer make correctly on its own.
+ * needs, plus the page's raw HTML.
  */
 export type PageClusterSignals = {
 	paths: readonly string[];
@@ -177,11 +293,7 @@ export type PageClusterSignals = {
 	 * `new URL(pageUrl).host`), forwarded to
 	 * {@link ./filter-first-party-stylesheet-hrefs.js | filterFirstPartyStylesheetHrefs}
 	 * so it can judge that page's `stylesheetHrefs` by direct comparison
-	 * instead of inferring a batch-wide dominant host. Optional: omit if the
-	 * caller doesn't have each page's URL on hand, at the cost of that
-	 * function's dominant-host fallback and its known limitations (see its
-	 * own JSDoc) — most crawlers already have this since they fetched the
-	 * page from that URL, so providing it is the expected default.
+	 * instead of inferring a batch-wide dominant host.
 	 */
 	host?: string;
 };
@@ -192,255 +304,99 @@ export type PageClusterSignals = {
 export type ResolvePageClusterKeysOptions = TokenizeOptions &
 	ResolveBlockingGroupKeysOptions &
 	ResolveStructuralClusterKeysOptions & {
-		/**
-		 * Tokenize each page's `<header>`/`<footer>`/`<nav>`/`<aside>`-excised
-		 * remainder ({@link ./extract-landmarks.js | extractLandmarks}'s
-		 * `remainderHtml`) instead of its raw HTML, so shared site chrome never
-		 * reaches the structural-similarity comparison. Defaults to `true`.
-		 * Set to `false` to fall back to tokenizing the untouched page (the
-		 * pre-landmark-extraction behavior) — this is a large behavioral
-		 * change not yet validated across many sites beyond the two real
-		 * corpora checked so far, so the escape hatch is kept available.
-		 *
-		 * Leaving this `true` means every page's HTML is parsed twice (once by
-		 * `extractLandmarks`, once by `tokenize` on its `remainderHtml`)
-		 * instead of once. Measured on a real crawl corpus (8,936 pages),
-		 * this is still net faster overall than the single-parse `false`
-		 * path (17,557ms vs 25,997ms end-to-end): `remainderHtml` is
-		 * substantially shorter than the original page once landmarks are
-		 * excised, and the resulting smaller `tokenize` pass costs less than
-		 * the extra `extractLandmarks` pass adds.
-		 */
 		excludeLandmarks?: boolean;
-		/**
-		 * Apply {@link ./reassign-orphan-block-keys.js | reassignOrphanBlockKeys}
-		 * to the blocking keys before clustering, so a page with no recorded
-		 * stylesheets ("orphan" — often a crawl-completeness gap, not evidence
-		 * the page is actually template-less) can rejoin a same-URL-section
-		 * `css:` block instead of being stranded on its weaker `path:` fallback.
-		 * Defaults to `true`. Set to `false` to fall back to the raw
-		 * {@link ./resolve-blocking-group-keys.js | resolveBlockingGroupKeys}
-		 * output — kept available both because this is not yet broadly-
-		 * validated beyond the two real crawls checked so far, and because it
-		 * has a known trade-off documented on
-		 * {@link ./reassign-orphan-block-keys.js | reassignOrphanBlockKeys}
-		 * itself: pooling pages for comparison can change unrelated pages'
-		 * cluster outcomes too, not just the orphan's.
-		 */
 		reassignOrphans?: boolean;
-		/**
-		 * Apply {@link ./remove-content-blocks.js | removeContentBlocks} to each
-		 * page's landmark-excised remainder before tokenizing, so a freeform
-		 * block-editor content area's page-to-page variation (which specific
-		 * mix of blocks an author used) never reaches the structural-similarity
-		 * comparison. No default — unlike `excludeLandmarks`/`reassignOrphans`,
-		 * this needs the caller's own block-editor attribute name (see
-		 * `removeContentBlocks`'s `blockAttribute` option), which this package
-		 * cannot guess. Omit to skip this step entirely.
-		 */
 		contentBlockAttribute?: string;
-		/**
-		 * Apply {@link ./filter-first-party-stylesheet-hrefs.js |
-		 * filterFirstPartyStylesheetHrefs} to `pages` before computing blocking
-		 * keys, so a page's incidental third-party embeds (e.g. a video
-		 * player's own stylesheet, extra web-font requests pulled in by a
-		 * widget) never get mistaken for a template-identifying signal by
-		 * {@link ./resolve-blocking-group-keys.js | resolveBlockingGroupKeys}.
-		 * Defaults to `true`. Set to `false` to block on every page's full,
-		 * unfiltered `stylesheetHrefs` — kept available for the same reason
-		 * `excludeLandmarks`'s escape hatch is: a real but not yet broadly-
-		 * validated behavioral change (confirmed so far on one real crawl).
-		 *
-		 * Inherits `filterFirstPartyStylesheetHrefs`'s "roughly homogeneous
-		 * batch" precondition (see that function's own JSDoc): `pages` should
-		 * be one site or one section, the same expectation
-		 * `resolveBlockingGroupKeys` already places on its own input.
-		 *
-		 * Provide each page's `host` (see `PageClusterSignals`) so this filter
-		 * can compare directly instead of inferring a batch-wide dominant
-		 * host — the inferred fallback can pick the wrong host on a tie (e.g.
-		 * a page loading its own first-party stylesheet plus the same
-		 * sitewide webfont request as every other page, tying "referenced by
-		 * 100% of pages" between the real first party and that third party).
-		 */
 		restrictStylesheetsToFirstParty?: boolean;
-		/**
-		 * Apply {@link ./detect-content-depth-cap.js | detectContentDepthCap}
-		 * separately *within each block* (after `excludeLandmarks`/
-		 * `contentBlockAttribute`, after blocking, before that block's own
-		 * tokenizing) to find how many levels of nesting inside
-		 * `<main>`/`role="main"` to keep, then
-		 * {@link ./cap-content-depth.js | capContentDepth} each of that
-		 * block's pages at that depth — a `contentBlockAttribute`-style fix
-		 * for freeform-content noise that needs no site-specific attribute
-		 * name, since `<main>` is an HTML5/ARIA standard. Defaults to `true`
-		 * (changed from the previous default of `false` — callers that relied
-		 * on the old opt-in behavior must now pass `autoCapMainDepth: false`
-		 * explicitly). Validated on two real crawl corpora (302 pages and
-		 * 8,936 pages) as correct for most sites. The self-tuning cross-block
-		 * Stage B that runs after Stage A assumes this cap is enabled; running
-		 * without it (`false`) still works but produces uncapped tokens that
-		 * Stage B has not been validated against.
-		 *
-		 * Per-block rather than once across the whole corpus: different
-		 * blocks (different templates/sections) can have genuinely different
-		 * "skeleton depths." Confirmed on real crawl data: an 814-page block
-		 * whose own knee sits at depth 2 stayed at 189 clusters (barely moved
-		 * from 224 uncapped) when capped at depth 3 — the knee derived from
-		 * the *whole* 8,936-page corpus, dominated by two much larger blocks
-		 * whose own knee is 3. Re-deriving the knee for that block alone
-		 * brings it down to 46. A block too small for its knee-detection
-		 * sweep to find a reliable jump just falls through to
-		 * `detectContentDepthCap`'s own no-knee fallback (the largest
-		 * candidate depth, effectively "don't cap") — the same safe default
-		 * it already has for any input, now reached per-block instead of
-		 * corpus-wide. Skipped entirely (no cap) for a block of exactly 1
-		 * page — nothing to compare it against, so a knee sweep there could
-		 * only ever confirm what's already true.
-		 *
-		 * Trade-off of going per-block: a corpus-wide sweep's cluster-count
-		 * ratios are diluted by thousands of ordinary pages, so one
-		 * incidental outlier (e.g. a single page with an extra wrapper `div`
-		 * from a stray widget) barely moves them. A small block's sweep has
-		 * no such dilution — a similar outlier among only a handful of pages
-		 * can itself clear `minKneeRatio` and produce a too-shallow cap for
-		 * that block. Not yet observed on either real corpus checked so far
-		 * (both corpora's small blocks happened to be uniform enough that
-		 * this didn't come up), so no size-based guard is added speculatively;
-		 * revisit if real data surfaces it.
-		 *
-		 * Composes with `contentBlockAttribute` rather than replacing it: both
-		 * can be set at once — `removeContentBlocks` runs first, then
-		 * `capContentDepth` on what's left — for a site whose CMS marks *some*
-		 * blocks with a known attribute but still has other, unmarked
-		 * freeform depth the attribute alone doesn't catch.
-		 *
-		 * Confirmed on real crawl data this can outperform
-		 * `contentBlockAttribute` on its own, not just stand in for it when the
-		 * attribute is unknown: on a 302-page corpus, `autoCapMainDepth` alone
-		 * produced 20 final clusters versus 27 for
-		 * `contentBlockAttribute: 'data-bgb'` together with
-		 * `restrictStylesheetsToFirstParty` — the site's known CMS attribute
-		 * doesn't mark every source of freeform depth, but the `<main>`
-		 * boundary catches all of it uniformly. See `detectContentDepthCap`'s
-		 * JSDoc for the real cost/accuracy numbers this per-block sweep
-		 * measures on the same two corpora.
-		 */
 		autoCapMainDepth?: boolean;
-		/**
-		 * Re-key two or more otherwise-distinct clusters onto one shared key
-		 * when every landmark type present on their pages is both identical
-		 * and rare corpus-wide — see
-		 * {@link ./merge-landmark-affined-clusters.js | mergeLandmarkAffinedClusters}'s
-		 * JSDoc for the exact rule, the withdrawn earlier prototype this
-		 * reimplements, and why "rare" (not merely "identical") is required.
-		 * Defaults to `false`.
-		 *
-		 * Kept `false` by default: unlike `autoCapMainDepth`/
-		 * `restrictStylesheetsToFirstParty`, this has not been run against
-		 * real crawl data at all as of this change — only synthetic-fixture
-		 * unit/regression tests. See `mergeLandmarkAffinedClusters`'s JSDoc
-		 * for its cost profile before enabling this on a large corpus.
-		 */
 		mergeRareLandmarkClusters?: boolean;
-		/** Forwarded to {@link ./merge-landmark-affined-clusters.js | mergeLandmarkAffinedClusters} as-is. */
 		landmarkRarityThreshold?: number;
-		/** Forwarded to {@link ./merge-landmark-affined-clusters.js | mergeLandmarkAffinedClusters} as-is. */
 		landmarkGateSimilarityThreshold?: number;
 	};
 
 /**
- * Connects the two stages this package otherwise leaves for the caller to
- * wire together: {@link ./resolve-blocking-group-keys.js | resolveBlockingGroupKeys}
- * (coarse blocking by URL path or stylesheet set) and structural clustering
- * within each block. Returns one final key per page, in the same order as
- * `pages`, unique across the whole input — not just within a block.
+ * Corpus size at or below which the async factory-based
+ * `resolvePageClusterKeys` reads the entire input into an array and delegates
+ * to {@link ./resolve-page-cluster-keys.js | resolvePageClusterKeysInMemory}
+ * unchanged — preserving corpus-wide semantics (chrome discovery, Stage B
+ * across all pages) exactly.
  *
- * **Stage A (per block):** Runs the complete-linkage dendrogram
- * ({@link ./complete-linkage-dendrogram.js | completeLinkageDendrogram})
- * and selects a threshold automatically via
- * {@link ./auto-cut-threshold.js | autoCutThreshold} (largest merge-height
- * gap, clamped to `similarityThreshold` so the default is never tightened,
- * only loosened). **`similarityThreshold` is an upper bound here, not a
- * per-pair hard floor** — the auto-cut can select a lower value when a
- * natural cluster boundary exists below `similarityThreshold`. To enforce a
- * strict minimum Jaccard per page-pair, use
- * {@link ./resolve-structural-cluster-keys.js | resolveStructuralClusterKeys}
- * directly (it skips auto-cut). For blocks large enough for frequency-based
- * comparison (`>= MIN_PAGE_COUNT_FOR_FREQUENCY_SPLIT`), each cluster's
- * token union (with anonymous `div` wrappers collapsed via
- * {@link ./collapse-anonymous-divs.js | collapseAnonymousDivs}) passes
- * through
- * {@link ./assign-contained-clusters.js | assignContainedClusters}
- * (containment ≥ 0.9) to absorb clusters caused by conditional rendering
- * (missing optional section, paginator absent). See
- * `assignContainedClusters`'s JSDoc for why this is directed assignment
- * rather than union-find.
+ * Above this threshold, the streaming path takes over: block dispatch during
+ * a second factory read, per-block chrome discovery (semantic drift from
+ * corpus-wide, unavoidable when the whole corpus does not fit in memory),
+ * and Stage B fed with the incrementally-accumulated cross-block units.
  *
- * **Stage B (cross-block, always):** After all blocks are processed,
- * {@link ./merge-cross-block-clusters.js | mergeCrossBlockClusters}
- * iteratively merges units across block boundaries — breaking through the
- * URL-path and stylesheet-set walls that Stage A cannot cross. Uses quorum
- * cores (80% of member pages' corpus-distinctive tokens) with three merge
- * mechanisms: complete-linkage at the fixed threshold (0.8), containment,
- * and shape-Jaccard (class-name-stripped skeleton similarity ≥ 0.9 for
- * multi-page units only). When those find nothing, falls back to an L2
- * multiset-containment signature anchored at `<main>` with shell
- * (header+nav+footer) corroboration. Converges to a fixed point in ≤ 10
- * rounds (real crawl data: 2–5 rounds).
+ * Chosen from Phase 0 spike measurements: a ~9,000-page real crawl (biggest
+ * block ~3,900) completed in ~108s / 1.25 GB heap on the in-memory path.
+ * Doubling that headroom to 20,000 keeps every corpus previously validated
+ * (302, 1,416, 8,936, 89 pages) on the exact code path they were validated
+ * against, so their gate values (9 / 21 / 63 / 3 clusters respectively)
+ * remain byte-reproducible. A ~176,000-page real crawl OOM'd on the in-memory
+ * path well below this threshold worth of pages ever being materialized, so
+ * anything above 20,000 is routed to streaming.
+ */
+export const CORPUS_INLINE_THRESHOLD = 20_000;
+
+/**
+ * Reservoir-sample size per block on the streaming path. Blocks larger than
+ * this have Stage A run on a random sample of `BLOCK_SAMPLE_SIZE` pages,
+ * with the remaining non-sample pages assigned via Jaccard similarity to
+ * the sample-derived clusters during Pass 1b. Blocks at or below this size
+ * still work — the sampling degenerates to "keep every input page unchanged"
+ * per the `reservoirSample` contract, so small blocks behave identically to
+ * the in-memory path.
  *
- * Cluster keys are composed from the block key and the local per-block
- * label via `JSON.stringify` (rather than string concatenation) to avoid
- * collisions regardless of what either half contains. Stage B preserves
- * the root unit's existing key, so merged clusters receive a key from one
- * of their constituent blocks, not a newly invented one.
+ * Chosen to bound accumulated Stage-B state: units × sample_size × per-
+ * member memory ≈ 200 units × 100 members × 25 KB ≈ 500 MB, well within an
+ * 8 GB Node heap even on macOS where jetsam (the kernel OOM killer) reacts
+ * to RSS pressure before V8's own heap limit trips.
  *
- * `excludeLandmarks` and `similarityThreshold` interact: removing shared
- * chrome makes every remaining comparison stricter (there's no more
- * chrome-driven baseline similarity propping scores up), so a threshold
- * tuned against raw, chrome-included tokens can become too strict once
- * landmarks are excluded. Confirmed on real crawl data: a 4-page block where
- * 3 same-template pages merged at the default `similarityThreshold` (0.8)
- * using raw tokens split one of the 3 into its own singleton once landmarks
- * were excluded, and re-merged correctly at `similarityThreshold: 0.6` — re-
- * tune per site after switching this on, the same as `similarityThreshold`
- * itself already needs.
+ * ## Semantic differences from the in-memory path
  *
- * `reassignOrphans` only ever pools a `path:`-fallback orphan alongside a
- * same-section `css:` block for comparison — it never forces a merge itself.
- * An orphan that turns out not to match anything in that pool (confirmed on
- * real crawl data) correctly surfaces as its own singleton.
+ * - **Chrome discovery is sample-based per block.** Landmark signatures that
+ *   are rare in the sample get treated as global chrome; only signatures
+ *   that show up on ≥ 2 sample members and below the sample-derived
+ *   auto-cut are reinjected. Full-block chrome discovery would see rare
+ *   signatures too — the sample-based decision approximates it.
+ * - **Non-sample pages are assigned by max-Jaccard against sample member
+ *   token sets.** A page whose closest sample member is genuinely dissimilar
+ *   still gets slotted into the least-bad cluster; this is a pragmatic
+ *   trade for a bounded assignment cost (no unbounded "outlier" cluster
+ *   growth).
+ * - **Stage B sees the sample-based `CrossBlockUnit`s only.** Non-sample
+ *   pages carry the final key that Stage B produces for their assigned
+ *   sample cluster, without contributing to Stage B's own DF / quorum-core
+ *   / shell-quorum computations.
  *
- * `restrictStylesheetsToFirstParty` runs before `reassignOrphans`: a page
- * whose only stylesheet reference was third-party becomes an orphan (no
- * first-party stylesheet left) *because of* the filtering, and is then
- * itself eligible for orphan reassignment — this is intentional, not an
- * ordering accident, since the underlying reason both options exist is the
- * same (a page's blocking key should reflect its template, not incidental
- * third-party embeds or missing crawl data).
+ * Preserves the in-memory path unchanged for corpora at or below
+ * {@link CORPUS_INLINE_THRESHOLD} — sampling is streaming-mode only.
+ */
+export const BLOCK_SAMPLE_SIZE = 100;
+
+/**
+ * Preserves the previous synchronous, array-in / array-out API of
+ * `resolvePageClusterKeys` under a new name so the factory-based async
+ * export can take the primary name while callers that already had a
+ * materialized page array (spec tests, the in-repo dogfood harness,
+ * downstream code that hasn't switched to streaming yet) retain the
+ * exact same behavior.
+ *
+ * Semantics: identical to the pre-refactor `resolvePageClusterKeys`.
+ * Corpus-wide chrome discovery, Stage B across every page, no memory
+ * bound — meant to be called on inputs already known to fit in memory.
+ * The async factory-based export delegates here whenever
+ * `pages.length ≤ CORPUS_INLINE_THRESHOLD`, guaranteeing existing corpora
+ * hit exactly this code path.
  * @param pages
  * @param options
- * @example
- * ```ts
- * resolvePageClusterKeys([
- * 	{ paths: ['news', '1'], stylesheetHrefs: [], html: '<body><article>one</article></body>' },
- * 	{ paths: ['news', '2'], stylesheetHrefs: [], html: '<body><article>two</article></body>' },
- * 	{ paths: ['about'], stylesheetHrefs: [], html: '<body><section>about</section></body>' },
- * ]);
- * // pages 0 and 1 (same block, same structure) share a key; page 2 (different block) gets its own
- * ```
  */
-export function resolvePageClusterKeys(
+export function resolvePageClusterKeysInMemory(
 	pages: readonly PageClusterSignals[],
 	options?: ResolvePageClusterKeysOptions,
 ): string[] {
 	const excludeLandmarks = options?.excludeLandmarks ?? true;
 	const mergeRareLandmarkClusters = options?.mergeRareLandmarkClusters ?? false;
 	if (mergeRareLandmarkClusters) {
-		// Eager, same rationale as autoCapMainDepth's own eager validation
-		// below: this option's own validation is otherwise only reached from
-		// mergeLandmarkAffinedClusters's call at the very end of this
-		// function, which never runs at all for an empty `pages`.
 		validateMergeLandmarkAffinedClustersOptions(options);
 	}
 
@@ -454,27 +410,17 @@ export function resolvePageClusterKeys(
 	// Always computed: landmark fields are needed by Stage B's shell
 	// corroboration regardless of excludeLandmarks/mergeRareLandmarkClusters,
 	// and remainderHtml is needed whenever excludeLandmarks is true.
-	// extractLandmarks parses the whole page once; computing it upfront avoids
-	// parsing the same page twice for the two options that each need it.
 	const landmarks: readonly ExtractLandmarksResult[] = pages.map((page) =>
 		extractLandmarks(page.html),
 	);
 
-	// Corpus-level chrome discovery: identify which landmark-instance
-	// signatures are *local* (below the auto-cut on the corpus-wide
-	// frequency histogram) and inject a compact pseudo-token per local
-	// signature into each page's block token set. Pages that share a local
-	// landmark then share a distinctive token unavailable to the pages that
-	// lack it — giving Stage A the structural signal it needs to split
-	// section-local template variants (e.g. a URL subsection carrying a
-	// section-local nav absent from its block siblings) that would
-	// otherwise merge together after landmark tokens are excised.
+	// Corpus-level chrome discovery
 	const localLandmarkTokensByPage = computeLocalLandmarkTokens(landmarks, options);
 
 	const contentBlockAttribute = options?.contentBlockAttribute;
 	const preparedHtml = pages.map((page, index) => {
 		const landmarksExcised = excludeLandmarks
-			? requireIndex(landmarks, index).remainderHtml
+			? landmarks[index]!.remainderHtml
 			: page.html;
 		return contentBlockAttribute === undefined
 			? landmarksExcised
@@ -488,21 +434,8 @@ export function resolvePageClusterKeys(
 		? filterFirstPartyStylesheetHrefs(pages)
 		: pages;
 
-	const reassignOrphans = options?.reassignOrphans ?? true;
-	const rawBlockKeys = resolveBlockingGroupKeys(blockingPages, options);
-	const blockKeys = reassignOrphans
-		? reassignOrphanBlockKeys(blockingPages, rawBlockKeys, options?.pathDepth)
-		: rawBlockKeys;
-
-	const indicesByBlockKey = new Map<string, number[]>();
-	for (const [index, blockKey] of blockKeys.entries()) {
-		const indices = indicesByBlockKey.get(blockKey);
-		if (indices) {
-			indices.push(index);
-		} else {
-			indicesByBlockKey.set(blockKey, [index]);
-		}
-	}
+	const blockKeys = resolveBlockKeys(blockingPages, options);
+	const indicesByBlockKey = groupIndicesByBlockKey(blockKeys);
 
 	const autoCapMainDepth = options?.autoCapMainDepth ?? true;
 	if (autoCapMainDepth) {
@@ -518,113 +451,20 @@ export function resolvePageClusterKeys(
 	const crossBlockUnits: CrossBlockUnit[] = [];
 
 	for (const [blockKey, indices] of indicesByBlockKey) {
-		const blockPreparedHtml = indices.map((index) => requireIndex(preparedHtml, index));
-		// A block of 1 can never produce more than one cluster regardless of
-		// how it's tokenized — nothing to compare it against — so detecting a
-		// knee and capping for it would only spend a full multi-depth sweep
-		// (see detectContentDepthCap's own cost notes) to arrive back at the
-		// same single-cluster result. Skipped rather than swept.
-		const maxMainDepth =
-			autoCapMainDepth && blockPreparedHtml.length > 1
-				? detectContentDepthCap(blockPreparedHtml, options)
-				: undefined;
-		const blockTokenSets: ReadonlySet<string>[] = blockPreparedHtml.map(
-			(html, position) => {
-				const capped =
-					maxMainDepth === undefined
-						? html
-						: capContentDepth(html, { landmark: 'main', maxDepth: maxMainDepth })
-								.remainderHtml;
-				const tokens = new Set(tokenize(capped, options).tokens);
-				// Reinject each page's local-landmark tokens (see
-				// computeLocalLandmarkTokens's JSDoc). Empty set when the
-				// corpus-level auto-cut finds no local chrome — a no-op
-				// for corpora where every landmark is site-wide.
-				const pageIndex = requireIndex(indices, position);
-				for (const token of requireIndex(localLandmarkTokensByPage, pageIndex)) {
-					tokens.add(token);
-				}
-				return tokens;
-			},
-		);
-
-		// Stage A: dendrogram + auto-cut + optional containment assignment
-		const blockSize = blockTokenSets.length;
-		const comparisonSets = deriveComparisonSets(blockTokenSets);
-		const merges = completeLinkageDendrogram(comparisonSets);
-		const cut = autoCutThreshold(
-			merges.map((m) => m.height),
-			similarityThreshold,
-		);
-		let roots = labelsAtThreshold(blockSize, merges, cut);
-
-		// Containment assignment only for blocks large enough to have had
-		// frequency-based comparison sets (same MIN_PAGE_COUNT_FOR_FREQUENCY_SPLIT
-		// threshold as deriveComparisonSets): below that floor, comparison sets
-		// equal raw token sets, and containment on full token sets causes chrome-
-		// dominated pages (index page whose HTML includes every nav variant) to
-		// spuriously absorb unrelated clusters.
-		if (blockSize >= MIN_PAGE_COUNT_FOR_FREQUENCY_SPLIT) {
-			const clusterTokens = new Map<number, Set<string>>();
-			const clusterPageCount = new Map<number, number>();
-			for (let i = 0; i < blockSize; i++) {
-				const r = requireIndex(roots, i);
-				let tokens = clusterTokens.get(r);
-				if (!tokens) {
-					tokens = new Set();
-					clusterTokens.set(r, tokens);
-				}
-				for (const t of requireIndex(comparisonSets, i))
-					tokens.add(collapseAnonymousDivs(t));
-				clusterPageCount.set(r, (clusterPageCount.get(r) ?? 0) + 1);
-			}
-			const entries = [...clusterTokens.entries()].map(([id, tokens]) => ({
-				id,
-				tokens: tokens as ReadonlySet<string>,
-				pageCount: clusterPageCount.get(id) ?? 0,
-			}));
-			const contResult = assignContainedClusters(entries);
-			roots = roots.map((r) => contResult.get(r) ?? r);
-		}
-
-		// Assign string cluster labels in first-seen order
-		const rootToLabel = new Map<number, string>();
-		const localLabels = roots.map((root) => {
-			let label = rootToLabel.get(root);
-			if (label === undefined) {
-				label = `cluster:${rootToLabel.size}`;
-				rootToLabel.set(root, label);
-			}
-			return label;
-		});
-
-		for (const [position, pageIndex] of indices.entries()) {
-			finalKeys[pageIndex] = JSON.stringify([
+		const result = stageAPerBlock(
+			{
 				blockKey,
-				requireIndex(localLabels, position),
-			]);
+				memberIndices: indices,
+				preparedHtml: indices.map((i) => preparedHtml[i]!),
+				landmarks: indices.map((i) => landmarks[i]!),
+				localLandmarkTokensByPage: indices.map((i) => localLandmarkTokensByPage[i]!),
+			},
+			options,
+		);
+		for (const [pageIndex, key] of result.pageKeys) {
+			finalKeys[pageIndex] = key;
 		}
-
-		// Gather CrossBlockUnit entries for Stage B
-		const unitKeyToPositions = new Map<string, number[]>();
-		for (const [position, pageIndex] of indices.entries()) {
-			const unitKey = finalKeys[pageIndex]!;
-			let positions = unitKeyToPositions.get(unitKey);
-			if (!positions) {
-				positions = [];
-				unitKeyToPositions.set(unitKey, positions);
-			}
-			positions.push(position);
-		}
-		for (const [unitKey, positions] of unitKeyToPositions) {
-			crossBlockUnits.push({
-				key: unitKey,
-				memberTokenSets: positions.map((pos) => requireIndex(blockTokenSets, pos)),
-				memberLandmarks: positions.map((pos) =>
-					requireIndex(landmarks, requireIndex(indices, pos)),
-				),
-			});
-		}
+		crossBlockUnits.push(...result.crossBlockUnits);
 	}
 
 	// Stage B: cross-block merge — always runs regardless of options
@@ -640,19 +480,6 @@ export function resolvePageClusterKeys(
 	if (!mergeRareLandmarkClusters) {
 		return finalKeys;
 	}
-	// Deliberately not a reuse of blockTokenSets (this function's own
-	// primary-clustering token sets): those follow excludeLandmarks (raw
-	// HTML, landmarks included, when false) and the Stage A frequency
-	// narrowing can further filter them for large blocks.
-	// mergeLandmarkAffinedClusters's secondary content-similarity gate is
-	// meant to be independent corroboration alongside the landmark match
-	// already used to select these pages — if it reused landmark-inclusive
-	// tokens, a bulky shared rare header's own tokens could inflate two
-	// otherwise-unrelated pages' similarity past the gate, and if it reused
-	// the frequency-narrowed set, the gate would silently test different
-	// content than its own JSDoc describes. Always tokenizing each page's
-	// landmark-excised remainderHtml here keeps the gate's evidence
-	// independent of both.
 	const mergeGateContentTokenSets = landmarks.map(
 		(entry) => new Set(tokenize(entry.remainderHtml, options).tokens),
 	);
@@ -662,4 +489,377 @@ export function resolvePageClusterKeys(
 		mergeGateContentTokenSets,
 		options,
 	);
+}
+
+/**
+ * Factory function returning an iterator over pages. Called once per streaming
+ * pass — the driver may invoke it multiple times to re-read the same corpus
+ * (once HTML-free for blocking, once again per block for HTML processing).
+ * Callers with a materialized array can wrap it as
+ * `() => pagesArray[Symbol.iterator]()`, or use
+ * {@link ./resolve-page-cluster-keys.js | resolvePageClusterKeysFromArray}.
+ *
+ * ## Why a factory rather than an `AsyncIterable`
+ *
+ * An `AsyncIterable` returned once cannot be traversed a second time (the
+ * iterator is spent after the first `for await`). The streaming driver must
+ * read the corpus at least twice — once with HTML dropped to compute
+ * blocking keys, and once again per block to process HTML. A factory
+ * function lets the caller build a fresh iterator each pass (typically by
+ * re-opening a JSONL file or re-issuing an archive query), so per-corpus
+ * memory stays proportional to the largest single block rather than to the
+ * full corpus.
+ */
+export type PageFactory = () =>
+	Iterable<PageClusterSignals> | AsyncIterable<PageClusterSignals>;
+
+/**
+ * Streaming, memory-bounded version of `resolvePageClusterKeysInMemory`.
+ *
+ * ## Behavior gate
+ *
+ * - `pageCount ≤ CORPUS_INLINE_THRESHOLD` — reads the whole factory into an
+ *   array, delegates to `resolvePageClusterKeysInMemory`. Same corpus-wide
+ *   chrome discovery, same Stage B across every page. All previously
+ *   validated corpora (302 / 1,416 / 8,936 / 89 pages) hit this path.
+ * - `pageCount > CORPUS_INLINE_THRESHOLD` — streaming path: reads the
+ *   factory twice (once for blocking signals, once for HTML processing),
+ *   dispatches HTML per block, runs Stage A per block, accumulates
+ *   cross-block units, then runs Stage B across all accumulated units. Peak
+ *   memory ≈ largest single block, not the whole corpus.
+ *
+ * ## Semantic differences in streaming mode
+ *
+ * - **Chrome discovery is per-block, not corpus-wide.** In the in-memory
+ *   path, {@link ./resolve-page-cluster-keys.js | computeLocalLandmarkTokens}
+ *   runs on all pages at once. In streaming mode the entire corpus cannot
+ *   be held at once, so chrome discovery runs per block. A landmark
+ *   signature that is rare corpus-wide but common within one block will
+ *   be treated as global chrome in streaming mode, whereas the in-memory
+ *   mode would treat it as local. This trade-off is why the threshold
+ *   above is set generously — every real corpus historically validated
+ *   here stays on the in-memory path.
+ * - **`mergeRareLandmarkClusters` is not supported in streaming mode** — it
+ *   requires corpus-wide landmark frequency knowledge before it can decide
+ *   which are "rare." Callers who need it must ensure their corpus fits
+ *   the in-memory path.
+ * @param pages
+ * @param options
+ * @example
+ * ```ts
+ * // JSONL file source — factory can be re-invoked to re-open the file.
+ * import { createReadStream } from 'node:fs';
+ * import readline from 'node:readline';
+ *
+ * const keys = await resolvePageClusterKeys(() => {
+ *   const lines = readline.createInterface({ input: createReadStream('pages.jsonl') });
+ *   return (async function* () {
+ *     for await (const line of lines) yield JSON.parse(line);
+ *   })();
+ * });
+ * ```
+ */
+export async function resolvePageClusterKeys(
+	pages: PageFactory,
+	options?: ResolvePageClusterKeysOptions,
+): Promise<string[]> {
+	// Pass 0: HTML-free — collect blocking signals (paths, stylesheetHrefs,
+	// host) into an array. This is the only per-page state we keep across
+	// the whole corpus in streaming mode.
+	const blockingSignals: {
+		paths: readonly string[];
+		stylesheetHrefs: readonly string[];
+		host?: string;
+	}[] = [];
+	for await (const page of pages()) {
+		blockingSignals.push({
+			paths: page.paths,
+			stylesheetHrefs: page.stylesheetHrefs,
+			host: page.host,
+		});
+	}
+
+	if (blockingSignals.length === 0) return [];
+
+	// Small corpus: read the whole factory again with HTML this time, then
+	// delegate to the in-memory path unchanged. Preserves every corpus-wide
+	// semantic (chrome, Stage B) for corpora within the threshold.
+	if (blockingSignals.length <= CORPUS_INLINE_THRESHOLD) {
+		const fullPages: PageClusterSignals[] = [];
+		for await (const page of pages()) {
+			fullPages.push({
+				paths: page.paths,
+				stylesheetHrefs: page.stylesheetHrefs,
+				html: page.html,
+				host: page.host,
+			});
+		}
+		return resolvePageClusterKeysInMemory(fullPages, options);
+	}
+
+	// Large corpus: streaming path.
+	if (options?.mergeRareLandmarkClusters === true) {
+		throw new Error(
+			`resolvePageClusterKeys: mergeRareLandmarkClusters is not supported in streaming mode (pages > ${CORPUS_INLINE_THRESHOLD}). Reduce the corpus or use resolvePageClusterKeysInMemory directly.`,
+		);
+	}
+
+	const excludeLandmarks = options?.excludeLandmarks ?? true;
+	const similarityThreshold = options?.similarityThreshold ?? 0.8;
+	if (!(similarityThreshold >= 0 && similarityThreshold <= 1)) {
+		throw new RangeError(
+			`resolvePageClusterKeys: similarityThreshold must be between 0 and 1, got ${similarityThreshold}`,
+		);
+	}
+	const autoCapMainDepth = options?.autoCapMainDepth ?? true;
+	if (autoCapMainDepth) {
+		validateDetectContentDepthCapOptions(options);
+	}
+
+	const restrictStylesheetsToFirstParty =
+		options?.restrictStylesheetsToFirstParty ?? true;
+	const blockingPagesForKeys = restrictStylesheetsToFirstParty
+		? filterFirstPartyStylesheetHrefs(blockingSignals)
+		: blockingSignals;
+	const blockKeys = resolveBlockKeys(blockingPagesForKeys, options);
+	const indicesByBlockKey = groupIndicesByBlockKey(blockKeys);
+
+	const finalKeys: string[] = Array.from({ length: blockingSignals.length });
+	const crossBlockUnits: CrossBlockUnit[] = [];
+	const contentBlockAttribute = options?.contentBlockAttribute;
+
+	/**
+	 * Per-block bucket accumulates a reservoir sample of the block's pages
+	 * (at most {@link BLOCK_SAMPLE_SIZE}). When the block is fully seen, the
+	 * sample is passed through Stage A to produce this block's cluster
+	 * representatives.
+	 */
+	type BlockBucket = {
+		readonly blockKey: string;
+		readonly targetSize: number;
+		/** Reservoir-bounded arrays of the sample-selected pages, parallel. */
+		reservoirIndices: number[];
+		reservoirPreparedHtml: string[];
+		reservoirLandmarks: ExtractLandmarksResult[];
+		/** Total pages seen so far for this block (across the whole stream). */
+		seenCount: number;
+		/** Per-block PRNG state; seed derived from block key for determinism. */
+		prng: () => number;
+	};
+	/**
+	 * Post–Stage-A learned parameters for a block. Used during Pass 1b to
+	 * assign non-sample pages of that block to the block's clusters.
+	 */
+	type BlockAssignment = {
+		/** `capContentDepth`'s `maxDepth`, learned from the sample. */
+		readonly maxMainDepth: number | undefined;
+		/** Signatures that are local chrome per the sample-based auto-cut. */
+		readonly localSignatures: ReadonlySet<string>;
+		/** unitKey → the sample members' token sets that back that cluster. */
+		readonly clustersByUnitKey: ReadonlyMap<string, readonly ReadonlySet<string>[]>;
+	};
+	/** Non-sample page indices that need Pass 1b Jaccard-based assignment. */
+	const pendingAssignmentBlockKeyByIndex = new Map<number, string>();
+	/** Block-level artifacts saved after Stage A runs on the sample. */
+	const blockAssignments = new Map<string, BlockAssignment>();
+
+	const buckets = new Map<string, BlockBucket>();
+	for (const [blockKey, indices] of indicesByBlockKey) {
+		buckets.set(blockKey, {
+			blockKey,
+			targetSize: indices.length,
+			reservoirIndices: [],
+			reservoirPreparedHtml: [],
+			reservoirLandmarks: [],
+			seenCount: 0,
+			prng: makeSeededPrng(blockKey),
+		});
+	}
+
+	/**
+	 * Runs Stage A on the block's reservoir sample, records sample-member
+	 * cluster keys into `finalKeys`, saves per-cluster member token sets so
+	 * Pass 1b can Jaccard-assign non-sample pages, and appends the produced
+	 * `CrossBlockUnit`s to the Stage-B input.
+	 * @param bucket
+	 */
+	function flushBlock(bucket: BlockBucket): void {
+		const { localSignatures, localTokensByPage } = computeLocalChromeArtifacts(
+			bucket.reservoirLandmarks,
+			options,
+		);
+		const result = stageAPerBlock(
+			{
+				blockKey: bucket.blockKey,
+				memberIndices: bucket.reservoirIndices,
+				preparedHtml: bucket.reservoirPreparedHtml,
+				landmarks: bucket.reservoirLandmarks,
+				localLandmarkTokensByPage: localTokensByPage,
+			},
+			// No capMembers — the reservoir already bounds `sampleSize`.
+			options,
+		);
+		for (const [idx, key] of result.pageKeys) {
+			finalKeys[idx] = key;
+		}
+		crossBlockUnits.push(...result.crossBlockUnits);
+
+		if (bucket.seenCount > bucket.reservoirIndices.length) {
+			// Save assignment artifacts for Pass 1b.
+			const maxMainDepth =
+				(options?.autoCapMainDepth ?? true) && bucket.reservoirPreparedHtml.length > 1
+					? detectContentDepthCap(bucket.reservoirPreparedHtml, options)
+					: undefined;
+			const clustersByUnitKey = new Map<string, ReadonlySet<string>[]>();
+			for (const unit of result.crossBlockUnits) {
+				clustersByUnitKey.set(unit.key, [...unit.memberTokenSets]);
+			}
+			blockAssignments.set(bucket.blockKey, {
+				maxMainDepth,
+				localSignatures,
+				clustersByUnitKey,
+			});
+		}
+
+		// Encourage V8 to reclaim the reservoir's transient allocations.
+		const maybeGc = (globalThis as { gc?: () => void }).gc;
+		if (maybeGc !== undefined) maybeGc();
+	}
+
+	// Pass 1: stream HTML pages, reservoir-sample each block, run Stage A
+	// on the sample the moment the block is fully seen.
+	let pageIndex = 0;
+	for await (const page of pages()) {
+		const blockKey = blockKeys[pageIndex]!;
+		const bucket = buckets.get(blockKey);
+		if (bucket === undefined) {
+			throw new Error(
+				`resolvePageClusterKeys: block "${blockKey}" is missing from the bucket registry`,
+			);
+		}
+		// Reservoir sampling (Algorithm R): keep the first BLOCK_SAMPLE_SIZE
+		// pages, then for each subsequent one replace a random reservoir slot
+		// with decreasing probability.
+		if (bucket.reservoirIndices.length < BLOCK_SAMPLE_SIZE) {
+			const landmarkResult = extractLandmarks(page.html);
+			const landmarksExcised = excludeLandmarks
+				? landmarkResult.remainderHtml
+				: page.html;
+			const prepared =
+				contentBlockAttribute === undefined
+					? landmarksExcised
+					: removeContentBlocks(landmarksExcised, {
+							blockAttribute: contentBlockAttribute,
+						}).remainderHtml;
+			const strippedLandmark = { ...landmarkResult, remainderHtml: '' };
+			bucket.reservoirIndices.push(pageIndex);
+			bucket.reservoirPreparedHtml.push(prepared);
+			bucket.reservoirLandmarks.push(strippedLandmark);
+		} else {
+			const j = Math.floor(bucket.prng() * (bucket.seenCount + 1));
+			if (j < BLOCK_SAMPLE_SIZE) {
+				const landmarkResult = extractLandmarks(page.html);
+				const landmarksExcised = excludeLandmarks
+					? landmarkResult.remainderHtml
+					: page.html;
+				const prepared =
+					contentBlockAttribute === undefined
+						? landmarksExcised
+						: removeContentBlocks(landmarksExcised, {
+								blockAttribute: contentBlockAttribute,
+							}).remainderHtml;
+				const strippedLandmark = { ...landmarkResult, remainderHtml: '' };
+				const evicted = bucket.reservoirIndices[j]!;
+				pendingAssignmentBlockKeyByIndex.set(evicted, bucket.blockKey);
+				bucket.reservoirIndices[j] = pageIndex;
+				bucket.reservoirPreparedHtml[j] = prepared;
+				bucket.reservoirLandmarks[j] = strippedLandmark;
+			} else {
+				pendingAssignmentBlockKeyByIndex.set(pageIndex, bucket.blockKey);
+			}
+		}
+		bucket.seenCount++;
+
+		if (bucket.seenCount === bucket.targetSize) {
+			flushBlock(bucket);
+			buckets.delete(bucket.blockKey);
+		}
+		pageIndex++;
+	}
+
+	if (pageIndex !== blockingSignals.length) {
+		throw new Error(
+			`resolvePageClusterKeys: streaming input yielded ${pageIndex} pages but Pass 0 saw ${blockingSignals.length} — factory must produce the same pages in the same order on repeated invocations`,
+		);
+	}
+	if (buckets.size > 0) {
+		throw new Error(
+			`resolvePageClusterKeys: ${buckets.size} block(s) never reached their target size — this should not happen if the factory produced identical pages across the two passes`,
+		);
+	}
+
+	// Pass 1b: for every non-sample page (evicted from a block's reservoir
+	// or never selected), re-stream its HTML and Jaccard-assign it to the
+	// nearest sample-derived cluster in its block. Nothing is added to
+	// crossBlockUnits here — the assignment writes directly into finalKeys.
+	if (pendingAssignmentBlockKeyByIndex.size > 0) {
+		let assignPageIndex = 0;
+		for await (const page of pages()) {
+			const targetBlockKey = pendingAssignmentBlockKeyByIndex.get(assignPageIndex);
+			if (targetBlockKey !== undefined) {
+				const assignment = blockAssignments.get(targetBlockKey);
+				if (assignment !== undefined) {
+					finalKeys[assignPageIndex] = assignPageToNearestCluster(
+						page.html,
+						assignment,
+						excludeLandmarks,
+						contentBlockAttribute,
+						options,
+						targetBlockKey,
+					);
+				}
+			}
+			assignPageIndex++;
+		}
+	}
+
+	// Stage B: cross-block merge over the accumulated (sample-based) units.
+	// Each unit already has at most BLOCK_SAMPLE_SIZE members from the
+	// reservoir sampling above, so no additional cap is needed here — the
+	// per-merge cost stays bounded across rounds.
+	const stageBResult = mergeCrossBlockClusters(crossBlockUnits, {
+		...options,
+		capMembers: BLOCK_SAMPLE_SIZE,
+	});
+	for (let i = 0; i < finalKeys.length; i++) {
+		const currentKey = finalKeys[i]!;
+		const rootKey = stageBResult.get(currentKey);
+		if (rootKey !== undefined && rootKey !== currentKey) {
+			finalKeys[i] = rootKey;
+		}
+	}
+	return finalKeys;
+}
+
+/**
+ * Convenience wrapper that runs {@link ./resolve-page-cluster-keys.js | resolvePageClusterKeys}
+ * on a materialized array. Preserves the pre-refactor sync API for callers
+ * that already have all pages in memory, while flowing through the same
+ * async driver so behavior stays consistent across the two entry points.
+ * @param pages
+ * @param options
+ * @example
+ * ```ts
+ * const keys = await resolvePageClusterKeysFromArray([
+ *   { paths: ['news', '1'], stylesheetHrefs: [], html: '<body><article>one</article></body>' },
+ *   { paths: ['news', '2'], stylesheetHrefs: [], html: '<body><article>two</article></body>' },
+ *   { paths: ['about'], stylesheetHrefs: [], html: '<body><section>about</section></body>' },
+ * ]);
+ * ```
+ */
+export function resolvePageClusterKeysFromArray(
+	pages: readonly PageClusterSignals[],
+	options?: ResolvePageClusterKeysOptions,
+): Promise<string[]> {
+	return resolvePageClusterKeys(() => pages, options);
 }

--- a/packages/@d-zero/page-cluster/src/stage-a-per-block.ts
+++ b/packages/@d-zero/page-cluster/src/stage-a-per-block.ts
@@ -1,0 +1,283 @@
+import type { ExtractLandmarksResult } from './extract-landmarks.js';
+import type { CrossBlockUnit } from './merge-cross-block-clusters.js';
+import type { TokenizeOptions } from './types.js';
+
+import { assignContainedClusters } from './assign-contained-clusters.js';
+import { autoCutThreshold } from './auto-cut-threshold.js';
+import { capContentDepth } from './cap-content-depth.js';
+import { collapseAnonymousDivs } from './collapse-anonymous-divs.js';
+import {
+	completeLinkageDendrogram,
+	labelsAtThreshold,
+} from './complete-linkage-dendrogram.js';
+import {
+	deriveComparisonSets,
+	MIN_PAGE_COUNT_FOR_FREQUENCY_SPLIT,
+} from './derive-comparison-sets.js';
+import { detectContentDepthCap } from './detect-content-depth-cap.js';
+import { computePerPageLandmarkInstances } from './per-page-landmark-signatures.js';
+import { reservoirSample } from './reservoir-sample.js';
+import { tokenize } from './tokenize.js';
+
+/**
+ * Maximum number of member pages retained per `CrossBlockUnit` for Stage B.
+ * Units larger than this are down-sampled deterministically (URL-independent
+ * — seeded from the unit key) via {@link ./reservoir-sample.js | reservoirSample}.
+ *
+ * ## Why cap
+ *
+ * `CrossBlockUnit.memberTokenSets` is `readonly ReadonlySet<string>[]`.
+ * V8's Set carries substantial per-entry overhead (hash slot + string
+ * reference + backing array padding), so a 200-token set weighs ~20 KB in
+ * practice — an order of magnitude more than the raw byte sum of its
+ * strings. Without a cap, the streaming path's batch-by-batch accumulation
+ * of `CrossBlockUnit`s across a 176k-page corpus reached OOM at ~100k pages
+ * on an 8 GB heap, entirely from Set overhead of retained members.
+ *
+ * ## Why the value
+ *
+ * Stage B's per-round computations (`computeDocumentFrequency`,
+ * `quorumCore`, `shellQuorum`) are frequency-based, so a representative
+ * sample gives statistically similar cores and shells to the full
+ * membership. 100 members is enough for the 80 % quorum threshold to
+ * discriminate signal from noise (needs ≥ 80 of 100 = 80 % vs. the
+ * corpus-wide 80 %), and keeps a per-unit memory footprint of ~2.5 MB
+ * (100 × ~25 KB per member incl. tokens + landmark instances). For a
+ * corpus with ~500 units that's ~1.25 GB — well within an 8 GB heap.
+ *
+ * Applied at unit *creation* here in {@link ./stage-a-per-block.js | stageAPerBlock},
+ * and re-applied after each merge in
+ * {@link ./merge-cross-block-clusters.js | mergeCrossBlockClusters}'s
+ * `applyMerges`, so a merged group can never balloon past this cap either.
+ *
+ * ## In-memory-path preservation
+ *
+ * A block with `≤ MAX_MEMBERS_PER_UNIT` members hits the deterministic
+ * "return the full input unchanged" branch of {@link ./reservoir-sample.js | reservoirSample},
+ * so every previously validated corpus (302 / 1,416 / 8,936 / 89 pages)
+ * keeps every member of every unit — the cap only kicks in for cluster
+ * sizes that could not run under the pre-refactor implementation anyway.
+ */
+export const MAX_MEMBERS_PER_UNIT = 100;
+
+/**
+ * @see stageAPerBlock
+ */
+export type StageAPerBlockOptions = TokenizeOptions & {
+	readonly similarityThreshold?: number;
+	readonly autoCapMainDepth?: boolean;
+	readonly minKneeRatio?: number;
+	readonly maxCandidateDepth?: number;
+	/**
+	 * When set, any Stage-A cluster with more than this many members has its
+	 * `memberTokenSets` / `memberLandmarkInstances` down-sampled via
+	 * {@link ./reservoir-sample.js | reservoirSample} (seed = unit key,
+	 * deterministic). Callers on the in-memory path omit this so validated
+	 * corpora keep full membership; the streaming path sets it to
+	 * {@link MAX_MEMBERS_PER_UNIT} to bound accumulated Stage B state.
+	 */
+	readonly capMembers?: number;
+};
+
+/**
+ * @see stageAPerBlock
+ */
+export type StageAPerBlockInput = {
+	/** The block's block key (as produced by pass 0). */
+	readonly blockKey: string;
+	/**
+	 * Original input indices of this block's members, in input order. Returned
+	 * unchanged in the mapping so the caller can write pages' cluster keys
+	 * back into a global keys array. Same length as `preparedHtml` /
+	 * `landmarks` / `localLandmarkTokensByPage`.
+	 */
+	readonly memberIndices: readonly number[];
+	/**
+	 * The block's per-page landmark-excised (and optionally
+	 * `removeContentBlocks`-stripped) HTML — what the in-memory driver calls
+	 * `preparedHtml`. Provided by the caller to keep this helper stateless
+	 * about `excludeLandmarks` / `contentBlockAttribute` decisions.
+	 */
+	readonly preparedHtml: readonly string[];
+	/** The block's per-page {@link ./extract-landmarks.js | ExtractLandmarksResult}. */
+	readonly landmarks: readonly ExtractLandmarksResult[];
+	/**
+	 * The block's per-page local-landmark reinjection token sets. Same-shape
+	 * output of {@link ./resolve-page-cluster-keys.js | computeLocalLandmarkTokens},
+	 * pre-computed by the caller so this helper stays agnostic to whether
+	 * chrome discovery ran corpus-wide (small-corpus in-memory path) or
+	 * per-block (large-corpus streaming path).
+	 */
+	readonly localLandmarkTokensByPage: readonly ReadonlySet<string>[];
+};
+
+/**
+ * @see stageAPerBlock
+ */
+export type StageAPerBlockResult = {
+	/**
+	 * Map from `memberIndices[i]` (original input index) to that page's
+	 * post-Stage-A cluster key. Keys are of the form
+	 * `JSON.stringify([blockKey, "cluster:N"])` (unchanged from the in-memory
+	 * driver's per-block loop) — Stage B later rewrites them into merged
+	 * groups when it finds cross-block matches.
+	 */
+	readonly pageKeys: ReadonlyMap<number, string>;
+	/**
+	 * One {@link ./merge-cross-block-clusters.js | CrossBlockUnit} per
+	 * post-Stage-A cluster, in first-seen order.
+	 */
+	readonly crossBlockUnits: readonly CrossBlockUnit[];
+};
+
+/**
+ * Runs Stage A (dendrogram + auto-cut + containment assignment) on one
+ * block's pages, and returns both the per-page cluster keys and the
+ * {@link ./merge-cross-block-clusters.js | CrossBlockUnit} rows that Stage B
+ * needs afterward.
+ *
+ * ## Why extract this from `resolvePageClusterKeys`?
+ *
+ * The in-memory driver holds every page's HTML/landmarks/preparedHtml in
+ * arrays before the per-block loop begins, and any dataset large enough to
+ * break memory does so before Stage A even starts. For streaming mode this
+ * inner per-block loop needs to run for one block at a time: read that
+ * block's HTML, run Stage A, emit its crossBlockUnit rows, free the block's
+ * memory, move to the next. Splitting the Stage A body into a standalone
+ * function is what makes that per-block iteration possible without
+ * duplicating the Stage A logic between the two drivers.
+ *
+ * Preserves the in-memory driver's per-block behavior exactly for the same
+ * inputs — same `preparedHtml`, same `landmarks`, same
+ * `localLandmarkTokensByPage`, same `options` → same output.
+ * @param input
+ * @param options
+ */
+export function stageAPerBlock(
+	input: StageAPerBlockInput,
+	options?: StageAPerBlockOptions,
+): StageAPerBlockResult {
+	const { blockKey, memberIndices, preparedHtml, landmarks, localLandmarkTokensByPage } =
+		input;
+	const similarityThreshold = options?.similarityThreshold ?? 0.8;
+	const autoCapMainDepth = options?.autoCapMainDepth ?? true;
+
+	// A block of 1 can never produce more than one cluster regardless of how
+	// it's tokenized — nothing to compare it against — so detecting a knee
+	// and capping for it would only spend a full multi-depth sweep to arrive
+	// back at the same single-cluster result. Skipped rather than swept.
+	const maxMainDepth =
+		autoCapMainDepth && preparedHtml.length > 1
+			? detectContentDepthCap(preparedHtml, options)
+			: undefined;
+	const blockTokenSets: ReadonlySet<string>[] = preparedHtml.map((html, position) => {
+		const capped =
+			maxMainDepth === undefined
+				? html
+				: capContentDepth(html, { landmark: 'main', maxDepth: maxMainDepth })
+						.remainderHtml;
+		const tokens = new Set(tokenize(capped, options).tokens);
+		// Reinject each page's local-landmark tokens (see
+		// resolve-page-cluster-keys.ts's computeLocalLandmarkTokens JSDoc).
+		const localTokens = localLandmarkTokensByPage[position];
+		if (localTokens !== undefined) {
+			for (const token of localTokens) tokens.add(token);
+		}
+		return tokens;
+	});
+
+	// Stage A: dendrogram + auto-cut + optional containment assignment
+	const blockSize = blockTokenSets.length;
+	const comparisonSets = deriveComparisonSets(blockTokenSets);
+	const merges = completeLinkageDendrogram(comparisonSets);
+	const cut = autoCutThreshold(
+		merges.map((m) => m.height),
+		similarityThreshold,
+	);
+	let roots = labelsAtThreshold(blockSize, merges, cut);
+
+	// Containment assignment only for blocks large enough to have had
+	// frequency-based comparison sets (same MIN_PAGE_COUNT_FOR_FREQUENCY_SPLIT
+	// threshold as deriveComparisonSets).
+	if (blockSize >= MIN_PAGE_COUNT_FOR_FREQUENCY_SPLIT) {
+		const clusterTokens = new Map<number, Set<string>>();
+		const clusterPageCount = new Map<number, number>();
+		for (let i = 0; i < blockSize; i++) {
+			const r = roots[i]!;
+			let tokens = clusterTokens.get(r);
+			if (!tokens) {
+				tokens = new Set();
+				clusterTokens.set(r, tokens);
+			}
+			for (const t of comparisonSets[i]!) tokens.add(collapseAnonymousDivs(t));
+			clusterPageCount.set(r, (clusterPageCount.get(r) ?? 0) + 1);
+		}
+		const entries = [...clusterTokens.entries()].map(([id, tokens]) => ({
+			id,
+			tokens: tokens as ReadonlySet<string>,
+			pageCount: clusterPageCount.get(id) ?? 0,
+		}));
+		const contResult = assignContainedClusters(entries);
+		roots = roots.map((r) => contResult.get(r) ?? r);
+	}
+
+	// Assign string cluster labels in first-seen order
+	const rootToLabel = new Map<number, string>();
+	const localLabels = roots.map((root) => {
+		let label = rootToLabel.get(root);
+		if (label === undefined) {
+			label = `cluster:${rootToLabel.size}`;
+			rootToLabel.set(root, label);
+		}
+		return label;
+	});
+
+	const pageKeys = new Map<number, string>();
+	const unitKeyToPositions = new Map<string, number[]>();
+	for (const [position, memberIndex] of memberIndices.entries()) {
+		const unitKey = JSON.stringify([blockKey, localLabels[position]!]);
+		pageKeys.set(memberIndex, unitKey);
+		let positions = unitKeyToPositions.get(unitKey);
+		if (!positions) {
+			positions = [];
+			unitKeyToPositions.set(unitKey, positions);
+		}
+		positions.push(position);
+	}
+
+	// Pre-tokenize each page's landmark instances once now, and hand Stage B
+	// those instance lists directly instead of the ~10×-larger raw
+	// `ExtractLandmarksResult` objects. Stage B's only consumer of landmark
+	// data (`shellQuorum`) previously re-ran `computePerPageLandmarkInstances`
+	// on every call — the new signature accepts pre-tokenized instances, so
+	// we compute them once per page here and skip the repeat work as a
+	// side benefit. The memory reduction is the primary reason: 176k pages ×
+	// ~1 KB PerPageLandmarkInstance is ~200 MB, versus ~2–3 GB when we kept
+	// full ExtractLandmarksResult objects.
+	const memberLandmarkInstancesByPage = computePerPageLandmarkInstances(
+		landmarks,
+		options,
+	);
+
+	const crossBlockUnits: CrossBlockUnit[] = [];
+	for (const [unitKey, positions] of unitKeyToPositions) {
+		// Down-sample any unit that exceeds `capMembers` (opt-in — the
+		// streaming path passes MAX_MEMBERS_PER_UNIT; the in-memory path
+		// omits the option to preserve full-membership Stage B semantics
+		// unchanged for validated corpora). Reservoir seed is the unit key
+		// so the sampling is deterministic across runs for the same input.
+		const cap = options?.capMembers;
+		const sampledPositions =
+			cap !== undefined && positions.length > cap
+				? reservoirSample(positions, cap, unitKey)
+				: positions;
+		crossBlockUnits.push({
+			key: unitKey,
+			memberTokenSets: sampledPositions.map((pos) => blockTokenSets[pos]!),
+			memberLandmarkInstances: sampledPositions.map(
+				(pos) => memberLandmarkInstancesByPage[pos]!,
+			),
+		});
+	}
+	return { pageKeys, crossBlockUnits };
+}


### PR DESCRIPTION
## Summary

`resolvePageClusterKeys` を **async ファクトリ入力**に変え、コーパスがマシンメモリを超えても完走できるようストリーミング経路を追加。従来の array 入力 API は syntactic sugar `resolvePageClusterKeysFromArray` として保持。

**BREAKING CHANGE**

```ts
// Before
resolvePageClusterKeys(pages: PageClusterSignals[], options?): string[]

// After
resolvePageClusterKeys(
    pages: () => Iterable<PageClusterSignals> | AsyncIterable<PageClusterSignals>,
    options?,
): Promise<string[]>

// Convenience for callers with an in-memory array
resolvePageClusterKeysFromArray(pages: PageClusterSignals[], options?): Promise<string[]>
```

## 動機

前 PR (#916) までの実装は全ページを配列に materialize する設計で、10 GB / 176k ページ級の実データで OS SIGKILL / V8 heap OOM が確定。実務の大規模クロールに耐えない。

## 変更点

### 経路分岐

| コーパスサイズ | 経路 | 挙動 |
|---|---|---|
| ≤ `CORPUS_INLINE_THRESHOLD` (20,000) | in-memory | 前 PR と byte-identical |
| > 20,000 | streaming | 3 パス構成 |

streaming 経路の 3 パス:

1. **Pass 0 — HTML-free blocking**: `paths` / `stylesheetHrefs` / `host` のみ全ページ走査。`resolveBlockKeys` (新規、既存の blocking / orphan-reassignment / first-party フィルタを合成) で全 blockKey を確定
2. **Pass 1 — per-block reservoir sampling**: 各ブロックから最大 `BLOCK_SAMPLE_SIZE` (100) ページを Algorithm R でサンプル。サンプルに Stage A を実行し、per-block `maxMainDepth` / local-chrome signatures / per-cluster member token sets を学習物として保持
3. **Pass 1b — Jaccard 割当**: 非サンプルページを再ストリームし、そのブロックの学習物と同一の変換空間（chrome 再注入、maxMainDepth 適用、tokenize）でトークン化 → 最良 Jaccard クラスタに割当

Stage B (`mergeCrossBlockClusters`) はサンプルベースの `CrossBlockUnit` 群に対して従来通り実行。

### メモリ削減

- `CrossBlockUnit.memberLandmarks: ExtractLandmarksResult[]` → `memberLandmarkInstances: PerPageLandmarkInstance[][]`。事前トークン化して保持することで per-page ~10× のメモリ削減。Stage B 側 (`shellQuorum`) も再トークン化を停止
- `mergeCrossBlockClusters` に opt-in `capMembers` を追加。merged group を各 merge 後にダウンサンプリング。streaming 経路のみ有効化、in-memory 経路には影響なし

### 決定論

- reservoir sampling は Mulberry32 PRNG を block key の FNV-1a hash でシード。同じコーパス・同じ入力順で同じ結果

## 検証

### 既存 4 コーパス回帰（in-memory 経路、ゲート値完全一致）

| ページ数 | クラスタ数 | resolve 時間 | peak RSS |
|---|---|---|---|
| 302 | 9 | 2.4 s | 251 MB |
| 8,936 | 21 | 106 s | 1.2 GB |
| 1,416 | 63 | 77 s | 3.2 GB |
| 89 | 3 | 0.7 s | 115 MB |

### 大規模実データ（streaming 経路）

- **176,046 ページ / 10 GB アーカイブ**
- 完走時間: **27.7 分**
- peak RSS: **1.4 GB**、peak heap: **2.8 GB**（従来 8 GB heap でも OOM）
- クラスタ数: 232

### テスト

- 767 spec 全 pass
- 新規 spec: `pass0-blocking.spec.ts`、`reservoir-sample.spec.ts`、`resolve-page-cluster-keys-streaming.spec.ts`

## 意図的に本 PR に含めていないもの（別 PR で継続）

- 公式 CLI（JSONL パイプ、bin フィールド）
- options 縮小と自己解決化（`landmarkGateSimilarityThreshold` 撤去等）
- `package.json` の `exports` を 4 サブパスに絞る作業
- README 刷新（Quickstart + アルゴリズム walkthrough）
- 進捗コールバック (`onProgress`)

## Test plan

- [x] `yarn build` / `yarn lint` / `yarn test` all pass
- [x] 既存 4 コーパスで前 PR ゲート値 (9 / 21 / 63 / 3) を維持
- [x] 176k ページの実データで完走確認（1.4 GB RSS / 27.7 min）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
