### PR TITLE
docs(page-cluster): rewrite README with mermaid pipeline and Stage B loop diagrams

### DIFF
--- a/packages/@d-zero/page-cluster/README.md
+++ b/packages/@d-zero/page-cluster/README.md
@@ -1,12 +1,8 @@
 # `@d-zero/page-cluster`
 
-大量クロール HTML の重複・類似ページを構造トークンで検出するパッケージ。CLI が主、ライブラリ関数群がオマケ。
+大量クロール HTML の重複・類似ページを構造トークンで検出するパッケージ。HTML ページ集合を受け取って、**同一テンプレートと判定できるページ**に同じクラスタキーを振る。テキストは無視して DOM 構造だけを見るので、本文が違っても同じテンプレートを使うページ群は 1 つのクラスタにまとまる。単一サイトで数万〜十数万ページ規模のクロール成果物を、テンプレート単位に畳んで概観したいときに使う。CLI が主、ライブラリ関数群がオマケ。
 
-## What this does
-
-`page-cluster` は HTML ページ集合を受け取って、**同一テンプレートと判定できるページ**に同じキーを振る。テキストは無視して DOM 構造だけを見るので、記事本文が違うが同じテンプレートを使うページ群は 1 つのクラスタにまとまる。単一サイトで数万〜十数万ページ規模のクロール成果物を、テンプレート単位に畳んで概観したいときに使う。
-
-## Install
+## Installation
 
 ```sh
 yarn add @d-zero/page-cluster
@@ -14,7 +10,13 @@ yarn add @d-zero/page-cluster
 
 インストールすると `page-cluster` コマンドが `node_modules/.bin/` 配下に入る。
 
-## Quickstart (CLI)
+## Usage
+
+### CLI
+
+```sh
+page-cluster [--content-block-attribute <name>] < pages.jsonl > clusters.jsonl
+```
 
 **入力**: JSONL 1 行 1 ページ。フィールドは以下。`html` 以外はすべて任意（`paths` / `stylesheetHrefs` がないと粗い分類になる）。
 
@@ -34,33 +36,29 @@ yarn add @d-zero/page-cluster
 { "id": "任意の識別子", "clusterKey": "..." }
 ```
 
-### クローラ出力（JSON 配列）を JSONL に変換して食わせる
-
-`jq` のワンライナーで配列を line-delimited にする典型例:
+クローラ出力が JSON 配列の場合は `jq` で line-delimited に変換して食わせる:
 
 ```sh
 jq -c '.[]' crawl-output.json | page-cluster > clusters.jsonl
 ```
 
-### `--content-block-attribute`
+#### オプション
 
-CMS が自由編集コンテンツブロックに付与している属性名（例: `data-bgb`）が分かっている場合に指定する。指定すると比較前にその属性を持つ要素配下を無視するので、同じテンプレートで本文構成だけ違うページを混同しなくなる。
+- `--content-block-attribute <name>` — CMS が自由編集コンテンツブロックに付与している属性名（例: `data-bgb`）が分かっている場合に指定する。指定すると比較前にその属性を持つ要素配下を無視するので、同じテンプレートで本文構成だけ違うページを混同しなくなる。唯一の site-specific なオプションで、未指定でも `<main>` / `role="main"` を起点にした自動深さキャップが常時働く（詳細は `resolve-page-cluster-keys.ts` の JSDoc を参照）
+- `--help` / `-h` — ヘルプを表示する
+- `--version` / `-v` — バージョンを表示する
 
-```sh
-page-cluster --content-block-attribute data-bgb < pages.jsonl > clusters.jsonl
-```
-
-### 進捗
+#### 進捗表示
 
 処理中は stderr に進捗を出す。stdout の JSONL 出力は影響を受けない。
 
-**対話端末 (TTY)**: `%earth%` アニメ付きの単一ヘッダー行が in-place に書き換わり、現在のフェーズ・進捗・経過時間を表示する。
+**対話端末（TTY）**: アニメーション付きの単一ヘッダー行が in-place に書き換わり、現在のフェーズ・進捗・経過時間を表示する。
 
 ```
 🌏 page-cluster — clustering 12/47 blocks (elapsed 23s)
 ```
 
