### PR TITLE
feat(page-cluster): show user-friendly stderr progress via Lanes

### DIFF
--- a/packages/@d-zero/dealer/src/display.spec.ts
+++ b/packages/@d-zero/dealer/src/display.spec.ts
@@ -1,6 +1,27 @@
+import { Writable } from 'node:stream';
+
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import { Display } from './display.js';
+
+/**
+ * `Writable` stub for stream-option tests. Collects every chunk into an
+ * in-memory buffer and exposes the concatenated string so assertions can
+ * grep for expected fragments.
+ */
+function makeStreamCollector(): {
+	readonly stream: NodeJS.WritableStream;
+	read(): string;
+} {
+	const chunks: Buffer[] = [];
+	const stream = new Writable({
+		write(chunk: Buffer | string, _encoding, cb) {
+			chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+			cb();
+		},
+	});
+	return { stream, read: () => Buffer.concat(chunks).toString('utf8') };
+}
 
 let stdoutWriteSpy: ReturnType<typeof vi.spyOn>;
 
@@ -215,5 +236,38 @@ describe('Display.write() after close()', () => {
 		display.write('late message');
 
 		expect(stdoutWriteSpy).not.toHaveBeenCalled();
+	});
+});
+
+describe('Display stream option', () => {
+	test('verbose writes go to the provided stream, not process.stdout', () => {
+		const collector = makeStreamCollector();
+		const display = new Display({ stream: collector.stream, verbose: true });
+		display.write('hello via stream');
+		display.close();
+
+		expect(collector.read()).toContain('hello via stream');
+		// stdoutWriteSpy is the process.stdout guard — no accidental leak
+		expect(stdoutWriteSpy).not.toHaveBeenCalled();
+	});
+
+	test('non-verbose frame paints go to the provided stream', () => {
+		const collector = makeStreamCollector();
+		const display = new Display({ stream: collector.stream });
+		display.write('frame via stream');
+		display.close();
+
+		expect(collector.read()).toContain('frame via stream');
+		expect(stdoutWriteSpy).not.toHaveBeenCalled();
+	});
+
+	test('default stream stays process.stdout (regression guard)', () => {
+		const display = new Display({ verbose: true });
+		display.write('default stdout');
+		display.close();
+
+		// Default routing must remain process.stdout so callers who don't pass
+		// stream (dealer/deal.ts) keep their pre-refactor behavior verbatim
+		expect(stdoutWriteSpy).toHaveBeenCalled();
 	});
 });

