### PR TITLE
fix(page-cluster): add missing build-cluster-reason exports entry

### DIFF
--- a/packages/@d-zero/page-cluster/package.json
+++ b/packages/@d-zero/page-cluster/package.json
@@ -32,6 +32,10 @@
 		"./jaccard-similarity": {
 			"import": "./dist/jaccard-similarity.js",
 			"types": "./dist/jaccard-similarity.d.ts"
+		},
+		"./build-cluster-reason": {
+			"import": "./dist/build-cluster-reason.js",
+			"types": "./dist/build-cluster-reason.d.ts"
 		}
 	},
 	"bin": "./dist/cli.js",


### PR DESCRIPTION
## Summary
- `@d-zero/page-cluster` の `package.json` の `exports` に `./build-cluster-reason` エントリが未登録で、Node のサブパスエクスポート制約により `import { buildClusterReason } from '@d-zero/page-cluster/build-cluster-reason'` が解決できなかった不具合を修正
- `dist/build-cluster-reason.js` / `.d.ts` 自体は既にビルド・tarball 同梱済みだったため、`exports` への登録のみで解決

## Test plan
- [x] `yarn build` — 全パッケージビルド成功、`dist/build-cluster-reason.{js,d.ts}` の生成を確認
- [x] `node --input-type=module -e "import { buildClusterReason } from '@d-zero/page-cluster/build-cluster-reason'; ..."` でサブパス解決が実際に成功することを確認
- [x] `yarn lint` — エラーなし
- [x] `yarn test` — 全118ファイル / 1673テスト成功

Closes #930

🤖 Generated with [Claude Code](https://claude.com/claude-code)