-**非TTY (パイプ・ファイルリダイレクト・CI)**: `[page-cluster] ...` 形式の行を追記する。`pass0:` / `pass1:` / `pass1b:` / `stage-b:` の phase トークンを含むので `grep` / `awk` 互換。
+**非 TTY（パイプ・ファイルリダイレクト・CI）**: `[page-cluster] ...` 形式の行を追記する。`pass0:` / `pass1:` / `pass1b:` / `stage-b:` の phase トークンを含むので `grep` / `awk` 互換。
 
 ```
 [page-cluster] reading input pages...
@@ -74,49 +72,89 @@ page-cluster --content-block-attribute data-bgb < pages.jsonl > clusters.jsonl
 
 silence したい場合は `2>/dev/null`。ログに残したい場合は `2> progress.log`。
 
-## API (brief)
+### Library
 
-すべての詳細は各関数の JSDoc にある。CLI 経由で十分な場合は読み飛ばして OK。
+サブパスエクスポート構成。import パスと提供関数の対応は以下。
 
-- **`tokenize(html, options?)`** — `<body>` 配下の HTML を構造トークン列に変換する低レベルプリミティブ
-- **`resolvePageClusterKeys(pagesFactory, options?)`** — ページ集合からクラスタキーを返すメインエントリー。ファクトリ関数入力で大規模コーパスに対応
-- **`resolvePageClusterKeysFromArray(pages, options?)`** — メモリに全ページ載る前提の array 入力ラッパー
-- **`resolveLandmarkVariantKeys(htmlList, landmarkType, options?)`** — `header` / `footer` / `nav` / `aside` などのランドマークバリアント分類
-- **`extractLandmarks(html)`** — 1 ページから 6 種の HTML5 ランドマーク（header / footer / nav / aside / form / search）を抽出
+| import パス                                          | 提供関数                                                                                                                                                                                        |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@d-zero/page-cluster`                               | `tokenize` — `<body>` 配下を構造トークン列に変換する低レベルプリミティブ                                                                                                                        |
+| `@d-zero/page-cluster/resolve-page-cluster-keys`     | `resolvePageClusterKeys`（非同期・ファクトリ入力・メモリ有界のメインエントリー）、`resolvePageClusterKeysFromArray`（array 入力ラッパー）、`resolvePageClusterKeysInMemory`（同期・array 入力） |
+| `@d-zero/page-cluster/extract-landmarks`             | `extractLandmarks` — 6 種の HTML5 ランドマーク（header / footer / nav / aside / form / search）を抽出                                                                                           |
+| `@d-zero/page-cluster/resolve-landmark-variant-keys` | `resolveLandmarkVariantKeys` — 特定ランドマークのデザインバリアントでページを分類                                                                                                               |
 
-## Algorithm
+```ts
+import { resolvePageClusterKeysFromArray } from '@d-zero/page-cluster/resolve-page-cluster-keys';
 
+const keys = await resolvePageClusterKeysFromArray([
+	{
+		paths: ['news', '1'],
+		stylesheetHrefs: ['/a.css'],
+		html: '<body><article>one</article></body>',
+	},
+	{
+		paths: ['news', '2'],
+		stylesheetHrefs: ['/a.css'],
+		html: '<body><article>two</article></body>',
+	},
+	{
+		paths: ['about'],
+		stylesheetHrefs: ['/a.css'],
+		html: '<body><section>about</section></body>',
+	},
+]);
+// keys[0] === keys[1]（同一テンプレート）、keys[2] は別クラスタ
 ```
-              ┌────────────────────────────────────────┐
-              │  Blocking (paths / stylesheet 集合)    │
-              └──────────────────┬─────────────────────┘
-                                 │  同じテンプレートを共有する候補群
-                                 ▼
-              ┌────────────────────────────────────────┐
-              │  Stage A: complete-linkage クラスタリング │
-              │     (ブロック内、Jaccard 距離)          │
-              └──────────────────┬─────────────────────┘
-                                 │  各ブロックのクラスタ代表
-                                 ▼
-              ┌────────────────────────────────────────┐
-              │  Stage B: quorum-core cross-block merge │
-              │  (ブロック境界を越えた再統合)            │
-              └────────────────────────────────────────┘
+
+オプション・型・設計判断の WHY はすべて各関数の JSDoc に記載している。CLI 経由で十分な場合は読み飛ばして OK。
+
+## アルゴリズム概観
+
+`clusterKey` がどう決まるかを知っておくと、出力の解釈（なぜこの 2 ページが同じキーなのか）とオプションの選択がしやすくなる。実装詳細の WHY は各ソースファイルの JSDoc が正。
+
+### 全体パイプライン
+
+```mermaid
+flowchart TD
+    IN[入力ページ集合] --> P0["Pass 0: ブロッキング<br>URL パス + first-party CSS 集合 → blockKey<br>（orphan ページの再割当を含む）"]
+    P0 --> GATE{"ページ数 ≤ 20,000?"}
+
+    GATE -- "yes（in-memory）" --> CHROME_ALL["chrome discovery（コーパス全体）<br>ランドマーク署名の度数分布に auto-cut<br>→ グローバル chrome 除外 / ローカル chrome 再注入"]
+    CHROME_ALL --> SA_ALL["Stage A × 全ブロック<br>深さキャップ → tokenize →<br>complete-linkage + auto-cut → 包含割当"]
+
+    GATE -- "no（ストリーミング）" --> RES["ブロックごとにリザーバサンプリング<br>（各ブロック最大 100 ページ、決定的シード）"]
+    RES --> SA_SAMPLE["chrome discovery + Stage A<br>（サンプルのみ、ブロック単位で逐次 flush）"]
+    SA_SAMPLE --> P1B["Pass 1b: 非サンプルページを<br>max-Jaccard で最寄りクラスタへ割当"]
+
+    SA_ALL --> SB["Stage B: ブロック越えマージ<br>（不動点ループ、下図）"]
+    P1B --> SB
+    SB --> OUT["clusterKey を入力順に出力"]
 ```
 