--- a/packages/@d-zero/dealer/src/display.ts
+++ b/packages/@d-zero/dealer/src/display.ts
@@ -20,6 +20,14 @@ interface Options {
 	animations?: Animations;
 	fps?: FPS;
 	verbose?: boolean;
+	/**
+	 * 出力先のストリーム。省略時は `process.stdout`。
+	 * `process.stderr` のような別ストリームを指定すると、フレーム描画・verbose
+	 * 出力・resize ハンドラ・カラム幅取得のすべてがそのストリームに向く。
+	 * page-cluster CLI のように stdout を別用途 (JSONL 出力) に使うツールが
+	 * stderr へ進捗を出すために追加された。
+	 */
+	stream?: NodeJS.WritableStream;
 }
 
 export class Display {
@@ -33,6 +41,7 @@ export class Display {
 	#sigintHandler: (() => void) | null = null;
 	#stack: string[] | null = null;
 	readonly #startTime = Date.now();
+	#stream: NodeJS.WritableStream;
 	#timer: ReturnType<typeof setTimeout> | null = null;
 	#verbose: boolean;
 
@@ -46,9 +55,12 @@ export class Display {
 		this.#frameInterval = 1000 / fps;
 
 		this.#verbose = options?.verbose ?? false;
+		this.#stream = options?.stream ?? process.stdout;
 
 		this.#resizeHandler = () => this.#resize();
-		process.stdout.on('resize', this.#resizeHandler);
+		// resize は TTY WriteStream でしか発火しないが、Writable (EventEmitter)
+		// なら .on 自体は存在するので runtime エラーにはならない。
+		(this.#stream as NodeJS.EventEmitter).on?.('resize', this.#resizeHandler);
 
 		if (!this.#verbose) {
 			this.#sigintHandler = () => {
@@ -78,7 +90,7 @@ export class Display {
 		}
 
 		if (this.#resizeHandler) {
-			process.stdout.off('resize', this.#resizeHandler);
+			(this.#stream as NodeJS.EventEmitter).off?.('resize', this.#resizeHandler);
 			this.#resizeHandler = null;
 		}
 
@@ -105,7 +117,7 @@ export class Display {
 
 		if (this.#verbose) {
 			for (const log of logs) {
-				process.stdout.write(this.#text(log, false) + '\n');
+				this.#stream.write(this.#text(log, false) + '\n');
 			}
 			return;
 		}
@@ -166,7 +178,8 @@ export class Display {
 		text = this.#countDown(text);
 		text = text.replaceAll(/\r?\n/g, ' ');
 		if (trim) {
-			text = text.slice(0, process.stdout.columns);
+			const columns = (this.#stream as { columns?: number }).columns;
+			text = text.slice(0, columns);
 		}
 		return `${RESET}${text}${RESET}`;
 	}
@@ -189,7 +202,7 @@ export class Display {
 		}
 		output += content;
 
-		process.stdout.write(output);
+		this.#stream.write(output);
 		this.#lastWroteLineNum = this.#stack.length;
 	}
 }

--- a/packages/@d-zero/dealer/src/lanes.ts
+++ b/packages/@d-zero/dealer/src/lanes.ts
@@ -15,6 +15,12 @@ export type LanesOptions = {
 	readonly fps?: FPS;
 	readonly indent?: string;
 	readonly sort?: SortFunc;
+	/**
+	 * 出力先ストリーム。省略時は `process.stdout`。
+	 * stdout を別用途に使う CLI (例: JSONL 出力を stdout に流す page-cluster)
+	 * が進捗表示だけを stderr に振り分けたいときに指定する。
+	 */
+	readonly stream?: NodeJS.WritableStream;
 	readonly verbose?: boolean;
 };
 
@@ -34,6 +40,7 @@ export class Lanes {
 		this.#display = new Display({
 			animations: options?.animations,
 			fps: options?.fps,
+			stream: options?.stream,
 			verbose: options?.verbose,
 		});
 		this.#indent = options?.indent ?? this.#indent;

--- a/packages/@d-zero/page-cluster/README.md
+++ b/packages/@d-zero/page-cluster/README.md
@@ -52,14 +52,27 @@ page-cluster --content-block-attribute data-bgb < pages.jsonl > clusters.jsonl
 
 ### 進捗
 
-処理中は stderr に `[page-cluster] ...` 形式で進捗を出す。stdout の JSONL 出力は影響を受けない。
+処理中は stderr に進捗を出す。stdout の JSONL 出力は影響を受けない。
+
+**対話端末 (TTY)**: `%earth%` アニメ付きの単一ヘッダー行が in-place に書き換わり、現在のフェーズ・進捗・経過時間を表示する。
 
 ```
-[page-cluster] pass0: 10000 pages read
-[page-cluster] pass1: block 12/47 complete
-[page-cluster] pass1b: 30000/70000 pages assigned
-[page-cluster] stage-b: merging 47 unit(s)
+🌏 page-cluster — clustering 12/47 blocks (elapsed 23s)
 ```
+
+**非TTY (パイプ・ファイルリダイレクト・CI)**: `[page-cluster] ...` 形式の行を追記する。`pass0:` / `pass1:` / `pass1b:` / `stage-b:` の phase トークンを含むので `grep` / `awk` 互換。
+
+```
+[page-cluster] reading input pages...
+[page-cluster] read 10000 pages, clustering...
+[page-cluster] pass0: 10000 pages read
+[page-cluster] pass1: clustered block 12/47
+[page-cluster] pass1b: 30000/70000 pages assigned
+[page-cluster] stage-b: merging 47 units
+[page-cluster] done — 10000 pages in 47 clusters (elapsed 87s)
+```
+
+silence したい場合は `2>/dev/null`。ログに残したい場合は `2> progress.log`。
 
 ## API (brief)
 

--- a/packages/@d-zero/page-cluster/package.json
+++ b/packages/@d-zero/page-cluster/package.json
@@ -26,9 +26,7 @@
 			"types": "./dist/resolve-page-cluster-keys.d.ts"
 		}
 	},
-	"bin": {
-		"page-cluster": "./dist/cli.js"
-	},
+	"bin": "./dist/cli.js",
 	"files": [
 		"dist"
 	],
@@ -38,6 +36,7 @@
 		"clean": "tsc --build --clean"
 	},
 	"dependencies": {
+		"@d-zero/dealer": "1.9.4",
 		"@d-zero/shared": "0.22.2",
 		"htmlparser2": "12.0.0"
 	},

--- a/packages/@d-zero/page-cluster/src/cli.spec.ts
+++ b/packages/@d-zero/page-cluster/src/cli.spec.ts
@@ -29,6 +29,20 @@ function makeStdin(input: string): NodeJS.ReadableStream {
 	return Readable.from([input]);
 }
 
+/**
+ * Removes ANSI SGR (`\x1B[…m`) escape sequences from a captured stream so
+ * regex assertions against Lanes-produced verbose output can focus on the
+ * human-readable payload. Lanes wraps every verbose line as
+ * `RESET header RESET message RESET`, and those RESET codes would otherwise
+ * sit between the `[page-cluster]` header and the trailing message,
+ * breaking any regex that spans that boundary.
+ * @param text
+ */
+function stripAnsi(text: string): string {
+	// eslint-disable-next-line no-control-regex
+	return text.replaceAll(/\u001B\[[\d;]*m/g, '');
+}
+
 describe('parseArgs', () => {
 	test('empty args', () => {
 		expect(parseArgs([])).toEqual({});
@@ -206,5 +220,74 @@ describe('runCli', () => {
 			.filter(Boolean)
 			.map((line) => JSON.parse(line) as { id: number | string; clusterKey: string });
 		expect(parsed.map((p) => p.id)).toEqual([0, 1]);
+	});
+
+	test('emits reading / clustered / done progress lines on stderr (non-TTY)', async () => {
+		const input = [
+			JSON.stringify({
+				id: 'a',
+				paths: ['news', '1'],
+				stylesheetHrefs: [],
+				html: '<body><article>one</article></body>',
+			}),
+			JSON.stringify({
+				id: 'b',
+				paths: ['news', '2'],
+				stylesheetHrefs: [],
+				html: '<body><article>two</article></body>',
+			}),
+			JSON.stringify({
+				id: 'c',
+				paths: ['about'],
+				stylesheetHrefs: [],
+				html: '<body><section>about</section></body>',
+			}),
+		].join('\n');
+		const stdout = makeCollector();
+		const stderr = makeCollector();
+		const code = await runCli({
+			stdin: makeStdin(input),
+			stdout: stdout.stream,
+			stderr: stderr.stream,
+			argv: [],
+			version: '0.0.0',
+		});
+		expect(code).toBe(0);
+		const stderrText = stripAnsi(stderr.read());
+		// The `makeCollector` `Writable` has no `isTTY` so CLI routes through
+		// Lanes' verbose path, producing plain `[page-cluster] …` lines that
+		// this test can regex directly (after stripping the RESET codes
+		// Lanes wraps around every field). Verbose lines keep the original
+		// `pass1:` / `stage-b:` phase tokens for grep/awk compatibility.
+		expect(stderrText).toMatch(/\[page-cluster\] reading input pages/);
+		expect(stderrText).toMatch(/\[page-cluster\] read 3 pages, clustering/);
+		expect(stderrText).toMatch(/\[page-cluster\] pass1: clustered block \d+\/\d+/);
+		expect(stderrText).toMatch(/\[page-cluster\] done — 3 pages in \d+ clusters/);
+		// Regression guard for the "literal 'undefined ' prefix" bug that
+		// code-review high effort caught before this commit: an unset
+		// lanes.header made every verbose progress line begin with the
+		// string "undefined " ahead of the "[page-cluster]" chunk.
+		expect(stderrText).not.toMatch(/undefined \[page-cluster\]/);
+	});
+
+	test('malformed JSONL still closes the Lanes display (no timer leak / process hang) and surfaces the error via Lanes', async () => {
+		const stdout = makeCollector();
+		const stderr = makeCollector();
+		// A Node timer leak would hang this test because Vitest waits for the
+		// event loop to drain. If `runCli` resolves without hanging, the
+		// `try/finally` did its job of releasing the Display's setTimeout.
+		const code = await runCli({
+			stdin: makeStdin('this is not json\n'),
+			stdout: stdout.stream,
+			stderr: stderr.stream,
+			argv: [],
+			version: '0.0.0',
+		});
+		expect(code).toBe(1);
+		// The error is routed through Lanes so a TTY Display.close() repaint
+		// would not erase it. Verbose mode surfaces it as `[page-cluster] error: <message>`.
+		expect(stripAnsi(stderr.read())).toMatch(
+			/\[page-cluster\] error: .*failed to parse JSONL/,
+		);
 	});
 });

--- a/packages/@d-zero/page-cluster/src/cli.ts
+++ b/packages/@d-zero/page-cluster/src/cli.ts
@@ -2,7 +2,8 @@
 // Wire the `page-cluster` executable to the library's factory-based
 // `resolvePageClusterKeys`. Reads JSONL from stdin (one page per line),
 // writes JSONL to stdout (one cluster assignment per line, in input order),
-// and streams progress to stderr.
+// and streams progress to stderr via `@d-zero/dealer`'s `Lanes` — in-place
+// animated header on a TTY, appended `[page-cluster] …` lines otherwise.
 
 import type {
 	PageClusterSignals,
@@ -11,6 +12,8 @@ import type {
 } from './resolve-page-cluster-keys.js';
 
 import process from 'node:process';
+
+import { Lanes } from '@d-zero/dealer';
 
 import { resolvePageClusterKeys } from './resolve-page-cluster-keys.js';
 
@@ -48,10 +51,28 @@ Options:
   --version                          Print the package version and exit.
 
 Progress:
-  Emitted to stderr as \`[page-cluster] <event>\` lines while the run is in
-  progress. Piping stderr to /dev/null silences them; the JSONL output on
-  stdout is unaffected.
+  Emitted to stderr while the run is in progress. On an interactive
+  terminal, an in-place animated header shows the current phase and
+  elapsed time. When stderr is not a TTY (redirected to a file, piped, or
+  under CI), each phase transition is appended as a \`[page-cluster] …\`
+  line so \`grep\` / \`awk\` stay trivial. Silence progress with
+  \`2>/dev/null\`; the JSONL output on stdout is unaffected either way.
 `;
+
+/**
+ * Log id used for the single-lane `lanes.update()` call under verbose mode.
+ * Lanes was originally designed for one line per parallel worker; here we
+ * only ever have one narrative line, so a fixed id is enough.
+ */
+const LANE_ID = 0;
+
+/**
+ * Prefix rendered ahead of every verbose progress line. Set on `lanes.header`
+ * at CLI init so that `lanes.update(LANE_ID, …)` under Lanes' verbose mode
+ * emits `[page-cluster] <line>` rather than the `undefined <line>` string
+ * it would produce with an unset header (see `dealer/lanes.ts:104`).
+ */
+const VERBOSE_HEADER = '[page-cluster]';
 
 /**
  * Parses `process.argv`-style arguments (already sliced past `node script`)
@@ -100,29 +121,6 @@ export function parseArgs(argv: readonly string[]): CliArgs {
 }
 
 /**
- * Renders a {@link ./resolve-page-cluster-keys.js | ProgressEvent} as a
- * single stderr line. Format is intentionally line-oriented and
- * self-descriptive so that piping to `grep` / `awk` stays trivial.
- * @param event
- */
-function formatProgress(event: ProgressEvent): string {
-	switch (event.phase) {
-		case 'pass0-signals': {
-			return `[page-cluster] pass0: ${event.pagesSeen} pages read\n`;
-		}
-		case 'pass1-block-complete': {
-			return `[page-cluster] pass1: block ${event.blocksProcessed}/${event.totalBlocks} complete\n`;
-		}
-		case 'pass1b-assign': {
-			return `[page-cluster] pass1b: ${event.pagesAssigned}/${event.pagesToAssign} pages assigned\n`;
-		}
-		case 'stage-b-start': {
-			return `[page-cluster] stage-b: merging ${event.unitCount} unit(s)\n`;
-		}
-	}
-}
-
-/**
  * Streams `stdin` and yields per-line JSON-parsed page objects (plus the
  * original line's `id`, preserved for the output row). Chunk-boundary
  * splitting is done by hand rather than via `readline` because certain
@@ -155,13 +153,11 @@ async function* readJsonlPages(
 				entry = JSON.parse(line) as typeof entry;
 			} catch (error) {
 				throw new Error(
-					`page-cluster: failed to parse JSONL line ${lineNo}: ${(error as Error).message}`,
+					`failed to parse JSONL line ${lineNo}: ${(error as Error).message}`,
 				);
 			}
 			if (typeof entry.html !== 'string') {
-				throw new TypeError(
-					`page-cluster: JSONL line ${lineNo} is missing a string \`html\` field`,
-				);
+				throw new TypeError(`JSONL line ${lineNo} is missing a string \`html\` field`);
 			}
 			yield {
 				id: entry.id,
@@ -187,13 +183,11 @@ async function* readJsonlPages(
 			entry = JSON.parse(leftover) as typeof entry;
 		} catch (error) {
 			throw new Error(
-				`page-cluster: failed to parse final JSONL line ${lineNo}: ${(error as Error).message}`,
+				`failed to parse final JSONL line ${lineNo}: ${(error as Error).message}`,
 			);
 		}
 		if (typeof entry.html !== 'string') {
-			throw new TypeError(
-				`page-cluster: JSONL line ${lineNo} is missing a string \`html\` field`,
-			);
+			throw new TypeError(`JSONL line ${lineNo} is missing a string \`html\` field`);
 		}
 		yield {
 			id: entry.id,
@@ -204,6 +198,128 @@ async function* readJsonlPages(
 				host: entry.host,
 			},
 		};
+	}
+}
+
+/**
+ * TTY / verbose text pair for one progress moment. `renderProgress` picks
+ * one arm depending on `useTty`. Keeping the two strings together at the
+ * call site avoids threading a `useTty` flag into every message-shaping
+ * helper.
+ */
+type ProgressLine = { readonly tty: string; readonly verbose: string };
+
+/**
+ * Renders the current lane message via TTY header or verbose-appended line
+ * depending on the `useTty` mode. Wraps both `lanes.header()` and
+ * `lanes.update(LANE_ID, …)` because — as documented in `dealer/lanes.ts` —
+ * `header()` under verbose is a state-only setter that produces no output,
+ * so verbose runs must go through `update()` to actually emit a line.
+ * @param lanes
+ * @param useTty
+ * @param line
+ */
+function renderProgress(lanes: Lanes, useTty: boolean, line: ProgressLine): void {
+	if (useTty) {
+		lanes.header(line.tty);
+	} else {
+		lanes.update(LANE_ID, line.verbose);
+	}
+}
+
+/**
+ * Human-facing wording for the "reading input pages" moment (before stdin
+ * is fully consumed). Verbose lines omit the `[page-cluster]` prefix — it
+ * is applied once via `VERBOSE_HEADER` when Lanes constructs each verbose
+ * line.
+ */
+const READING_INPUT: ProgressLine = {
+	tty: '%earth% page-cluster — reading input...',
+	verbose: 'reading input pages...',
+};
+
+/**
+ * Progress line emitted after stdin is fully consumed, before the async
+ * factory-based `resolvePageClusterKeys` starts producing events.
+ * @param pageCount
+ */
+function readingDoneLine(pageCount: number): ProgressLine {
+	return {
+		tty: `%earth% page-cluster — read ${pageCount} pages, clustering...`,
+		verbose: `read ${pageCount} pages, clustering...`,
+	};
+}
+
+/**
+ * Final summary line rendered right before `lanes.close()`.
+ * @param pageCount
+ * @param clusterCount
+ * @param elapsedSec
+ */
+function doneLine(
+	pageCount: number,
+	clusterCount: number,
+	elapsedSec: number,
+): ProgressLine {
+	const body = `${pageCount} pages in ${clusterCount} clusters (elapsed ${elapsedSec}s)`;
+	return {
+		tty: `page-cluster — done: ${body}`,
+		verbose: `done — ${body}`,
+	};
+}
+
+/**
+ * Fatal-error line rendered via Lanes rather than a direct
+ * `stderr.write` — the interactive Display's `close()` runs a
+ * CURSOR_UP + ERASE_DOWN repaint that would wipe any raw stderr write
+ * emitted before it, silently swallowing the diagnostic in TTY mode.
+ * Sending the error through Lanes puts it into the final repainted
+ * frame, so it survives `close()`.
+ * @param message
+ */
+function errorLine(message: string): ProgressLine {
+	return {
+		tty: `page-cluster: ${message}`,
+		verbose: `error: ${message}`,
+	};
+}
+
+/**
+ * Maps a library `ProgressEvent` to a human-facing `ProgressLine`. The
+ * verbose arm keeps the historical `pass0:` / `pass1:` / `pass1b:` /
+ * `stage-b:` phase tokens so callers who grep stderr by phase name (a
+ * pattern the earlier `formatProgress` documented) stay compatible; TTY
+ * lines use natural-language wording since interactive users read the
+ * header, not grep.
+ * @param event
+ * @param elapsedSec
+ */
+function formatProgressLine(event: ProgressEvent, elapsedSec: number): ProgressLine {
+	switch (event.phase) {
+		case 'pass0-signals': {
+			return {
+				tty: `%earth% page-cluster — reading signals: ${event.pagesSeen} pages (elapsed ${elapsedSec}s)`,
+				verbose: `pass0: ${event.pagesSeen} pages read`,
+			};
+		}
+		case 'pass1-block-complete': {
+			return {
+				tty: `%earth% page-cluster — clustering ${event.blocksProcessed}/${event.totalBlocks} blocks (elapsed ${elapsedSec}s)`,
+				verbose: `pass1: clustered block ${event.blocksProcessed}/${event.totalBlocks}`,
+			};
+		}
+		case 'pass1b-assign': {
+			return {
+				tty: `%earth% page-cluster — assigning pages: ${event.pagesAssigned}/${event.pagesToAssign} (elapsed ${elapsedSec}s)`,
+				verbose: `pass1b: ${event.pagesAssigned}/${event.pagesToAssign} pages assigned`,
+			};
+		}
+		case 'stage-b-start': {
+			return {
+				tty: `%earth% page-cluster — merging ${event.unitCount} units (elapsed ${elapsedSec}s)`,
+				verbose: `stage-b: merging ${event.unitCount} units`,
+			};
+		}
 	}
 }
 
@@ -243,39 +359,73 @@ export async function runCli(options: {
 		return 2;
 	}
 
-	// Load every JSONL line into memory once so the ids array stays parallel
-	// to the pages array — the streaming driver reads its factory twice, and
-	// stdin is a one-shot pipe.
-	const ids: (string | number | undefined)[] = [];
-	const pages: PageClusterSignals[] = [];
+	// TTY detection: `NodeJS.WritableStream` doesn't expose `isTTY`, but the
+	// concrete `WriteStream` (and the in-memory `Writable` collectors tests
+	// pass in) does — reading it defensively lets both real usage and
+	// unit-test doubles work without a separate `--no-progress` flag.
+	const useTty = (options.stderr as { isTTY?: boolean }).isTTY === true;
+	const lanes = new Lanes({ stream: options.stderr, verbose: !useTty });
+	// Verbose Lanes prepends `#header` to every `update()` line. Without
+	// this seed call the header would be undefined and each progress line
+	// would begin with the literal string `undefined ` — bug caught by
+	// code-review high effort. TTY mode overwrites the header per event
+	// so the seed value is only surfaced verbatim under verbose.
+	if (!useTty) {
+		lanes.header(VERBOSE_HEADER);
+	}
+	const startTime = Date.now();
+	const elapsed = () => Math.max(0, Math.round((Date.now() - startTime) / 1000));
+
+	// Every early return past this point must run through the finally block
+	// so `lanes.close()` releases the display's setTimeout timer — without
+	// it a `return 1` on a stdin parse error would leave the process
+	// hanging on the timer's next tick.
 	try {
-		for await (const { id, page } of readJsonlPages(options.stdin)) {
-			ids.push(id);
-			pages.push(page);
+		renderProgress(lanes, useTty, READING_INPUT);
+
+		// Load every JSONL line into memory once so the ids array stays
+		// parallel to the pages array — the streaming driver reads its
+		// factory twice, and stdin is a one-shot pipe.
+		const ids: (string | number | undefined)[] = [];
+		const pages: PageClusterSignals[] = [];
+		try {
+			for await (const { id, page } of readJsonlPages(options.stdin)) {
+				ids.push(id);
+				pages.push(page);
+			}
+		} catch (error) {
+			renderProgress(lanes, useTty, errorLine((error as Error).message));
+			return 1;
 		}
-	} catch (error) {
-		options.stderr.write(`${(error as Error).message}\n`);
-		return 1;
-	}
 
-	const resolveOptions: ResolvePageClusterKeysOptions = {
-		contentBlockAttribute: args.contentBlockAttribute,
-		onProgress: (event) => options.stderr.write(formatProgress(event)),
-	};
-	let keys: string[];
-	try {
-		keys = await resolvePageClusterKeys(() => pages, resolveOptions);
-	} catch (error) {
-		options.stderr.write(`page-cluster: ${(error as Error).message}\n`);
-		return 1;
-	}
+		renderProgress(lanes, useTty, readingDoneLine(pages.length));
 
-	for (const [index, key] of keys.entries()) {
-		options.stdout.write(
-			`${JSON.stringify({ id: ids[index] ?? index, clusterKey: key })}\n`,
-		);
+		const resolveOptions: ResolvePageClusterKeysOptions = {
+			contentBlockAttribute: args.contentBlockAttribute,
+			onProgress: (event) => {
+				renderProgress(lanes, useTty, formatProgressLine(event, elapsed()));
+			},
+		};
+		let keys: string[];
+		try {
+			keys = await resolvePageClusterKeys(() => pages, resolveOptions);
+		} catch (error) {
+			renderProgress(lanes, useTty, errorLine((error as Error).message));
+			return 1;
+		}
+
+		const clusterCount = new Set(keys).size;
+		renderProgress(lanes, useTty, doneLine(pages.length, clusterCount, elapsed()));
+
+		for (const [index, key] of keys.entries()) {
+			options.stdout.write(
+				`${JSON.stringify({ id: ids[index] ?? index, clusterKey: key })}\n`,
+			);
+		}
+		return 0;
+	} finally {
+		lanes.close();
 	}
-	return 0;
 }
 
 /**

--- a/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys-streaming.spec.ts
+++ b/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys-streaming.spec.ts
@@ -1,4 +1,4 @@
-import type { PageClusterSignals } from './resolve-page-cluster-keys.js';
+import type { PageClusterSignals, ProgressEvent } from './resolve-page-cluster-keys.js';
 
 import { describe, expect, test } from 'vitest';
 
@@ -97,5 +97,70 @@ describe('resolvePageClusterKeysFromArray', () => {
 
 	test('empty input returns empty', async () => {
 		expect(await resolvePageClusterKeysFromArray([])).toEqual([]);
+	});
+});
+
+describe('resolvePageClusterKeys onProgress on small corpus', () => {
+	test('emits pass1-block-complete once per block with monotonic blocksProcessed', async () => {
+		const pages = buildTinyCorpus();
+		const events: ProgressEvent[] = [];
+		await resolvePageClusterKeys(() => pages, {
+			onProgress: (event) => events.push(event),
+		});
+
+		// `buildTinyCorpus()` yields three distinct blocking groups (`news`,
+		// `about`, `contact` — each has its own stylesheet host / path shape),
+		// so the streaming resolver processes exactly three blocks and
+		// emits `pass1-block-complete` three times with `blocksProcessed`
+		// values 1, 2, 3 in order and `totalBlocks` constant at 3. Hardcoded
+		// literals (instead of `map((_, i) => i + 1)`) so a regression that
+		// changes emission count is caught by a mismatch rather than a
+		// coincidentally-generated matching array.
+		const pass1Events = events.filter((e) => e.phase === 'pass1-block-complete');
+		expect(pass1Events).toHaveLength(3);
+		expect(pass1Events.map((e) => e.blocksProcessed)).toEqual([1, 2, 3]);
+		expect(pass1Events.map((e) => e.totalBlocks)).toEqual([3, 3, 3]);
+	});
+
+	test('emits stage-b-start exactly once after all blocks complete', async () => {
+		const pages = buildTinyCorpus();
+		const events: ProgressEvent[] = [];
+		await resolvePageClusterKeys(() => pages, {
+			onProgress: (event) => events.push(event),
+		});
+
+		const stageBIndex = events.findIndex((e) => e.phase === 'stage-b-start');
+		expect(stageBIndex).toBeGreaterThan(-1);
+		expect(events.filter((e) => e.phase === 'stage-b-start')).toHaveLength(1);
+		// Every pass1-block-complete must precede stage-b-start.
+		const pass1Count = events.filter((e) => e.phase === 'pass1-block-complete').length;
+		const pass1IndicesBeforeStageB = events
+			.slice(0, stageBIndex)
+			.filter((e) => e.phase === 'pass1-block-complete').length;
+		expect(pass1IndicesBeforeStageB).toBe(pass1Count);
+	});
+
+	test('result with onProgress is byte-for-byte identical to resolvePageClusterKeysInMemory', async () => {
+		const pages = buildTinyCorpus();
+		const withProgress = await resolvePageClusterKeys(() => pages, {
+			onProgress: () => {
+				// discard; only the return value matters here
+			},
+		});
+		const inMemory = resolvePageClusterKeysInMemory(pages);
+		expect(withProgress).toEqual(inMemory);
+	});
+
+	test('no onProgress delegates to sync in-memory path (no yield overhead)', async () => {
+		// Regression guard for the deliberate short-circuit that keeps
+		// library-only callers on the pre-refactor code path. The clearest
+		// black-box signal is that the sync `resolvePageClusterKeysInMemory`
+		// helper is what produces the reference keys — so asserting equality
+		// against it (rather than a hand-written expected array) is what
+		// documents the intended equivalence.
+		const pages = buildTinyCorpus();
+		const withoutProgress = await resolvePageClusterKeys(() => pages);
+		const inMemory = resolvePageClusterKeysInMemory(pages);
+		expect(withoutProgress).toEqual(inMemory);
 	});
 });

--- a/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys.ts
+++ b/packages/@d-zero/page-cluster/src/resolve-page-cluster-keys.ts
@@ -301,19 +301,28 @@ export type PageClusterSignals = {
  * progress on multi-minute jobs — the CLI wires this straight to stderr.
  *
  * The event is a discriminated union on `phase`:
- * - `pass0-signals`: reading blocking signals (paths / stylesheetHrefs /
- *   host) from the factory. Fires every ~1,000 pages during Pass 0.
- * - `pass1-block-complete`: one block's Stage A finished. Fires once per
- *   block, with the block's key and a running count of how many blocks
- *   have completed so far.
- 
- * - `pass1b-assign`: streaming assignment of non-sample pages is in
- *   progress (large-corpus path only). Fires every ~1,000 pages of Pass 1b.
- * - `stage-b-start`: cross-block merge has begun. Fires once per call.
+ * - `pass0-signals`: streaming path only. Reading blocking signals (paths /
+ *   stylesheetHrefs / host) from the factory. Fires every ~1,000 pages
+ *   during Pass 0.
+ * - `pass1-block-complete`: one block's Stage A finished. Fires on **both**
+ *   the small-corpus path (`≤ CORPUS_INLINE_THRESHOLD`, once per block in
+ *   `indicesByBlockKey` iteration order) and the streaming path (once per
+ *   block as its reservoir fills). The event carries the block's key and a
+ *   running count of how many blocks have completed so far.
+ * - `pass1b-assign`: streaming path only. Streaming assignment of
+ *   non-sample pages is in progress. Fires every ~1,000 pages of Pass 1b.
+ *   Conceptually absent on the small-corpus path — every page is a "sample"
+ *   there.
+ * - `stage-b-start`: cross-block merge has begun. Fires once per call on
+ *   both paths.
  *
  * Stage B does not currently emit per-round events — a future extension
  * that passes a callback down into `mergeCrossBlockClusters` can add them
  * without breaking the existing shape.
+ *
+ * The **sync** `resolvePageClusterKeysInMemory` never emits any progress
+ * (it has no way to yield to a caller mid-block anyway). Only the async
+ * factory-based entry point participates in `onProgress`.
  */
 export type ProgressEvent =
 	| { readonly phase: 'pass0-signals'; readonly pagesSeen: number }
@@ -344,8 +353,13 @@ export type ResolvePageClusterKeysOptions = TokenizeOptions &
 		 * Optional observability hook — invoked at every progress event
 		 * documented on {@link ./resolve-page-cluster-keys.js | ProgressEvent}.
 		 * Fires only on the async factory-based `resolvePageClusterKeys`;
-		 * the in-memory `resolvePageClusterKeysInMemory` path leaves this
-		 * untouched.
+		 * the sync `resolvePageClusterKeysInMemory` never emits events.
+		 * On the async path, passing this option promotes the small-corpus
+		 * branch (`≤ CORPUS_INLINE_THRESHOLD`) from delegating to the
+		 * sync helper to running a per-block async loop that emits
+		 * `pass1-block-complete` and `stage-b-start`. Omitting `onProgress`
+		 * keeps the small-corpus branch on the pre-refactor sync path with
+		 * zero yield overhead.
 		 */
 		onProgress?: (event: ProgressEvent) => void;
 	};
@@ -508,6 +522,117 @@ export function resolvePageClusterKeysInMemory(
 }
 
 /**
+ * Async twin of {@link ./resolve-page-cluster-keys.js | resolvePageClusterKeysInMemory}
+ * that emits `pass1-block-complete` (per block) and `stage-b-start`
+ * `ProgressEvent`s and yields control back to the event loop between
+ * blocks with `setImmediate`, so the async factory-based
+ * `resolvePageClusterKeys` can expose live progress on small corpora
+ * (`≤ CORPUS_INLINE_THRESHOLD`) without blocking the caller's UI thread.
+ *
+ * Semantic equivalence with `resolvePageClusterKeysInMemory` is preserved
+ * exactly: same corpus-wide chrome discovery, same per-block Stage A, same
+ * un-capped Stage B across the entire crossBlockUnits array. `finalKeys`
+ * returned here must be byte-for-byte identical to what the sync path
+ * would have produced for the same `pages` input — spec-enforced by
+ * `resolve-page-cluster-keys-streaming.spec.ts`.
+ *
+ * The sync `resolvePageClusterKeysInMemory` is deliberately left in place
+ * as its own implementation rather than being folded into a shared helper.
+ * The intentional duplication guarantees that library callers who pass no
+ * `onProgress` incur zero behavioral difference from the pre-refactor code
+ * (see the `onProgress === undefined` short-circuit in
+ * {@link ./resolve-page-cluster-keys.js | resolvePageClusterKeys}).
+ * @param pages
+ * @param onProgress
+ * @param options
+ */
+async function resolveSmallCorpusWithProgress(
+	pages: readonly PageClusterSignals[],
+	onProgress: (event: ProgressEvent) => void,
+	options?: ResolvePageClusterKeysOptions,
+): Promise<string[]> {
+	const excludeLandmarks = options?.excludeLandmarks ?? true;
+
+	const similarityThreshold = options?.similarityThreshold ?? 0.8;
+	if (!(similarityThreshold >= 0 && similarityThreshold <= 1)) {
+		throw new RangeError(
+			`resolvePageClusterKeys: similarityThreshold must be between 0 and 1, got ${similarityThreshold}`,
+		);
+	}
+
+	const landmarks: readonly ExtractLandmarksResult[] = pages.map((page) =>
+		extractLandmarks(page.html),
+	);
+	const localLandmarkTokensByPage = computeLocalLandmarkTokens(landmarks, options);
+
+	const contentBlockAttribute = options?.contentBlockAttribute;
+	const preparedHtml = pages.map((page, index) => {
+		const landmarksExcised = excludeLandmarks
+			? landmarks[index]!.remainderHtml
+			: page.html;
+		return contentBlockAttribute === undefined
+			? landmarksExcised
+			: removeContentBlocks(landmarksExcised, { blockAttribute: contentBlockAttribute })
+					.remainderHtml;
+	});
+
+	const restrictStylesheetsToFirstParty =
+		options?.restrictStylesheetsToFirstParty ?? true;
+	const blockingPages = restrictStylesheetsToFirstParty
+		? filterFirstPartyStylesheetHrefs(pages)
+		: pages;
+
+	const blockKeys = resolveBlockKeys(blockingPages, options);
+	const indicesByBlockKey = groupIndicesByBlockKey(blockKeys);
+
+	validateDetectContentDepthCapOptions(options);
+
+	const finalKeys: string[] = Array.from({ length: pages.length });
+	const crossBlockUnits: CrossBlockUnit[] = [];
+	const totalBlocks = indicesByBlockKey.size;
+	let blocksProcessed = 0;
+
+	for (const [blockKey, indices] of indicesByBlockKey) {
+		const result = stageAPerBlock(
+			{
+				blockKey,
+				memberIndices: indices,
+				preparedHtml: indices.map((i) => preparedHtml[i]!),
+				landmarks: indices.map((i) => landmarks[i]!),
+				localLandmarkTokensByPage: indices.map((i) => localLandmarkTokensByPage[i]!),
+			},
+			options,
+		);
+		for (const [pageIndex, key] of result.pageKeys) {
+			finalKeys[pageIndex] = key;
+		}
+		crossBlockUnits.push(...result.crossBlockUnits);
+		blocksProcessed++;
+		onProgress({
+			phase: 'pass1-block-complete',
+			blockKey,
+			blocksProcessed,
+			totalBlocks,
+		});
+		// Yield to the event loop so Lanes' setTimeout frame can paint the
+		// updated header before the next block starts.
+		await new Promise<void>((resolve) => setImmediate(resolve));
+	}
+
+	onProgress({ phase: 'stage-b-start', unitCount: crossBlockUnits.length });
+
+	const stageBResult = mergeCrossBlockClusters(crossBlockUnits, options);
+	for (let i = 0; i < finalKeys.length; i++) {
+		const currentKey = finalKeys[i]!;
+		const rootKey = stageBResult.get(currentKey);
+		if (rootKey !== undefined && rootKey !== currentKey) {
+			finalKeys[i] = rootKey;
+		}
+	}
+	return finalKeys;
+}
+
+/**
  * Factory function returning an iterator over pages. Called once per streaming
  * pass — the driver may invoke it multiple times to re-read the same corpus
  * (once HTML-free for blocking, once again per block for HTML processing).
@@ -598,8 +723,8 @@ export async function resolvePageClusterKeys(
 	if (blockingSignals.length === 0) return [];
 
 	// Small corpus: read the whole factory again with HTML this time, then
-	// delegate to the in-memory path unchanged. Preserves every corpus-wide
-	// semantic (chrome, Stage B) for corpora within the threshold.
+	// delegate to the in-memory path. Preserves every corpus-wide semantic
+	// (chrome, Stage B) for corpora within the threshold.
 	if (blockingSignals.length <= CORPUS_INLINE_THRESHOLD) {
 		const fullPages: PageClusterSignals[] = [];
 		for await (const page of pages()) {
@@ -610,7 +735,15 @@ export async function resolvePageClusterKeys(
 				host: page.host,
 			});
 		}
-		return resolvePageClusterKeysInMemory(fullPages, options);
+		// Without an onProgress callback the caller does not need visibility
+		// into per-block progress, so delegate to the untouched sync path —
+		// keeping behavior byte-for-byte identical (and yield-overhead-free)
+		// to how library-only consumers experienced this before the CLI
+		// progress work landed.
+		if (onProgress === undefined) {
+			return resolvePageClusterKeysInMemory(fullPages, options);
+		}
+		return resolveSmallCorpusWithProgress(fullPages, onProgress, options);
 	}
 
 	// Large corpus: streaming path.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1350,8 +1350,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@d-zero/page-cluster@workspace:packages/@d-zero/page-cluster"
   dependencies:
+    "@d-zero/dealer": "npm:1.9.4"
     "@d-zero/shared": "npm:0.22.2"
     htmlparser2: "npm:12.0.0"
+  bin:
+    page-cluster: ./dist/cli.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

- `page-cluster` CLI が小規模コーパス (`<CORPUS_INLINE_THRESHOLD`, 実運用のほぼ全ケース) で完全に無音だった問題を解消。stdin から stdout まで数秒〜1分超の沈黙がなくなり、開始バナー・進捗・完了サマリを stderr に出す
- **TTY**: `@d-zero/dealer` の `Lanes` を stream オプション対応にして `stderr` に流し、`🌏 page-cluster — clustering 3/12 blocks (elapsed 12s)` のような in-place アニメヘッダーを表示
- **非TTY** (パイプ/ファイル/CI): `[page-cluster] pass1: clustered block 3/12` の行を追記。`pass0:` / `pass1:` / `pass1b:` / `stage-b:` の phase トークンを維持し `grep` / `awk` 互換
- **API 経由の呼び出し側は無影響**: `resolvePageClusterKeys` は `onProgress` 未指定時に従来通り同期 `resolvePageClusterKeysInMemory` に丸投げ (yield オーバーヘッドゼロ)。`onProgress` 指定時のみ既存 helper を async for に展開しブロック境界で progress 発火 + `setImmediate` yield
- **エラー消失バグ修正**: TTY モードで stderr に直接書いたエラーが `Display.close()` の ERASE_DOWN に消される問題を Lanes 経由での emission に統一して解決
- **タイマーリーク修正**: エラーパスで `lanes.close()` が呼ばれず setTimeout がプロセスをハングさせる穴を `try/finally` で塞ぐ

## Test plan

- [x] `yarn lint` (0 errors)
- [x] `yarn test` — 全 3102 テストパス、追加 9 テスト全パス
- [ ] TTY 実機確認: 対話端末で page-cluster を実行しアニメヘッダーが動作すること
- [ ] 非TTY 実機確認: `page-cluster < in.jsonl > out.jsonl 2> progress.log` で phase トークン付きの行が並ぶこと
- [ ] エラーパス実機確認: 壊れた JSONL を食わせて `[page-cluster] error: …` が TTY でも消えずに表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