-- **Blocking** — URL パスと stylesheet 集合を安価なブロッキング信号として粗く分割。同一ブロック内でだけ高価な構造比較を行うので、コーパス全体に対する比較コストを O(n²) から劇的に減らす
-- **Stage A** — ブロック内で `<main>` 配下のトークン列に対して complete-linkage 階層的クラスタリングを実行し、max-gap detection でカット高を選ぶ
-- **Stage B** — 各クラスタの quorum-core（80% クォーラム）を代表としてブロック境界をまたぐ再統合を反復。complete-linkage、包含、shape-Jaccard、L2 signature の 4 経路で融合を試みて不動点まで回す
-- **大規模自動切替** — 20,000 ページ超で自動的に**ストリーミング経路**に切り替わる。ブロックごとにリザーバサンプルで代表を学ばせ、非サンプルページを Jaccard で最寄りクラスタに割当。メモリ使用量が最大ブロックのサイズに比例するようになる
+- **Pass 0（ブロッキング）** — HTML を読まず、URL パスと first-party stylesheet 集合だけで粗く分割する。高価な構造比較を同一ブロック内に閉じ込め、コーパス全体の比較コストを O(n²) から劇的に減らす。stylesheet を持たない orphan ページは同一セクションの CSS ブロックへ再割当される
+- **chrome discovery** — 全ページのランドマーク署名の度数分布に auto-cut を当て、閾値以上を「グローバル chrome」（サイト共通のヘッダー等）として比較から除外し、閾値未満かつ 2 ページ以上に出現するものを「ローカル chrome」（セクション固有のナビ等）としてトークン再注入する
+- **Stage A（ブロック内クラスタリング）** — ブロックごとに直線的な処理。`<main>` の深さキャップ（候補深度を全走査して knee を探す自動選択）→ tokenize → complete-linkage 階層クラスタリング → max-gap auto-cut でカット高を決定 → 最後に包含関係にあるクラスタを吸収する包含割当（割当チェーンを辿り、循環はメンバー最大のクラスタをルートに選んで解決）
+- **Pass 1b（ストリーミング時のみ）** — 20,000 ページ超では各ブロックをリザーバサンプリング（最大 100 ページ、ブロックキーをシードにした決定的乱数）で代表させ、サンプル外のページは Stage A 完了後に max-Jaccard で最寄りクラスタへ一括割当する。メモリ使用量はコーパス全体ではなくサンプルサイズに比例する
+- **Stage B（ブロック越えマージ）** — ブロック分割はあくまで比較コスト削減のためなので、最後に同一テンプレートがブロックを跨いで分かれていないか再統合する。これが唯一の反復処理（次節）
+
+### Stage B: ブロック越え統合の不動点ループ
+
+```mermaid
+flowchart TD
+    START["ラウンド開始（最大 10 ラウンド）"] --> CORE["現在のプール済みメンバーから再計算:<br>文書頻度 → distinctive tokens → quorum core（80%）"]
+    CORE --> FINE["fine stage（単一 union-find 上で 3 経路）:<br>① complete-linkage（固定 0.8）<br>② 包含割当（0.9、チェーン走査 + サイクル解決）<br>③ shape-Jaccard（0.9、複数ページユニットのみ）"]
+    FINE --> Q1{"fine でマージ発生?"}
+    Q1 -- yes --> APPLY1["マージ適用（メンバー統合）"]
+    APPLY1 --> START
+    Q1 -- no --> L2["L2 stage:<br>L2 signature 包含 + shell 相互裏付け<br>（shell は auto-cut で自己発見）"]
+    L2 --> Q2{"L2 でマージ発生?"}
+    Q2 -- yes --> APPLY2["マージ適用"]
+    APPLY2 --> START
+    Q2 -- no --> DONE["収束 — 全ユニットのキーが不動点に到達"]
+```
+
+マージが起きるとユニットのメンバー構成が変わり、文書頻度も quorum core も変わる。そのため毎ラウンド、統合後のプールから全指標を**再計算**してマージを再試行する。fine stage・L2 stage の両方でマージが 1 件も出なくなった時点で不動点に到達したとみなして収束する（安全弁として最大 10 ラウンド。実データでは 7 ラウンド以内に収束）。L2 stage は fine stage が空振りしたラウンドでしか実行されない最後の粗い経路で、誤マージ防止のために shell（ランドマーク由来トークン）の相互裏付けを要求する。
 
 ### Self-tuning
 
-閾値はすべて **max-gap auto-cut**（度数分布の最大ギャップの中点を境界とする）でデータから自己発見される。Stage A のマージ高さカット、Stage B のシェル判定、コーパス全体の共通クローム判定など、3 階層でこの同一プリミティブを再帰使用しているので、サイトごとにハイパーパラメータをチューニングする必要はない。詳細は `autoCutThreshold` の JSDoc を参照。
-
-## Notes
-
-### `contentBlockAttribute` の存在意義
-
-このパッケージが持つ唯一の site-specific なオプション。CMS の自由編集ブロックに付与される属性名（例: `data-bgb`）は HTML から自動検知できないので外部知識として受け取る形にしている。指定された属性を持つ要素の配下は比較対象から除外され、同じテンプレート上で本文構成だけ違うページの誤分割を防ぐ。
-
-未指定でも大半のケースで動くよう、`<main>` / `role="main"` を起点にした自動深さキャップが常時有効になっている。
+閾値の多くは **max-gap auto-cut**（度数分布の隣接ギャップ最大の中点を境界とする）でデータから自己発見される。① Stage A のカット高、② Stage B の shell 判定、③ chrome discovery のグローバル/ローカル判定、④ Pass 0 の URL パス深さ選択、の 4 箇所で同一プリミティブを再利用しているので、サイトごとにハイパーパラメータをチューニングする必要はない。詳細は `autoCutThreshold` の JSDoc を参照。例外的に Stage B fine stage の complete-linkage だけは固定閾値 0.8 を使う（理由は `merge-cross-block-clusters.ts` の JSDoc を参照）。

--- a/packages/@d-zero/page-cluster/package.json
+++ b/packages/@d-zero/page-cluster/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@d-zero/page-cluster",
 	"version": "0.3.0",
-	"description": "Tokenizes an HTML document's body into a structural signature for duplicate/near-duplicate page detection at crawl scale",
+	"description": "Clusters crawled HTML pages by DOM-structure similarity — assigns the same key to pages sharing a template, ignoring text content. CLI-first, with library APIs.",
 	"author": "D-ZERO",
 	"license": "MIT",
 	"publishConfig": {


### PR DESCRIPTION
## Summary

- 直線 3 箱のアスキー図を廃止し、実装に沿った mermaid 2 枚に置き換え
  - **全体パイプライン図**: 20,000 ページでの in-memory / ストリーミング分岐、リザーバサンプリング（各ブロック最大 100 ページ）、Pass 1b の最寄りクラスタ割当を明示
  - **Stage B 不動点ループ図**: 毎ラウンド quorum core を再計算 → fine 3 経路（complete-linkage 0.8 固定 / 包含割当 0.9 / shape-Jaccard 0.9）→ マージ発生でラウンド先頭へループバック → fine 空のときのみ L2 経路 → 両方空で収束（最大 10 ラウンド）
- 見出しをハウススタイル（Installation / Usage）に統一
- 実装との乖離を修正:
  - サブパスエクスポートの対応表を明示（`tokenize` のみルート、他 3 系統はサブパス import）
  - 同期版 API `resolvePageClusterKeysInMemory` を追記
  - CLI の `--help` / `--version` を追記
- `package.json` の `description` を tokenize 単体の説明からパッケージ全体像を表す文言に更新

## Test plan

- [x] `yarn lint` — エラー 0（既存の警告 11 件のみ）
- [x] `yarn build` — 全 28 パッケージ成功
- [x] `yarn test` — 1580 tests passed（108 files）
- [ ] GitHub 上で mermaid 2 枚が正しくレンダリングされることを目視確認
- [ ] npm 上での description 表示は次回リリース時に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
