### PR TITLE
feat(anatomist): add package classifying main-content layout from box geometry

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -120,6 +120,9 @@
 		"oncomment",
 
 		// Divi Builder (WordPress page builder plugin)
-		"Divi"
+		"Divi",
+
+		// anatomist layout classification terminology
+		"misparse"
 	]
 }

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -21,5 +21,13 @@ export default lintStagedConfigGenerator({
 			// leniency htmlparser2 is supposed to be tested against.
 			prettier: 'packages/@d-zero/page-cluster/src/__fixtures__/**/*.html',
 		},
+		{
+			// Same markuplint-not-installed issue as page-cluster's fixtures
+			// above: these are `<body>`-only fragments used as
+			// getBoundingClientRect-shim input for anatomist's classify-layer
+			// tests, not full documents, so markuplint's document-validity
+			// rules don't apply to them regardless.
+			markuplint: 'packages/@d-zero/anatomist/src/__fixtures__/*.html',
+		},
 	],
 });

--- a/packages/@d-zero/anatomist/README.md
+++ b/packages/@d-zero/anatomist/README.md
@@ -1,0 +1,95 @@
+# `@d-zero/anatomist`
+
+URL を実際にブラウザでレンダリングし、main コンテンツ配下の子ブロックを「縦積み・横並び・シンプルgrid・複雑grid・テーブル・float画像+テキスト」のレイアウトパターンに分類して、ブロックごとの座標・innerHTML を含む再帰的な JSON ツリーとして出力するパッケージ。判定は `getComputedStyle` ではなく `getBoundingClientRect` で測定した実際の座標配置を主軸に行い、CSS プロパティ（`display` / `float` 等）は判定の裏付け情報として `signals` に残す。`page-cluster` で見つけたクラスタの代表ページのような、個別 URL のレイアウト構造を機械的に把握したいときに使う。CLI が主、ライブラリ関数群がオマケ。
+
+## Installation
+
+```sh
+yarn add @d-zero/anatomist
+```
+
+インストールすると `anatomist` コマンドが `node_modules/.bin/` 配下に入る。
+
+## Usage
+
+### CLI
+
+```sh
+anatomist [options] < urls.txt > results.jsonl
+```
+
+**入力**: 1 行 1 URL（`#` 始まりの行と空行は無視）。`--input-format json` で JSON 配列も受け付ける。
+
+**出力**: JSONL 1 行につき「1 URL × 1 ビューポート」。既定のビューポートは PC(1280px) → タブレット(768px) → モバイル(375px) の順。
+
+```json
+{
+	"url": "https://example.com/",
+	"viewport": { "name": "pc", "width": 1280 },
+	"mainSelector": "main#content",
+	"root": {
+		"layoutType": "horizontal-row",
+		"tagName": "DIV",
+		"id": null,
+		"classList": ["cards"],
+		"boundingBox": { "x": 0, "y": 0, "width": 960, "height": 220 },
+		"innerHTML": "...",
+		"confidence": 0.8,
+		"signals": { "rowCount": 1, "childCount": 3 },
+		"children": [/* 同じ形の LayoutBlock が再帰的に続く */]
+	}
+}
+```
+
+main 要素が見つからなかった場合は `mainSelector: null, root: null`。
+
+`layoutType` は視覚的な配置パターン（座標から読み取れる見た目）を表し、CSS の実装手段（`flex` か `grid` か `inline-block` か）とは独立している。実装手段は常に `signals` に生値として残るので、両方を突き合わせられる。`leaf` は「子要素がなく判定不要」、`unknown` は「子要素はあるがどのパターンにも自信を持って割り当てられなかった」を意味し、両者は区別される。
+
+#### オプション
+
+- `--input, -f <path>` — URL リストファイル（省略時は stdin）
+- `--input-format <lines|json>` — 既定 `lines`
+- `--main-selector <selector>` — main 要素の自動探索をスキップし、指定セレクタのみで解決する
+- `--viewport <name:width>` — 複数指定可。既定プリセットを完全に置き換える（高さは幅から自動算出されるため指定不可）
+- `--max-depth <n>` — 分類の最大深度（既定 6）。単一子のラッパー要素はこの深度にカウントされない
+- `--min-area <px>` — 「意味のある子要素」とみなす最小面積（既定 800）
+- `--inner-html <all|leaf-only|none>` — 各ブロックの `innerHTML` を含める範囲。既定 `all`（親子で内容が重複することを許容し、各ブロック単体で内容が分かることを優先する）
+- `--no-bounding-box` — 出力から `boundingBox` を除く
+- `--concurrency <n>` — 同時に処理する URL 数（既定 1、1 ブラウザの複数タブで並列化）
+- `--timeout <ms>` — ビューポートごとのナビゲーションタイムアウト
+- `--max-scroll-height <px>` — このスクロール高さを超えるページは全体スクロールをスキップする（`beforePageScan` のガードをそのまま利用）
+- `--out <path>` — 結果を標準出力ではなくファイルに書き出す
+- `--pretty` — 各結果を整形（2 スペースインデント）
+- `--help` / `--version`
+
+#### レイアウト判定でカバーしない範囲
+
+- `<iframe>` の内部（別ドキュメントのため）、Shadow DOM 内部は走査しない
+- `position: absolute/fixed` の要素は行/列クラスタリングの対象から除外する
+- タブ UI（`role="tab"` 等）の非選択パネルは展開されない（`<details>` / `aria-expanded="false"` のみ強制展開する）ため、`display: none` のまま解析対象外になる
+- カルーセル対策のオーバーフロー検知（`resolve-layout-type.ts` の `checkOverflow`）は「子要素群が親の1.5倍を超えてはみ出す」という単一のヒューリスティックであり、`transform` によるスライダー実装は捕捉できるが、`position: sticky/fixed` や `zoom`/`scale` 変形など他の「座標が実際の見た目とズレる」CSS パターンは対象外（`transform` / `overflow` / `position: sticky` はそもそも計測していない）。新しいパターンが見つかるたびにこの比率を調整するのではなく、これは既知の限定的な安全装置として扱う
+
+### Library
+
+サブパスエクスポート構成。
+
+| import パス                              | 提供関数                                                                       |
+| ---------------------------------------- | ------------------------------------------------------------------------------ |
+| `@d-zero/anatomist`                      | `analyzePageLayout` — 1 URL を複数ビューポートで解析するメインエントリー       |
+| `@d-zero/anatomist/capture-layout`       | `captureLayout` — Puppeteer の `Page` から main 配下の座標・スタイルを採取する |
+| `@d-zero/anatomist/classify-layout-tree` | `classifyLayoutTree` — 採取済みツリーからレイアウトパターンを判定する純粋関数  |
+
+```ts
+import puppeteer from 'puppeteer';
+import { analyzePageLayout } from '@d-zero/anatomist';
+
+const browser = await puppeteer.launch();
+const page = await browser.newPage();
+const results = await analyzePageLayout(page, 'https://example.com/');
+for (const { viewport, root } of results) {
+	console.log(viewport.name, root?.layoutType);
+}
+await browser.close();
+```
+
+`classifyLayoutTree` は DOM/ブラウザに依存しない純粋関数なので、`captureLayout` が返した `RawLayoutNode` ツリー（または自分で組み立てたもの）を渡すだけで単体テストできる。

--- a/packages/@d-zero/anatomist/package.json
+++ b/packages/@d-zero/anatomist/package.json
@@ -1,0 +1,46 @@
+{
+	"name": "@d-zero/anatomist",
+	"version": "0.1.0",
+	"description": "Renders a URL's main content in a real browser and classifies its child blocks into layout patterns (vertical stack, horizontal row, grid, table, float-wrap) from measured box geometry. CLI-first, with library APIs.",
+	"author": "D-ZERO",
+	"license": "MIT",
+	"publishConfig": {
+		"access": "public"
+	},
+	"type": "module",
+	"exports": {
+		".": {
+			"import": "./dist/analyze-page-layout.js",
+			"types": "./dist/analyze-page-layout.d.ts"
+		},
+		"./classify-layout-tree": {
+			"import": "./dist/classify-layout-tree.js",
+			"types": "./dist/classify-layout-tree.d.ts"
+		},
+		"./capture-layout": {
+			"import": "./dist/capture-layout.js",
+			"types": "./dist/capture-layout.d.ts"
+		}
+	},
+	"bin": "./dist/cli.js",
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc",
+		"watch": "tsc --watch",
+		"clean": "tsc --build --clean"
+	},
+	"dependencies": {
+		"@d-zero/beholder": "4.1.1",
+		"@d-zero/dealer": "1.10.2",
+		"@d-zero/puppeteer-page-scan": "4.6.6",
+		"@d-zero/shared": "0.22.3",
+		"puppeteer": "25.3.0"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/d-zero-dev/tools.git",
+		"directory": "packages/@d-zero/anatomist"
+	}
+}

--- a/packages/@d-zero/anatomist/src/__fixtures__/complex-grid.html
+++ b/packages/@d-zero/anatomist/src/__fixtures__/complex-grid.html
@@ -1,0 +1,8 @@
+<body>
+	<main data-rect="0,0,700,420">
+		<div class="card" data-rect="0,0,220,200">Card 1</div>
+		<div class="card" data-rect="240,0,220,200">Card 2</div>
+		<div class="card" data-rect="480,0,220,200">Card 3</div>
+		<div class="card featured" data-rect="0,220,700,200">Featured banner spanning the full row</div>
+	</main>
+</body>

--- a/packages/@d-zero/anatomist/src/__fixtures__/float-wrap.html
+++ b/packages/@d-zero/anatomist/src/__fixtures__/float-wrap.html
@@ -1,0 +1,6 @@
+<body>
+	<main data-rect="0,0,700,300">
+		<img src="thumbnail.jpg" alt="Thumbnail" style="float: left" data-rect="0,0,200,200" />
+		<p data-rect="0,0,700,280">Text that wraps around the floated thumbnail image, occupying the same visual row and overlapping its box both horizontally and vertically.</p>
+	</main>
+</body>

--- a/packages/@d-zero/anatomist/src/__fixtures__/horizontal-row.html
+++ b/packages/@d-zero/anatomist/src/__fixtures__/horizontal-row.html
@@ -1,0 +1,7 @@
+<body>
+	<main data-rect="0,0,700,120">
+		<div class="card" data-rect="0,0,220,100">Card A</div>
+		<div class="card" data-rect="240,0,220,100">Card B</div>
+		<div class="card" data-rect="480,0,220,100">Card C</div>
+	</main>
+</body>

--- a/packages/@d-zero/anatomist/src/__fixtures__/mock-node.ts
+++ b/packages/@d-zero/anatomist/src/__fixtures__/mock-node.ts
@@ -1,0 +1,20 @@
+import type { RawLayoutNode } from '../types.js';
+
+/**
+ * Builds a minimal `RawLayoutNode` for classify-layer unit tests, so tests
+ * can specify only the fields relevant to what they're checking. Not used
+ * by production code — test-only fixture.
+ * @param overrides
+ */
+export function mockNode(overrides: Partial<RawLayoutNode> = {}): RawLayoutNode {
+	return {
+		tagName: 'DIV',
+		id: null,
+		classList: [],
+		boundingBox: { x: 0, y: 0, width: 100, height: 40 },
+		style: { display: 'block', float: 'none', position: 'static', visibility: 'visible' },
+		innerHTML: '',
+		children: [],
+		...overrides,
+	};
+}

--- a/packages/@d-zero/anatomist/src/__fixtures__/simple-grid.html
+++ b/packages/@d-zero/anatomist/src/__fixtures__/simple-grid.html
@@ -1,0 +1,10 @@
+<body>
+	<main data-rect="0,0,700,420">
+		<div class="card" data-rect="0,0,220,200">Card 1</div>
+		<div class="card" data-rect="240,0,220,200">Card 2</div>
+		<div class="card" data-rect="480,0,220,200">Card 3</div>
+		<div class="card" data-rect="0,220,220,200">Card 4</div>
+		<div class="card" data-rect="240,220,220,200">Card 5</div>
+		<div class="card" data-rect="480,220,220,200">Card 6</div>
+	</main>
+</body>

--- a/packages/@d-zero/anatomist/src/__fixtures__/table.html
+++ b/packages/@d-zero/anatomist/src/__fixtures__/table.html
@@ -1,0 +1,18 @@
+<body>
+	<main data-rect="0,0,700,300">
+		<table data-rect="0,0,700,300">
+			<thead data-rect="0,0,700,40">
+				<tr data-rect="0,0,700,40">
+					<th data-rect="0,0,350,40">Name</th>
+					<th data-rect="350,0,350,40">Value</th>
+				</tr>
+			</thead>
+			<tbody data-rect="0,40,700,40">
+				<tr data-rect="0,40,700,40">
+					<td data-rect="0,40,350,40">Alpha</td>
+					<td data-rect="350,40,350,40">1</td>
+				</tr>
+			</tbody>
+		</table>
+	</main>
+</body>

--- a/packages/@d-zero/anatomist/src/__fixtures__/vertical-stack.html
+++ b/packages/@d-zero/anatomist/src/__fixtures__/vertical-stack.html
@@ -1,0 +1,7 @@
+<body>
+	<main data-rect="0,0,700,300">
+		<p data-rect="0,0,700,80">First paragraph</p>
+		<p data-rect="0,90,700,80">Second paragraph</p>
+		<p data-rect="0,180,700,80">Third paragraph</p>
+	</main>
+</body>

--- a/packages/@d-zero/anatomist/src/analyze-page-layout.spec.ts
+++ b/packages/@d-zero/anatomist/src/analyze-page-layout.spec.ts
@@ -1,0 +1,107 @@
+import type { Page } from 'puppeteer';
+
+import { beforePageScan } from '@d-zero/puppeteer-page-scan';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { analyzePageLayout } from './analyze-page-layout.js';
+import { captureLayout } from './capture-layout.js';
+
+vi.mock('@d-zero/puppeteer-page-scan', () => ({
+	beforePageScan: vi.fn().mockResolvedValue({ scrolled: true, scrollHeight: 1000 }),
+}));
+
+vi.mock('./capture-layout.js', () => ({
+	captureLayout: vi.fn(),
+}));
+
+const PAGE = {} as unknown as Page;
+const URL = 'https://example.com/';
+
+describe('analyzePageLayout', () => {
+	beforeEach(() => {
+		vi.mocked(captureLayout)
+			.mockReset()
+			.mockResolvedValue({ mainSelector: null, root: null });
+		vi.mocked(beforePageScan).mockClear();
+	});
+
+	it('scans every default viewport, largest to smallest, with disclosures forced open', async () => {
+		await analyzePageLayout(PAGE, URL);
+
+		expect(beforePageScan).toHaveBeenCalledTimes(3);
+		expect(beforePageScan).toHaveBeenNthCalledWith(
+			1,
+			PAGE,
+			URL,
+			expect.objectContaining({ name: 'pc', width: 1280, openDisclosures: true }),
+		);
+		expect(beforePageScan).toHaveBeenNthCalledWith(
+			2,
+			PAGE,
+			URL,
+			expect.objectContaining({ name: 'tablet', width: 768, openDisclosures: true }),
+		);
+		expect(beforePageScan).toHaveBeenNthCalledWith(
+			3,
+			PAGE,
+			URL,
+			expect.objectContaining({ name: 'sp', width: 375, openDisclosures: true }),
+		);
+	});
+
+	it('respects an explicit viewport list instead of the default', async () => {
+		const results = await analyzePageLayout(PAGE, URL, {
+			viewports: [{ name: 'custom', width: 999 }],
+		});
+
+		expect(beforePageScan).toHaveBeenCalledTimes(1);
+		expect(results).toHaveLength(1);
+		expect(results[0]?.viewport).toEqual({ name: 'custom', width: 999 });
+	});
+
+	it('returns a null root when no main element resolves', async () => {
+		const results = await analyzePageLayout(PAGE, URL, {
+			viewports: [{ name: 'pc', width: 1280 }],
+		});
+
+		expect(results).toEqual([
+			{ url: URL, viewport: { name: 'pc', width: 1280 }, mainSelector: null, root: null },
+		]);
+	});
+
+	it('classifies the captured raw tree when main resolves', async () => {
+		vi.mocked(captureLayout).mockResolvedValue({
+			mainSelector: 'main',
+			root: {
+				tagName: 'MAIN',
+				id: null,
+				classList: [],
+				boundingBox: { x: 0, y: 0, width: 100, height: 100 },
+				style: {
+					display: 'block',
+					float: 'none',
+					position: 'static',
+					visibility: 'visible',
+				},
+				innerHTML: '',
+				children: [],
+			},
+		});
+
+		const results = await analyzePageLayout(PAGE, URL, {
+			viewports: [{ name: 'pc', width: 1280 }],
+		});
+
+		expect(results[0]?.mainSelector).toBe('main');
+		expect(results[0]?.root?.layoutType).toBe('leaf');
+	});
+
+	it('forwards mainContentSelector to captureLayout', async () => {
+		await analyzePageLayout(PAGE, URL, {
+			viewports: [{ name: 'pc', width: 1280 }],
+			mainContentSelector: '#x',
+		});
+
+		expect(captureLayout).toHaveBeenCalledWith(PAGE, { mainContentSelector: '#x' });
+	});
+});

--- a/packages/@d-zero/anatomist/src/analyze-page-layout.ts
+++ b/packages/@d-zero/anatomist/src/analyze-page-layout.ts
@@ -1,0 +1,82 @@
+import type { ClassifyLayoutTreeOptions } from './classify-layout-tree.js';
+import type { LayoutAnalysisResult, ViewportSpec } from './types.js';
+import type { Page } from 'puppeteer';
+
+import { beforePageScan } from '@d-zero/puppeteer-page-scan';
+
+import { captureLayout } from './capture-layout.js';
+import { classifyLayoutTree } from './classify-layout-tree.js';
+import { DEFAULT_VIEWPORTS } from './default-viewports.js';
+
+export type AnalyzePageLayoutOptions = {
+	/** Viewports to analyze, in the order they're applied. Default: `DEFAULT_VIEWPORTS` (PC → tablet → mobile). */
+	viewports?: readonly ViewportSpec[];
+	/** Explicit main-content selector; skips the priority-list/fallback search when it matches. */
+	mainContentSelector?: string | null;
+	/** Navigation timeout (ms) passed to `beforePageScan`. */
+	timeout?: number;
+	/** Scroll-height guard passed to `beforePageScan` — pages taller than this skip the full-page scroll (see `beforePageScan`'s JSDoc). */
+	maxScrollHeight?: number;
+} & ClassifyLayoutTreeOptions;
+
+/**
+ * Analyzes one URL's main-content layout at each of several viewports,
+ * reusing a single `page` across them (see `default-viewports.ts` for why
+ * the default order is largest-to-smallest).
+ *
+ * `beforePageScan` is called with `openDisclosures: true` for every
+ * viewport: without forcing `<details>`/`aria-expanded` disclosures open,
+ * their contents stay unrendered (zero-size boxes), making the layout
+ * inside them unclassifiable. This trades fidelity to the page's default
+ * collapsed state for the ability to see accordion/tab-panel layouts at
+ * all.
+ * @param page - A Puppeteer page, not yet navigated to `url` (or already
+ *   there — `beforePageScan` detects and reloads instead of re-opening).
+ * @param url - The URL to analyze.
+ * @param options
+ * @returns One result per viewport, in the order `options.viewports` (or
+ *   the default) lists them.
+ * @example
+ * ```ts
+ * const results = await analyzePageLayout(page, 'https://example.com/');
+ * for (const { viewport, root } of results) {
+ *   console.log(viewport.name, root?.layoutType);
+ * }
+ * ```
+ */
+export async function analyzePageLayout(
+	page: Page,
+	url: string,
+	options: AnalyzePageLayoutOptions = {},
+): Promise<LayoutAnalysisResult[]> {
+	const viewports = options.viewports ?? DEFAULT_VIEWPORTS;
+	const results: LayoutAnalysisResult[] = [];
+
+	for (const viewport of viewports) {
+		await beforePageScan(page, url, {
+			name: viewport.name,
+			width: viewport.width,
+			openDisclosures: true,
+			timeout: options.timeout,
+			maxScrollHeight: options.maxScrollHeight,
+		});
+
+		const { mainSelector, root } = await captureLayout(page, {
+			mainContentSelector: options.mainContentSelector,
+		});
+
+		results.push({
+			url,
+			viewport,
+			mainSelector,
+			root: root
+				? classifyLayoutTree(root, {
+						maxDepth: options.maxDepth,
+						minArea: options.minArea,
+					})
+				: null,
+		});
+	}
+
+	return results;
+}

--- a/packages/@d-zero/anatomist/src/capture-layout-tree.spec.ts
+++ b/packages/@d-zero/anatomist/src/capture-layout-tree.spec.ts
@@ -1,0 +1,160 @@
+import { JSDOM } from 'jsdom';
+import { describe, expect, it } from 'vitest';
+
+import { captureLayoutTree } from './capture-layout-tree.js';
+
+const SELECTORS = ['main', '#main', '.main'];
+const FALLBACK_SELECTORS = ['[id*="main" i]'];
+
+/**
+ * Builds a `Document` whose `getBoundingClientRect` reads pixel geometry
+ * off a `data-rect="x,y,width,height"` attribute instead of running jsdom's
+ * (nonexistent) layout engine. This is the "monkeypatch to inject
+ * pseudo-coordinates" from the plan — it validates that rect data flows
+ * from element to `RawLayoutNode` correctly, not that any real browser's
+ * layout algorithm is reproduced.
+ * @param html
+ */
+function createDocument(html: string): Document {
+	const dom = new JSDOM(html, { url: 'https://example.com/' });
+	const { window } = dom;
+	window.Element.prototype.getBoundingClientRect = function (this: Element) {
+		const raw = this.dataset.rect;
+		const [x, y, width, height] = raw ? raw.split(',').map(Number) : [0, 0, 0, 0];
+		return {
+			x: x!,
+			y: y!,
+			width: width!,
+			height: height!,
+			top: y!,
+			left: x!,
+			right: x! + width!,
+			bottom: y! + height!,
+			toJSON() {
+				return this;
+			},
+		} as DOMRect;
+	};
+	return window.document;
+}
+
+describe('captureLayoutTree', () => {
+	it('returns null selector and null root when no main element resolves', () => {
+		const doc = createDocument('<body><div>No main</div></body>');
+
+		const result = captureLayoutTree(null, SELECTORS, FALLBACK_SELECTORS, 10, doc);
+
+		expect(result).toEqual({ mainSelector: null, root: null });
+	});
+
+	it('resolves <main> via the priority selector list', () => {
+		const doc = createDocument(
+			'<body><main id="page" data-rect="0,0,800,600"><p data-rect="0,0,100,20">Hi</p></main></body>',
+		);
+
+		const result = captureLayoutTree(null, SELECTORS, FALLBACK_SELECTORS, 10, doc);
+
+		expect(result.mainSelector).toBe('main#page');
+		expect(result.root?.tagName).toBe('MAIN');
+		expect(result.root?.children).toHaveLength(1);
+		expect(result.root?.children[0]?.tagName).toBe('P');
+	});
+
+	it('falls back to the fallback selector list when the priority list has no match', () => {
+		const doc = createDocument(
+			'<body><div id="primaryMain" data-rect="0,0,800,600">Fallback</div></body>',
+		);
+
+		const result = captureLayoutTree(null, SELECTORS, FALLBACK_SELECTORS, 10, doc);
+
+		expect(result.mainSelector).toBe('div#primaryMain');
+	});
+
+	it('tries the explicit mainContentSelector before the priority list', () => {
+		const doc = createDocument(
+			'<body><main data-rect="0,0,1,1">Wrong</main><section id="custom" data-rect="0,0,800,600">Right</section></body>',
+		);
+
+		const result = captureLayoutTree('#custom', SELECTORS, FALLBACK_SELECTORS, 10, doc);
+
+		expect(result.mainSelector).toBe('section#custom');
+	});
+
+	it('reports each child box in coordinates relative to the parent box', () => {
+		const doc = createDocument(
+			'<body><main data-rect="10,20,800,600"><div data-rect="30,50,100,40"></div></main></body>',
+		);
+
+		const result = captureLayoutTree(null, SELECTORS, FALLBACK_SELECTORS, 10, doc);
+
+		expect(result.root?.boundingBox).toEqual({ x: 0, y: 0, width: 800, height: 600 });
+		expect(result.root?.children[0]?.boundingBox).toEqual({
+			x: 20,
+			y: 30,
+			width: 100,
+			height: 40,
+		});
+	});
+
+	it('stops descending once captureMaxDepth is exhausted', () => {
+		const doc = createDocument(
+			'<body><main data-rect="0,0,100,100">' +
+				'<div id="d1" data-rect="0,0,100,100">' +
+				'<div id="d2" data-rect="0,0,100,100">' +
+				'<div id="d3" data-rect="0,0,100,100"></div>' +
+				'</div>' +
+				'</div>' +
+				'</main></body>',
+		);
+
+		// captureMaxDepth counts remaining descents from main itself: 2 allows
+		// main -> d1 -> d2 (d2's own children, d3, are not walked).
+		const result = captureLayoutTree(null, SELECTORS, FALLBACK_SELECTORS, 2, doc);
+
+		const d1 = result.root?.children[0];
+		expect(d1?.id).toBe('d1');
+		const d2 = d1?.children[0];
+		expect(d2?.id).toBe('d2');
+		expect(d2?.children).toHaveLength(0);
+	});
+
+	it('does not descend into a hidden (display: none) subtree', () => {
+		const doc = createDocument(
+			'<body><main data-rect="0,0,100,100">' +
+				'<div style="display: none" data-rect="0,0,0,0"><span data-rect="0,0,10,10"></span></div>' +
+				'</main></body>',
+		);
+
+		const result = captureLayoutTree(null, SELECTORS, FALLBACK_SELECTORS, 10, doc);
+
+		const hidden = result.root?.children[0];
+		expect(hidden?.style.display).toBe('none');
+		expect(hidden?.children).toHaveLength(0);
+	});
+
+	it('does not descend into an iframe', () => {
+		const doc = createDocument(
+			'<body><main data-rect="0,0,100,100"><iframe data-rect="0,0,50,50"></iframe></main></body>',
+		);
+
+		const result = captureLayoutTree(null, SELECTORS, FALLBACK_SELECTORS, 10, doc);
+
+		expect(result.root?.children[0]?.tagName).toBe('IFRAME');
+		expect(result.root?.children[0]?.children).toHaveLength(0);
+	});
+
+	it('captures raw style values verbatim without interpreting them', () => {
+		const doc = createDocument(
+			'<body><main data-rect="0,0,100,100"><div style="float: left; position: absolute;" data-rect="0,0,10,10"></div></main></body>',
+		);
+
+		const result = captureLayoutTree(null, SELECTORS, FALLBACK_SELECTORS, 10, doc);
+
+		expect(result.root?.children[0]?.style).toEqual({
+			display: 'block',
+			float: 'left',
+			position: 'absolute',
+			visibility: 'visible',
+		});
+	});
+});

--- a/packages/@d-zero/anatomist/src/capture-layout-tree.ts
+++ b/packages/@d-zero/anatomist/src/capture-layout-tree.ts
@@ -1,0 +1,211 @@
+/**
+ * Main-content geometry capture for a rendered page.
+ *
+ * Runs entirely against a `Document` (Puppeteer page realm or jsdom with a
+ * `getBoundingClientRect` shim — see the spec) so the tree-shape logic is
+ * unit-tested without a browser, matching the pattern in
+ * `@d-zero/beholder/get-main-contents.ts`.
+ *
+ * This function makes no layout judgment: it only resolves the main-content
+ * element and walks its descendants into a `RawLayoutNode` tree of
+ * geometry + raw style + innerHTML. Classification happens later, in
+ * `classify-layout-tree.ts`, against this tree — never here.
+ *
+ * WHY every helper is nested inside `captureLayoutTree` rather than a
+ * sibling top-level function (unlike this file's other exports): Puppeteer
+ * serializes a `page.evaluate` callback via `Function#toString()` and
+ * re-evaluates only that source text inside the browser realm — it does
+ * not ship any other declaration from this module along with it. A sibling
+ * top-level helper would be `undefined` at runtime in the page, throwing
+ * `ReferenceError` on first use. `extractMainContentsFromDocument` in
+ * `@d-zero/beholder` nests its helpers for the same reason; this function
+ * does too, for the same reason no `@medv/finder` / shared-helper import is // cspell:disable-line
+ * usable here either. The selector arrays are instead passed as plain-data
+ * arguments (see `capture-layout.ts`), sourced from
+ * `@d-zero/beholder`'s `MAIN_CONTENT_SELECTORS` / `MAIN_CONTENT_FALLBACK_SELECTORS`
+ * rather than re-resolving `extractMainContentsFromDocument`'s own
+ * diagnostic-only selector string. That string is a tag+id+class
+ * fingerprint built for logging, not a unique identity — re-querying it
+ * (e.g. a bare `<div>` with no id/class resolving to the selector `"div"`)
+ * can match a different element than the one actually found, so this
+ * module resolves the element itself directly instead of round-tripping
+ * through that string.
+ * @module
+ */
+
+import type { RawLayoutNode } from './types.js';
+
+/**
+ * Resolves the main-content element and captures its subtree geometry.
+ * @param mainContentSelector - Explicit selector that, when given, is used
+ *   on its own — no fallback to the priority list on a miss. Unlike
+ *   `extractMainContentsFromDocument`'s OR-selector approach, this fully
+ *   replaces the priority-list/fallback search: joining it into one
+ *   combined selector would let DOM order override the caller's explicit
+ *   choice (`#custom,main` still matches whichever of the two appears
+ *   first in the document, not `#custom` specifically), and a caller
+ *   passing `--main-selector` wants exactly that element or nothing.
+ * @param selectors - Priority-ordered selector list
+ *   (`@d-zero/beholder`'s `MAIN_CONTENT_SELECTORS`), passed as data because
+ *   this function must stay closure-free for `page.evaluate`.
+ * @param fallbackSelectors - Loose fallback selectors
+ *   (`@d-zero/beholder`'s `MAIN_CONTENT_FALLBACK_SELECTORS`).
+ * @param captureMaxDepth - Hard recursion cap on how far the walk descends.
+ *   Deliberately generous (see `capture-layout.ts`'s default) and is not
+ *   the same knob as `should-recurse.ts`'s `maxDepth`: the classify layer
+ *   decides where the *meaningful* layout tree ends (collapsing
+ *   single-child wrappers first), so capture must go deeper than that to
+ *   avoid truncating data classification would otherwise use.
+ * @param doc - The document to inspect (defaults to the global `document`
+ *   in the page realm; jsdom tests pass an explicit `Document`).
+ * @returns The resolved main selector (`null` when nothing matched) and
+ *   its captured subtree (`null` alongside it in that case).
+ * @example
+ * ```ts
+ * // In page.evaluate / browser:
+ * const { root } = captureLayoutTree(null, MAIN_CONTENT_SELECTORS, MAIN_CONTENT_FALLBACK_SELECTORS, 30);
+ * ```
+ */
+export function captureLayoutTree(
+	mainContentSelector: string | null,
+	selectors: readonly string[],
+	fallbackSelectors: readonly string[],
+	captureMaxDepth: number,
+	doc: Document = document,
+): { mainSelector: string | null; root: RawLayoutNode | null } {
+	const win = doc.defaultView;
+	if (!win) {
+		return { mainSelector: null, root: null };
+	}
+
+	/**
+	 * @param value
+	 */
+	function cssEscape(value: string): string {
+		if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+			return CSS.escape(value);
+		}
+		return value.replaceAll(/([ !"#$%&'()*+,./:;<=>?@[\\\]^`{|}~])/g, '\\$1');
+	}
+
+	/**
+	 * Builds a tag+id+class diagnostic selector for the resolved main
+	 * element, so callers can pass it back via `--main-selector` on a later
+	 * run to skip re-resolution. Not guaranteed unique (same caveat as
+	 * beholder's `buildSelector`) — it's a diagnostic/reuse aid, not an identity.
+	 * @param el
+	 */
+	function buildDiagnosticSelector(el: Element): string {
+		const tag = el.nodeName.toLowerCase();
+		const id = el.id ? `#${cssEscape(el.id)}` : '';
+		const classes = [...el.classList].map((c) => `.${cssEscape(c)}`).join('');
+		return `${tag}${id}${classes}`;
+	}
+
+	/**
+	 * Resolves the main-content element using the same priority-list-then-
+	 * fallback strategy as `extractMainContentsFromDocument`, but returns
+	 * the `Element` itself (needed to walk its subtree) rather than a
+	 * metrics summary.
+	 */
+	function resolveMainElement(): Element | null {
+		if (mainContentSelector) {
+			try {
+				return doc.querySelector(mainContentSelector);
+			} catch {
+				return null;
+			}
+		}
+
+		let element: Element | null = null;
+		try {
+			element = doc.querySelector(selectors.join(','));
+		} catch {
+			// The built-in selector list is a fixed, known-valid constant, so
+			// this should be unreachable — but fail closed rather than throw.
+		}
+
+		if (element) {
+			return element;
+		}
+
+		for (const sel of fallbackSelectors) {
+			const candidate = doc.querySelector(sel);
+			if (candidate && candidate !== doc.body && candidate !== doc.documentElement) {
+				return candidate;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Recursively captures one element and its descendants.
+	 *
+	 * Elements with no rendered box (`display: none`, zero-area) still
+	 * appear as a node (so their existence and raw style are visible in the
+	 * output) but their descendants are not walked — there is nothing a
+	 * hidden subtree's geometry could contribute to layout classification.
+	 *
+	 * Frame and shadow boundaries are not crossed: an `<iframe>` is captured
+	 * as a childless node (its content is a different document), and
+	 * shadow-root children are not visited (`el.children` only ever sees
+	 * light-DOM children).
+	 * @param el
+	 * @param originRect
+	 * @param remainingDepth
+	 * @param view - Threaded through explicitly (rather than closing over
+	 *   the outer `win`) because TypeScript can't carry the outer
+	 *   null-check's narrowing into a nested function declaration.
+	 */
+	function captureNode(
+		el: Element,
+		originRect: DOMRect,
+		remainingDepth: number,
+		view: Window,
+	): RawLayoutNode {
+		const rect = el.getBoundingClientRect();
+		const computed = view.getComputedStyle(el);
+		const style = {
+			display: computed.display,
+			float: computed.float,
+			position: computed.position,
+			visibility: computed.visibility,
+		};
+		const isRendered = style.display !== 'none' && rect.width > 0 && rect.height > 0;
+		const isFrame = el.tagName === 'IFRAME';
+
+		const children: RawLayoutNode[] =
+			isRendered && !isFrame && remainingDepth > 0
+				? [...el.children].map((child) =>
+						captureNode(child, rect, remainingDepth - 1, view),
+					)
+				: [];
+
+		return {
+			tagName: el.tagName,
+			id: el.id || null,
+			classList: [...el.classList],
+			boundingBox: {
+				x: rect.x - originRect.x,
+				y: rect.y - originRect.y,
+				width: rect.width,
+				height: rect.height,
+			},
+			style,
+			innerHTML: el.innerHTML,
+			children,
+		};
+	}
+
+	const mainElement = resolveMainElement();
+	if (!mainElement) {
+		return { mainSelector: null, root: null };
+	}
+
+	const originRect = mainElement.getBoundingClientRect();
+	return {
+		mainSelector: buildDiagnosticSelector(mainElement),
+		root: captureNode(mainElement, originRect, captureMaxDepth, win),
+	};
+}

--- a/packages/@d-zero/anatomist/src/capture-layout.spec.ts
+++ b/packages/@d-zero/anatomist/src/capture-layout.spec.ts
@@ -1,0 +1,42 @@
+import type { Page } from 'puppeteer';
+
+import {
+	MAIN_CONTENT_FALLBACK_SELECTORS,
+	MAIN_CONTENT_SELECTORS,
+} from '@d-zero/beholder';
+import { describe, expect, it, vi } from 'vitest';
+
+import { captureLayoutTree } from './capture-layout-tree.js';
+import { captureLayout } from './capture-layout.js';
+
+describe('captureLayout', () => {
+	it('evaluates captureLayoutTree with the shared beholder selector lists and defaults', async () => {
+		const evaluate = vi.fn().mockResolvedValue({ mainSelector: null, root: null });
+		const page = { evaluate } as unknown as Page;
+
+		await captureLayout(page);
+
+		expect(evaluate).toHaveBeenCalledWith(
+			captureLayoutTree,
+			null,
+			MAIN_CONTENT_SELECTORS,
+			MAIN_CONTENT_FALLBACK_SELECTORS,
+			60,
+		);
+	});
+
+	it('forwards an explicit mainContentSelector and captureMaxDepth', async () => {
+		const evaluate = vi.fn().mockResolvedValue({ mainSelector: '#x', root: null });
+		const page = { evaluate } as unknown as Page;
+
+		await captureLayout(page, { mainContentSelector: '#x', captureMaxDepth: 5 });
+
+		expect(evaluate).toHaveBeenCalledWith(
+			captureLayoutTree,
+			'#x',
+			MAIN_CONTENT_SELECTORS,
+			MAIN_CONTENT_FALLBACK_SELECTORS,
+			5,
+		);
+	});
+});

--- a/packages/@d-zero/anatomist/src/capture-layout.ts
+++ b/packages/@d-zero/anatomist/src/capture-layout.ts
@@ -1,0 +1,47 @@
+import type { RawLayoutNode } from './types.js';
+import type { Page } from 'puppeteer';
+
+import {
+	MAIN_CONTENT_FALLBACK_SELECTORS,
+	MAIN_CONTENT_SELECTORS,
+} from '@d-zero/beholder';
+
+import { captureLayoutTree } from './capture-layout-tree.js';
+
+/**
+ * Hard recursion cap passed to {@link captureLayoutTree}. Set well above
+ * the classify layer's `maxDepth` (default 6, see `should-recurse.ts`)
+ * because single-child wrapper chains are collapsed during classification,
+ * not during capture — capture has to walk past them to reach the content
+ * classification will actually reason about.
+ */
+const DEFAULT_CAPTURE_MAX_DEPTH = 60;
+
+/**
+ * Captures the main-content geometry tree from a Puppeteer page via a
+ * single `page.evaluate`. The selector lists are `@d-zero/beholder`'s
+ * shared constants, passed as data because `captureLayoutTree` must stay
+ * closure-free for serialization.
+ * @param page - Puppeteer page whose DOM has finished loading and settled
+ *   (e.g. via `beforePageScan`).
+ * @param options - Optional main-content selector override and recursion cap.
+ * @param options.mainContentSelector
+ * @param options.captureMaxDepth
+ * @returns The resolved main selector and its captured subtree geometry.
+ * @example
+ * ```ts
+ * const { mainSelector, root } = await captureLayout(page, { mainContentSelector: '#page-body' });
+ * ```
+ */
+export async function captureLayout(
+	page: Page,
+	options?: { mainContentSelector?: string | null; captureMaxDepth?: number },
+): Promise<{ mainSelector: string | null; root: RawLayoutNode | null }> {
+	return page.evaluate(
+		captureLayoutTree,
+		options?.mainContentSelector ?? null,
+		MAIN_CONTENT_SELECTORS,
+		MAIN_CONTENT_FALLBACK_SELECTORS,
+		options?.captureMaxDepth ?? DEFAULT_CAPTURE_MAX_DEPTH,
+	);
+}

--- a/packages/@d-zero/anatomist/src/classify-layout-tree.integration.spec.ts
+++ b/packages/@d-zero/anatomist/src/classify-layout-tree.integration.spec.ts
@@ -1,0 +1,91 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import {
+	MAIN_CONTENT_FALLBACK_SELECTORS,
+	MAIN_CONTENT_SELECTORS,
+} from '@d-zero/beholder';
+import { JSDOM } from 'jsdom';
+import { describe, expect, it } from 'vitest';
+
+import { captureLayoutTree } from './capture-layout-tree.js';
+import { classifyLayoutTree } from './classify-layout-tree.js';
+
+const FIXTURES_DIR = fileURLToPath(new URL('__fixtures__/', import.meta.url));
+
+/**
+ * Loads one fixture HTML file and wires up the same `getBoundingClientRect`
+ * shim as `capture-layout-tree.spec.ts`, reading pixel geometry off each
+ * element's `data-rect="x,y,width,height"` attribute — see that file's
+ * `createDocument` for why this is a data-driven substitute for jsdom's
+ * (nonexistent) layout engine rather than an attempt to reproduce it.
+ * @param name
+ */
+function loadFixtureDocument(name: string): Document {
+	const html = readFileSync(`${FIXTURES_DIR}${name}`, 'utf8');
+	const { window } = new JSDOM(html, { url: 'https://example.com/' });
+	window.Element.prototype.getBoundingClientRect = function (this: Element) {
+		const raw = this.dataset.rect;
+		const [x, y, width, height] = raw ? raw.split(',').map(Number) : [0, 0, 0, 0];
+		return {
+			x: x!,
+			y: y!,
+			width: width!,
+			height: height!,
+			top: y!,
+			left: x!,
+			right: x! + width!,
+			bottom: y! + height!,
+			toJSON() {
+				return this;
+			},
+		} as DOMRect;
+	};
+	return window.document;
+}
+
+/**
+ * @param fixtureName
+ */
+function classifyFixture(fixtureName: string) {
+	const doc = loadFixtureDocument(fixtureName);
+	const { root } = captureLayoutTree(
+		null,
+		MAIN_CONTENT_SELECTORS,
+		MAIN_CONTENT_FALLBACK_SELECTORS,
+		10,
+		doc,
+	);
+	if (!root) {
+		throw new Error(`fixture ${fixtureName} did not resolve a main element`);
+	}
+	return classifyLayoutTree(root);
+}
+
+describe('capture + classify integration (fixture HTML end-to-end)', () => {
+	it('classifies stacked paragraphs as vertical-stack', () => {
+		expect(classifyFixture('vertical-stack.html').layoutType).toBe('vertical-stack');
+	});
+
+	it('classifies three same-row cards as horizontal-row', () => {
+		expect(classifyFixture('horizontal-row.html').layoutType).toBe('horizontal-row');
+	});
+
+	it('classifies a uniform 3x2 card grid as simple-grid', () => {
+		const block = classifyFixture('simple-grid.html');
+		expect(block.layoutType).toBe('simple-grid');
+		expect(block.children).toHaveLength(6);
+	});
+
+	it('classifies a grid with a full-width banner row as complex-grid', () => {
+		expect(classifyFixture('complex-grid.html').layoutType).toBe('complex-grid');
+	});
+
+	it('classifies a <table> as table', () => {
+		expect(classifyFixture('table.html').layoutType).toBe('table');
+	});
+
+	it('classifies a floated image with wrapping text as float-wrap', () => {
+		expect(classifyFixture('float-wrap.html').layoutType).toBe('float-wrap');
+	});
+});

--- a/packages/@d-zero/anatomist/src/classify-layout-tree.spec.ts
+++ b/packages/@d-zero/anatomist/src/classify-layout-tree.spec.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import { mockNode } from './__fixtures__/mock-node.js';
+import { classifyLayoutTree } from './classify-layout-tree.js';
+
+/**
+ * @param x
+ * @param y
+ * @param width
+ * @param height
+ * @param overrides
+ */
+function cell(
+	x: number,
+	y: number,
+	width: number,
+	height: number,
+	overrides: Parameters<typeof mockNode>[0] = {},
+) {
+	return mockNode({ boundingBox: { x, y, width, height }, ...overrides });
+}
+
+describe('classifyLayoutTree', () => {
+	it('renders a childless node as a leaf', () => {
+		const root = mockNode({ innerHTML: '<p>hi</p>', children: [] });
+		const result = classifyLayoutTree(root);
+		expect(result.layoutType).toBe('leaf');
+		expect(result.children).toEqual([]);
+		expect(result.innerHTML).toBe('<p>hi</p>');
+	});
+
+	it('collapses a chain of single-child wrappers before classifying real content', () => {
+		const cardA = cell(0, 0, 100, 100, { id: 'card-a' });
+		const cardB = cell(120, 0, 100, 100, { id: 'card-b' });
+		const inner = mockNode({
+			id: 'inner',
+			boundingBox: { x: 0, y: 0, width: 220, height: 100 },
+			children: [cardA, cardB],
+		});
+		const wrapper = mockNode({ id: 'wrapper', children: [inner] });
+		const root = mockNode({ id: 'root', children: [wrapper] });
+
+		const result = classifyLayoutTree(root);
+
+		// root -> wrapper -> inner are all single-child, so classification
+		// should reach `inner`'s two-card row directly, at depth 0.
+		expect(result.layoutType).toBe('horizontal-row');
+		expect(result.id).toBe('inner');
+		expect(result.children).toHaveLength(2);
+		expect(result.children[0]?.layoutType).toBe('leaf');
+	});
+
+	it('classifies a multi-row grid and recurses into each cell', () => {
+		const children = [
+			cell(0, 0, 100, 100, { children: [cell(0, 0, 50, 20)] }),
+			cell(120, 0, 100, 100, { children: [cell(0, 0, 50, 20)] }),
+			cell(0, 120, 100, 100, { children: [cell(0, 0, 50, 20)] }),
+			cell(120, 120, 100, 100, { children: [cell(0, 0, 50, 20)] }),
+		];
+		const root = mockNode({
+			boundingBox: { x: 0, y: 0, width: 300, height: 300 },
+			children,
+		});
+
+		const result = classifyLayoutTree(root);
+
+		expect(result.layoutType).toBe('simple-grid');
+		expect(result.children).toHaveLength(4);
+		// Each cell has one meaningful child of its own -> collapses into a leaf.
+		expect(result.children[0]?.layoutType).toBe('leaf');
+	});
+
+	it('leafs out once maxDepth is reached, keeping innerHTML but no children', () => {
+		// root (depth 0) has two branches, each with two grandchildren (depth 1).
+		const grandchildA1 = cell(0, 0, 50, 50, { innerHTML: 'bottom' });
+		const grandchildA2 = cell(60, 0, 50, 50);
+		const branchA = mockNode({
+			boundingBox: { x: 0, y: 0, width: 100, height: 100 },
+			innerHTML: 'branch-a',
+			children: [grandchildA1, grandchildA2],
+		});
+		const branchB = mockNode({ boundingBox: { x: 120, y: 0, width: 100, height: 100 } });
+		const root = mockNode({ children: [branchA, branchB] });
+
+		const result = classifyLayoutTree(root, { maxDepth: 1 });
+
+		// depth 0 classifies root's two branches; depth 1 (branchA's children)
+		// hits maxDepth and leafs instead of classifying further.
+		expect(result.children[0]?.layoutType).toBe('leaf');
+		expect(result.children[0]?.innerHTML).toBe('branch-a');
+		expect(result.children[0]?.children).toEqual([]);
+	});
+
+	it('excludes children below minArea from classification', () => {
+		const tiny = cell(0, 0, 5, 5);
+		const big = cell(0, 0, 200, 100);
+		const root = mockNode({ children: [tiny, big] });
+
+		// Only `big` is meaningful -> single meaningful child -> collapse into it -> leaf (no children of its own).
+		const result = classifyLayoutTree(root);
+		expect(result.boundingBox).toEqual(big.boundingBox);
+		expect(result.layoutType).toBe('leaf');
+	});
+
+	it('does not hang on a long single-child wrapper chain (collapse safety bound)', () => {
+		let node = cell(0, 0, 100, 100, { id: 'deepest' });
+		for (let i = 0; i < 100; i++) {
+			node = mockNode({ children: [node] });
+		}
+
+		const result = classifyLayoutTree(node);
+
+		// Should terminate and produce some deterministic result rather than
+		// looping forever — the exact id reached depends on MAX_COLLAPSE_CHAIN,
+		// which is an implementation detail this test intentionally doesn't pin.
+		expect(result).toBeDefined();
+	});
+});

--- a/packages/@d-zero/anatomist/src/classify-layout-tree.ts
+++ b/packages/@d-zero/anatomist/src/classify-layout-tree.ts
@@ -1,0 +1,107 @@
+import type { LayoutBlock, RawLayoutNode } from './types.js';
+
+import { resolveLayoutType } from './resolve-layout-type.js';
+import { DEFAULT_MIN_AREA, decideRecursion } from './should-recurse.js';
+
+/**
+ * Safety bound on a single-child wrapper chain (`main > div > div > ...`)
+ * before {@link classifyNode} gives up collapsing and renders a leaf
+ * instead. Not expected to trigger on real markup — it exists only so a
+ * pathological or cyclic-looking structure can't hang classification.
+ */
+const MAX_COLLAPSE_CHAIN = 50;
+
+export type ClassifyLayoutTreeOptions = {
+	/** Maximum classification depth (collapsed wrappers don't count — see `should-recurse.ts`). Default `6`. */
+	maxDepth?: number;
+	/** Minimum child box area (px²) to count as meaningful. Default `800`. */
+	minArea?: number;
+};
+
+/**
+ * @param node
+ */
+function toLeafBlock(node: RawLayoutNode): LayoutBlock {
+	return {
+		layoutType: 'leaf',
+		tagName: node.tagName,
+		id: node.id,
+		classList: node.classList,
+		boundingBox: node.boundingBox,
+		innerHTML: node.innerHTML,
+		confidence: 0,
+		signals: {},
+		children: [],
+	};
+}
+
+/**
+ * @param node
+ * @param depth
+ * @param options
+ */
+function classifyNode(
+	node: RawLayoutNode,
+	depth: number,
+	options: Required<ClassifyLayoutTreeOptions>,
+): LayoutBlock {
+	let current = node;
+	let collapseCount = 0;
+	let decision = decideRecursion(current, depth, options);
+
+	while (decision.kind === 'collapse' && collapseCount < MAX_COLLAPSE_CHAIN) {
+		current = decision.child;
+		collapseCount++;
+		decision = decideRecursion(current, depth, options);
+	}
+
+	if (decision.kind !== 'classify') {
+		return toLeafBlock(current);
+	}
+
+	const resolution = resolveLayoutType(current, decision.children);
+	const children = decision.children.map((child) =>
+		classifyNode(child, depth + 1, options),
+	);
+
+	return {
+		layoutType: resolution.layoutType,
+		tagName: current.tagName,
+		id: current.id,
+		classList: current.classList,
+		boundingBox: current.boundingBox,
+		innerHTML: current.innerHTML,
+		confidence: resolution.confidence,
+		signals: resolution.signals,
+		children,
+	};
+}
+
+/**
+ * Converts a captured `RawLayoutNode` tree (see `capture-layout-tree.ts`)
+ * into a classified `LayoutBlock` tree, by recursively: collapsing
+ * single-child wrapper chains, resolving each remaining container's
+ * visual layout pattern from its children's geometry, and leaf-ing out at
+ * `maxDepth` or when there are no more meaningful children (see
+ * `should-recurse.ts` and `resolve-layout-type.ts`).
+ *
+ * The tree's root itself is never assigned a layout judgment about *its
+ * own* placement (there's no parent to place it relative to) — it always
+ * starts from `decideRecursion` at depth 0, so it's classified exactly
+ * like any other container based on what pattern its own children form.
+ * @param root - The captured main-content root (`capture-layout-tree.ts`'s `root`).
+ * @param options
+ * @example
+ * ```ts
+ * const block = classifyLayoutTree(root, { maxDepth: 6 });
+ * ```
+ */
+export function classifyLayoutTree(
+	root: RawLayoutNode,
+	options: ClassifyLayoutTreeOptions = {},
+): LayoutBlock {
+	return classifyNode(root, 0, {
+		maxDepth: options.maxDepth ?? 6,
+		minArea: options.minArea ?? DEFAULT_MIN_AREA,
+	});
+}

--- a/packages/@d-zero/anatomist/src/cli.spec.ts
+++ b/packages/@d-zero/anatomist/src/cli.spec.ts
@@ -1,0 +1,282 @@
+import type { RunBatchOptions } from './run-batch.js';
+
+import { createWriteStream } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { PassThrough } from 'node:stream';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { runCli } from './cli.js';
+import { runBatch } from './run-batch.js';
+
+vi.mock('./run-batch.js', () => ({
+	runBatch: vi.fn().mockResolvedValue(),
+}));
+
+vi.mock('node:fs', () => ({
+	createWriteStream: vi.fn(),
+}));
+
+vi.mock('node:fs/promises', () => ({
+	readFile: vi.fn(),
+}));
+
+/**
+ * @param text
+ */
+function stdinWith(text: string): NodeJS.ReadableStream {
+	const stream = new PassThrough();
+	stream.end(text);
+	return stream;
+}
+
+/**
+ * @param stream
+ */
+function collect(stream: PassThrough): () => string {
+	let data = '';
+	stream.on('data', (chunk: Buffer) => {
+		data += chunk.toString('utf8');
+	});
+	return () => data;
+}
+
+describe('runCli', () => {
+	beforeEach(() => {
+		vi.mocked(runBatch).mockReset().mockResolvedValue();
+		vi.mocked(readFile).mockReset();
+		vi.mocked(createWriteStream).mockReset();
+	});
+
+	it('prints help and exits 0 for --help', async () => {
+		const stdout = new PassThrough();
+		const readStdout = collect(stdout);
+		const exitCode = await runCli({
+			stdin: stdinWith(''),
+			stdout,
+			stderr: new PassThrough(),
+			argv: ['--help'],
+			version: '1.0.0',
+		});
+
+		expect(exitCode).toBe(0);
+		expect(readStdout()).toContain('Usage:');
+		expect(runBatch).not.toHaveBeenCalled();
+	});
+
+	it('prints the version and exits 0 for --version', async () => {
+		const stdout = new PassThrough();
+		const readStdout = collect(stdout);
+		const exitCode = await runCli({
+			stdin: stdinWith(''),
+			stdout,
+			stderr: new PassThrough(),
+			argv: ['--version'],
+			version: '1.2.3',
+		});
+
+		expect(exitCode).toBe(0);
+		expect(readStdout()).toBe('1.2.3\n');
+	});
+
+	it('exits 2 and prints usage for an unrecognized flag', async () => {
+		const stderr = new PassThrough();
+		const readStderr = collect(stderr);
+		const exitCode = await runCli({
+			stdin: stdinWith(''),
+			stdout: new PassThrough(),
+			stderr,
+			argv: ['--bogus'],
+			version: '1.0.0',
+		});
+
+		expect(exitCode).toBe(2);
+		expect(readStderr()).toContain('unrecognized argument');
+	});
+
+	it('reads URLs from stdin and passes them to runBatch', async () => {
+		await runCli({
+			stdin: stdinWith('https://a.example/\nhttps://b.example/\n'),
+			stdout: new PassThrough(),
+			stderr: new PassThrough(),
+			argv: [],
+			version: '1.0.0',
+		});
+
+		expect(runBatch).toHaveBeenCalledWith(
+			['https://a.example/', 'https://b.example/'],
+			expect.anything(),
+		);
+	});
+
+	it('exits 1 with a message when the URL list fails to parse', async () => {
+		const stderr = new PassThrough();
+		const readStderr = collect(stderr);
+		const exitCode = await runCli({
+			stdin: stdinWith('not json'),
+			stdout: new PassThrough(),
+			stderr,
+			argv: ['--input-format', 'json'],
+			version: '1.0.0',
+		});
+
+		expect(exitCode).toBe(1);
+		expect(readStderr()).toContain('anatomist:');
+	});
+
+	it('exits 1 with a message when a --viewport spec fails to parse', async () => {
+		const stderr = new PassThrough();
+		const readStderr = collect(stderr);
+		const exitCode = await runCli({
+			stdin: stdinWith('https://a.example/'),
+			stdout: new PassThrough(),
+			stderr,
+			argv: ['--viewport', 'not-a-spec'],
+			version: '1.0.0',
+		});
+
+		expect(exitCode).toBe(1);
+		expect(readStderr()).toContain('anatomist:');
+	});
+
+	it('writes each onResult callback as a JSONL line to stdout', async () => {
+		vi.mocked(runBatch).mockImplementation((_urls, options?: RunBatchOptions) => {
+			options?.onResult?.({
+				url: 'https://a.example/',
+				viewport: { name: 'pc', width: 1280 },
+				mainSelector: 'main',
+				root: null,
+			});
+			return Promise.resolve();
+		});
+
+		const stdout = new PassThrough();
+		const readStdout = collect(stdout);
+		const exitCode = await runCli({
+			stdin: stdinWith('https://a.example/'),
+			stdout,
+			stderr: new PassThrough(),
+			argv: [],
+			version: '1.0.0',
+		});
+
+		expect(exitCode).toBe(0);
+		const lines = readStdout().trim().split('\n');
+		expect(lines).toHaveLength(1);
+		expect(JSON.parse(lines[0]!)).toMatchObject({ url: 'https://a.example/' });
+	});
+
+	it('exits 1 when runBatch reports a per-URL error via onError', async () => {
+		vi.mocked(runBatch).mockImplementation((_urls, options?: RunBatchOptions) => {
+			options?.onError?.('https://bad.example/', new Error('boom'));
+			return Promise.resolve();
+		});
+
+		const stderr = new PassThrough();
+		const readStderr = collect(stderr);
+		const exitCode = await runCli({
+			stdin: stdinWith('https://bad.example/'),
+			stdout: new PassThrough(),
+			stderr,
+			argv: [],
+			version: '1.0.0',
+		});
+
+		expect(exitCode).toBe(1);
+		expect(readStderr()).toContain('failed to analyze https://bad.example/');
+	});
+
+	it('reads the URL list from --input instead of stdin when given', async () => {
+		vi.mocked(readFile).mockResolvedValue('https://from-file.example/\n');
+
+		await runCli({
+			stdin: stdinWith('https://from-stdin.example/'),
+			stdout: new PassThrough(),
+			stderr: new PassThrough(),
+			argv: ['--input', 'urls.txt'],
+			version: '1.0.0',
+		});
+
+		expect(readFile).toHaveBeenCalledWith('urls.txt', 'utf8');
+		expect(runBatch).toHaveBeenCalledWith(
+			['https://from-file.example/'],
+			expect.anything(),
+		);
+	});
+
+	it('writes results to the --out file instead of stdout, and closes the stream', async () => {
+		const written: string[] = [];
+		const mockEnd = vi.fn((callback: () => void) => {
+			callback();
+		});
+		vi.mocked(createWriteStream).mockReturnValue({
+			write: vi.fn((chunk: string) => {
+				written.push(chunk);
+				return true;
+			}),
+			end: mockEnd,
+		} as never);
+		vi.mocked(runBatch).mockImplementation((_urls, options?: RunBatchOptions) => {
+			options?.onResult?.({
+				url: 'https://a.example/',
+				viewport: { name: 'pc', width: 1280 },
+				mainSelector: 'main',
+				root: null,
+			});
+			return Promise.resolve();
+		});
+
+		const stdout = new PassThrough();
+		const readStdout = collect(stdout);
+		const exitCode = await runCli({
+			stdin: stdinWith('https://a.example/'),
+			stdout,
+			stderr: new PassThrough(),
+			argv: ['--out', 'result.jsonl'],
+			version: '1.0.0',
+		});
+
+		expect(createWriteStream).toHaveBeenCalledWith('result.jsonl');
+		expect(written.join('')).toContain('https://a.example/');
+		expect(readStdout()).toBe(''); // stdout must stay untouched when --out is given
+		expect(mockEnd).toHaveBeenCalled();
+		expect(exitCode).toBe(0);
+	});
+
+	it('exits 1 with a message when the --out stream fails to close, instead of throwing', async () => {
+		vi.mocked(createWriteStream).mockReturnValue({
+			write: vi.fn(() => true),
+			end: vi.fn((callback: (error: Error) => void) => {
+				callback(new Error('disk full'));
+			}),
+		} as never);
+
+		const stderr = new PassThrough();
+		const readStderr = collect(stderr);
+		const exitCode = await runCli({
+			stdin: stdinWith('https://a.example/'),
+			stdout: new PassThrough(),
+			stderr,
+			argv: ['--out', 'result.jsonl'],
+			version: '1.0.0',
+		});
+
+		expect(exitCode).toBe(1);
+		expect(readStderr()).toContain('failed to write result.jsonl');
+	});
+
+	it('forwards parsed CLI options to runBatch', async () => {
+		await runCli({
+			stdin: stdinWith('https://a.example/'),
+			stdout: new PassThrough(),
+			stderr: new PassThrough(),
+			argv: ['--main-selector', '#x', '--max-depth', '3', '--concurrency', '2'],
+			version: '1.0.0',
+		});
+
+		expect(runBatch).toHaveBeenCalledWith(
+			['https://a.example/'],
+			expect.objectContaining({ mainContentSelector: '#x', maxDepth: 3, concurrency: 2 }),
+		);
+	});
+});

--- a/packages/@d-zero/anatomist/src/cli.ts
+++ b/packages/@d-zero/anatomist/src/cli.ts
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+// Wires the `anatomist` executable to `runBatch`. Reads a URL list from a
+// file or stdin, writes one JSON result per (URL, viewport) to stdout (or
+// `--out`), and streams `deal()`'s progress to stderr — in-place animated
+// header on a TTY, appended lines otherwise (see `@d-zero/dealer`'s `Lanes`).
+
+import { createWriteStream } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import process from 'node:process';
+
+import { formatResultLine } from './format-output.js';
+import { parseArgs } from './parse-args.js';
+import { parseUrlList } from './parse-url-list.js';
+import { resolveViewports } from './resolve-viewports.js';
+import { runBatch } from './run-batch.js';
+
+const HELP_TEXT = `Usage:
+  anatomist [options] < urls.txt > results.jsonl
+
+Reads one URL per line from stdin (or --input), renders each in a real
+browser at one or more viewports, and writes one JSON result per
+(url, viewport) pair to stdout, in the order URLs and viewports were given.
+
+Output shape (one line per result, JSONL):
+  {
+    "url": "...",
+    "viewport": { "name": "pc", "width": 1280 },
+    "mainSelector": "main#content" | null,
+    "root": {
+      "layoutType": "vertical-stack" | "horizontal-row" | "simple-grid" |
+                     "complex-grid" | "table" | "float-wrap" | "unknown" | "leaf",
+      "tagName": "DIV", "id": null, "classList": [],
+      "boundingBox": { "x": 0, "y": 0, "width": 800, "height": 400 },
+      "innerHTML": "...",
+      "confidence": 0.85,
+      "signals": { "...": "..." },
+      "children": [ /* same shape, recursively */ ]
+    } | null
+  }
+
+Options:
+  --input, -f <path>          Read the URL list from <path> instead of stdin.
+  --input-format <format>     "lines" (default, one URL per line, # comments
+                               ignored) or "json" (a JSON array of strings).
+  --main-selector <selector>  Skip main-element auto-detection and use this
+                               selector directly.
+  --viewport <name:width>     Analyze this viewport instead of the default
+                               preset (pc:1280, tablet:768, sp:375). Repeat
+                               to analyze several; height is derived from
+                               width, not settable.
+  --max-depth <n>             Maximum classification depth (default 6).
+  --min-area <px>             Minimum child box area to count as meaningful
+                               (default 800).
+  --inner-html <mode>         "all" (default), "leaf-only", or "none" —
+                               controls which blocks carry innerHTML.
+  --no-bounding-box           Omit boundingBox from the output.
+  --concurrency <n>           URLs processed concurrently (default 1).
+  --timeout <ms>              Navigation timeout per viewport.
+  --max-scroll-height <px>    Skip the full-page scroll on pages taller than
+                               this (passed through to beforePageScan).
+  --out <path>                Write results to <path> instead of stdout.
+  --pretty                    Pretty-print each result (2-space indent).
+  --help                      Print this help and exit.
+  --version                   Print the package version and exit.
+
+Progress is written to stderr; the JSONL output on stdout is unaffected.
+Silence it with 2>/dev/null.
+`;
+
+/**
+ * @param stream
+ */
+async function readAll(stream: NodeJS.ReadableStream): Promise<string> {
+	stream.setEncoding?.('utf8');
+	const chunks: string[] = [];
+	for await (const chunk of stream) {
+		chunks.push(chunk as string);
+	}
+	return chunks.join('');
+}
+
+/**
+ * Test-friendly entry point: takes the run's stdin/stdout/stderr streams
+ * and the parsed CLI flags rather than reading them out of the process
+ * globals (pattern shared with `@d-zero/page-cluster`'s `runCli`).
+ * @param options
+ * @param options.stdin
+ * @param options.stdout
+ * @param options.stderr
+ * @param options.argv
+ * @param options.version
+ */
+export async function runCli(options: {
+	stdin: NodeJS.ReadableStream;
+	stdout: NodeJS.WritableStream;
+	stderr: NodeJS.WritableStream;
+	argv: readonly string[];
+	version: string;
+}): Promise<number> {
+	const args = parseArgs(options.argv);
+	if (args.help) {
+		options.stdout.write(HELP_TEXT);
+		return 0;
+	}
+	if (args.version) {
+		options.stdout.write(`${options.version}\n`);
+		return 0;
+	}
+	if (args.unknownFlag !== undefined) {
+		options.stderr.write(
+			`anatomist: unrecognized argument ${JSON.stringify(args.unknownFlag)}\n`,
+		);
+		options.stderr.write(HELP_TEXT);
+		return 2;
+	}
+
+	const inputText = args.input
+		? await readFile(args.input, 'utf8')
+		: await readAll(options.stdin);
+
+	let urls: string[];
+	try {
+		urls = parseUrlList(inputText, args.inputFormat);
+	} catch (error) {
+		options.stderr.write(`anatomist: ${(error as Error).message}\n`);
+		return 1;
+	}
+
+	let viewports;
+	try {
+		viewports = resolveViewports(args.viewports);
+	} catch (error) {
+		options.stderr.write(`anatomist: ${(error as Error).message}\n`);
+		return 1;
+	}
+
+	const outStream: NodeJS.WritableStream = args.out
+		? createWriteStream(args.out)
+		: options.stdout;
+
+	let hadError = false;
+	await runBatch(urls, {
+		viewports,
+		mainContentSelector: args.mainSelector,
+		maxDepth: args.maxDepth,
+		minArea: args.minArea,
+		concurrency: args.concurrency,
+		timeout: args.timeout,
+		maxScrollHeight: args.maxScrollHeight,
+		stderr: options.stderr,
+		onResult: (result) => {
+			const line = formatResultLine(result, {
+				pretty: args.pretty,
+				includeBoundingBox: !args.noBoundingBox,
+				innerHtmlMode: args.innerHtml,
+			});
+			outStream.write(`${line}\n`);
+		},
+		onError: (url, error) => {
+			hadError = true;
+			options.stderr.write(
+				`anatomist: failed to analyze ${url}: ${(error as Error).message}\n`,
+			);
+		},
+	});
+
+	if (args.out) {
+		try {
+			await new Promise<void>((resolve, reject) => {
+				(outStream as ReturnType<typeof createWriteStream>).end(
+					(error?: Error | null) => {
+						if (error) {
+							reject(error);
+						} else {
+							resolve();
+						}
+					},
+				);
+			});
+		} catch (error) {
+			// Consistent with every other failure path here: report to stderr
+			// and return a non-zero exit code, rather than letting the error
+			// propagate as an unhandled rejection out of runCli.
+			options.stderr.write(
+				`anatomist: failed to write ${args.out}: ${(error as Error).message}\n`,
+			);
+			return 1;
+		}
+	}
+
+	return hadError ? 1 : 0;
+}
+
+/**
+ * Reads the package version out of `package.json` at runtime. Kept as a
+ * separate helper so `runCli` can be exercised in tests without needing a
+ * real `package.json` on disk.
+ */
+async function readPackageVersion(): Promise<string> {
+	try {
+		const url = new URL('../package.json', import.meta.url);
+		const raw = await readFile(url, 'utf8');
+		const parsed = JSON.parse(raw) as { version?: string };
+		return parsed.version ?? '0.0.0';
+	} catch {
+		return '0.0.0';
+	}
+}
+
+// Only run when invoked as the actual entry point.
+if (import.meta.url === `file://${process.argv[1]}`) {
+	const version = await readPackageVersion();
+	const exitCode = await runCli({
+		stdin: process.stdin,
+		stdout: process.stdout,
+		stderr: process.stderr,
+		argv: process.argv.slice(2),
+		version,
+	});
+	process.exit(exitCode);
+}

--- a/packages/@d-zero/anatomist/src/cluster-into-rows.spec.ts
+++ b/packages/@d-zero/anatomist/src/cluster-into-rows.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { clusterIntoRows } from './cluster-into-rows.js';
+
+/**
+ * @param x
+ * @param y
+ * @param width
+ * @param height
+ */
+function box(x: number, y: number, width: number, height: number) {
+	return { boundingBox: { x, y, width, height } };
+}
+
+describe('clusterIntoRows', () => {
+	it('returns an empty array for no items', () => {
+		expect(clusterIntoRows([])).toEqual([]);
+	});
+
+	it('puts a single item in its own row', () => {
+		const a = box(0, 0, 100, 40);
+		expect(clusterIntoRows([a])).toEqual([[a]]);
+	});
+
+	it('groups items with fully overlapping Y spans into one row', () => {
+		const a = box(0, 0, 100, 40);
+		const b = box(120, 0, 100, 40);
+		const c = box(240, 0, 100, 40);
+		expect(clusterIntoRows([a, b, c])).toEqual([[a, b, c]]);
+	});
+
+	it('splits items with disjoint Y spans into separate rows', () => {
+		const a = box(0, 0, 100, 40);
+		const b = box(0, 100, 100, 40);
+		expect(clusterIntoRows([a, b])).toEqual([[a], [b]]);
+	});
+
+	it('tolerates partial vertical misalignment above the overlap threshold', () => {
+		// a spans [0,40], b spans [5,45] -> overlap 35 / shorter span 40 = 0.875
+		const a = box(0, 0, 100, 40);
+		const b = box(120, 5, 100, 40);
+		expect(clusterIntoRows([a, b])).toEqual([[a, b]]);
+	});
+
+	it('splits items whose vertical overlap falls below the ratio threshold', () => {
+		// a spans [0,40], b spans [35,75] -> overlap 5 / shorter span 40 = 0.125
+		const a = box(0, 0, 100, 40);
+		const b = box(120, 35, 100, 40);
+		expect(clusterIntoRows([a, b])).toEqual([[a], [b]]);
+	});
+
+	it('is insensitive to input order (sorts by Y internally)', () => {
+		const a = box(0, 0, 100, 40);
+		const b = box(0, 100, 100, 40);
+		expect(clusterIntoRows([b, a])).toEqual([[a], [b]]);
+	});
+
+	it('expands the row window so a later item can join via an accumulated overlap it lacks with the first item alone', () => {
+		// a: [0,40]; b: [20,60] overlaps a at ratio 20/40=0.5 -> joins, window becomes [0,60]
+		// c: [40,80] has zero overlap with a's original [0,40] span, but overlaps
+		// the *expanded* window [0,60] at ratio 20/40=0.5 -> joins only because
+		// the window expanded via b.
+		const a = box(0, 0, 100, 40);
+		const b = box(120, 20, 100, 40);
+		const c = box(240, 40, 100, 40);
+		expect(clusterIntoRows([a, b, c])).toEqual([[a, b, c]]);
+	});
+
+	it('respects a custom overlapRatio threshold', () => {
+		const a = box(0, 0, 100, 40);
+		const b = box(120, 35, 100, 40); // ratio 0.125
+		expect(clusterIntoRows([a, b], 0.1)).toEqual([[a, b]]);
+		expect(clusterIntoRows([a, b], 0.5)).toEqual([[a], [b]]);
+	});
+});

--- a/packages/@d-zero/anatomist/src/cluster-into-rows.ts
+++ b/packages/@d-zero/anatomist/src/cluster-into-rows.ts
@@ -1,0 +1,78 @@
+import type { BoundingBox } from './types.js';
+
+/** Anything with a box to cluster by position. */
+export type WithBoundingBox = { boundingBox: BoundingBox };
+
+/**
+ * Groups items into visual rows by greedily merging items whose vertical
+ * (Y-axis) span overlaps the current row's accumulated span by at least
+ * `overlapRatio`.
+ *
+ * WHY overlap ratio, not shared Y coordinate: real layouts rarely align
+ * every item in a row to the same top edge (baseline alignment, differing
+ * heights, icon + label pairs). Requiring a minimum overlap fraction of
+ * the shorter item's height tolerates that variance while still splitting
+ * clearly-separate rows.
+ *
+ * A row's span expands (union) as members are added, so a tall first item
+ * doesn't prematurely reject a shorter item that only overlaps the tail of
+ * its span — the row's window is what accumulates, not the first item's
+ * span alone.
+ * @param items - Items sorted internally by Y position; caller's order
+ *   determines only the caller's expectations of stability, not correctness.
+ * @param overlapRatio - Minimum required Y-overlap, as a fraction of the
+ *   shorter of the two spans being compared. Default `0.5`.
+ * @returns Rows, each in ascending-Y-then-caller order; the input order
+ *   within a row is not otherwise significant.
+ * @example
+ * ```ts
+ * clusterIntoRows([
+ *   { boundingBox: { x: 0, y: 0, width: 100, height: 40 } },
+ *   { boundingBox: { x: 120, y: 5, width: 100, height: 40 } },
+ *   { boundingBox: { x: 0, y: 60, width: 100, height: 40 } },
+ * ]);
+ * // [[item0, item1], [item2]]
+ * ```
+ */
+export function clusterIntoRows<T extends WithBoundingBox>(
+	items: readonly T[],
+	overlapRatio = 0.5,
+): T[][] {
+	if (items.length === 0) {
+		return [];
+	}
+
+	const sorted = items.toSorted((a, b) => a.boundingBox.y - b.boundingBox.y);
+	const rows: T[][] = [];
+
+	let currentRow: T[] = [sorted[0]!];
+	let rowTop = sorted[0]!.boundingBox.y;
+	let rowBottom = rowTop + sorted[0]!.boundingBox.height;
+
+	for (let i = 1; i < sorted.length; i++) {
+		const item = sorted[i]!;
+		const itemTop = item.boundingBox.y;
+		const itemBottom = itemTop + item.boundingBox.height;
+
+		const overlap = Math.max(
+			0,
+			Math.min(rowBottom, itemBottom) - Math.max(rowTop, itemTop),
+		);
+		const shorterSpan = Math.min(rowBottom - rowTop, itemBottom - itemTop);
+		const ratio = shorterSpan > 0 ? overlap / shorterSpan : 0;
+
+		if (ratio >= overlapRatio) {
+			currentRow.push(item);
+			rowTop = Math.min(rowTop, itemTop);
+			rowBottom = Math.max(rowBottom, itemBottom);
+		} else {
+			rows.push(currentRow);
+			currentRow = [item];
+			rowTop = itemTop;
+			rowBottom = itemBottom;
+		}
+	}
+	rows.push(currentRow);
+
+	return rows;
+}

--- a/packages/@d-zero/anatomist/src/default-viewports.spec.ts
+++ b/packages/@d-zero/anatomist/src/default-viewports.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_VIEWPORTS } from './default-viewports.js';
+
+describe('DEFAULT_VIEWPORTS', () => {
+	it('lists pc, tablet, then sp, largest width first', () => {
+		expect(DEFAULT_VIEWPORTS).toEqual([
+			{ name: 'pc', width: 1280 },
+			{ name: 'tablet', width: 768 },
+			{ name: 'sp', width: 375 },
+		]);
+	});
+
+	it('is ordered strictly by decreasing width', () => {
+		const widths = DEFAULT_VIEWPORTS.map((v) => v.width);
+		expect(widths).toEqual(widths.toSorted((a, b) => b - a));
+	});
+});

--- a/packages/@d-zero/anatomist/src/default-viewports.ts
+++ b/packages/@d-zero/anatomist/src/default-viewports.ts
@@ -1,0 +1,18 @@
+import type { ViewportSpec } from './types.js';
+
+/**
+ * Default viewport presets, ordered largest to smallest.
+ *
+ * WHY this order: pages are reloaded once and then have their viewport
+ * resized in place across presets (see `analyze-page-layout.ts`) rather
+ * than reloaded per preset. Resizing down from a desktop layout mirrors
+ * how a real browser window shrinks and lets already-loaded images/fonts
+ * stay in place; resizing up from mobile first can leave a page that
+ * lazy-loads content only above a certain viewport width with holes that
+ * a later downsize wouldn't fill back in.
+ */
+export const DEFAULT_VIEWPORTS: readonly ViewportSpec[] = [
+	{ name: 'pc', width: 1280 },
+	{ name: 'tablet', width: 768 },
+	{ name: 'sp', width: 375 },
+];

--- a/packages/@d-zero/anatomist/src/detect-float-wrap-pattern.spec.ts
+++ b/packages/@d-zero/anatomist/src/detect-float-wrap-pattern.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { mockNode } from './__fixtures__/mock-node.js';
+import { detectFloatWrapPattern } from './detect-float-wrap-pattern.js';
+
+describe('detectFloatWrapPattern', () => {
+	it('does not match when no child is floated media', () => {
+		const children = [mockNode(), mockNode()];
+		expect(detectFloatWrapPattern(children).matched).toBe(false);
+	});
+
+	it('does not match a floated image with no overlapping sibling', () => {
+		const image = mockNode({
+			tagName: 'IMG',
+			style: {
+				display: 'block',
+				float: 'left',
+				position: 'static',
+				visibility: 'visible',
+			},
+			boundingBox: { x: 0, y: 0, width: 100, height: 100 },
+		});
+		const paragraph = mockNode({
+			tagName: 'P',
+			boundingBox: { x: 0, y: 200, width: 300, height: 40 },
+		});
+		expect(detectFloatWrapPattern([image, paragraph]).matched).toBe(false);
+	});
+
+	it('matches a floated image overlapping a text sibling (text wraps around it)', () => {
+		const image = mockNode({
+			tagName: 'IMG',
+			style: {
+				display: 'block',
+				float: 'left',
+				position: 'static',
+				visibility: 'visible',
+			},
+			boundingBox: { x: 0, y: 0, width: 100, height: 100 },
+		});
+		const paragraph = mockNode({
+			tagName: 'P',
+			boundingBox: { x: 0, y: 0, width: 300, height: 150 },
+		});
+		const result = detectFloatWrapPattern([image, paragraph]);
+		expect(result.matched).toBe(true);
+		expect(result.confidence).toBe(0.75);
+	});
+
+	it('ignores a non-media floated element (e.g. a floated div is not "media")', () => {
+		const floatedDiv = mockNode({
+			tagName: 'DIV',
+			style: {
+				display: 'block',
+				float: 'left',
+				position: 'static',
+				visibility: 'visible',
+			},
+		});
+		const other = mockNode({ boundingBox: { x: 0, y: 0, width: 100, height: 100 } });
+		expect(detectFloatWrapPattern([floatedDiv, other]).matched).toBe(false);
+	});
+});

--- a/packages/@d-zero/anatomist/src/detect-float-wrap-pattern.ts
+++ b/packages/@d-zero/anatomist/src/detect-float-wrap-pattern.ts
@@ -1,0 +1,67 @@
+import type { BoundingBox, DetectionResult, RawLayoutNode } from './types.js';
+
+/** Tags treated as "media" for float-wrap detection — text wrapping around a floated image/figure. */
+const FLOATED_MEDIA_TAGS: ReadonlySet<string> = new Set(['IMG', 'FIGURE', 'PICTURE']);
+
+/**
+ * @param a
+ * @param b
+ */
+function horizontallyOverlaps(a: BoundingBox, b: BoundingBox): boolean {
+	return a.x < b.x + b.width && b.x < a.x + a.width;
+}
+
+/**
+ * @param a
+ * @param b
+ */
+function verticallyOverlaps(a: BoundingBox, b: BoundingBox): boolean {
+	return a.y < b.y + b.height && b.y < a.y + a.height;
+}
+
+/**
+ * Detects a floated-media-with-text-wrap pattern: a floated image-like
+ * child (`float !== 'none'`) whose box overlaps another child's box both
+ * horizontally and vertically — the geometric signature of text flowing
+ * around a float, since non-floated siblings would otherwise stack below
+ * it with no overlap.
+ *
+ * `float` is used as the first-order signal here — unlike every other
+ * detector in this package, where geometry decides and CSS only
+ * corroborates — because float only affects layout in normal flow: a
+ * flex/grid item with `float` set is unaffected by it, so this detector
+ * should only ever fire for non-flex/grid parents, which
+ * `resolve-layout-type.ts`'s ordering (grid/row detectors run first)
+ * already guarantees.
+ * @param children - The container's visible, in-flow children.
+ * @example
+ * ```ts
+ * detectFloatWrapPattern([floatedThumbnail, wrappingParagraph]);
+ * // { matched: true, confidence: 0.75, ... }
+ * ```
+ */
+export function detectFloatWrapPattern(
+	children: readonly RawLayoutNode[],
+): DetectionResult {
+	const floatedMedia = children.filter(
+		(c) => c.style.float !== 'none' && FLOATED_MEDIA_TAGS.has(c.tagName),
+	);
+	if (floatedMedia.length === 0) {
+		return { matched: false, confidence: 0, signals: { floatedMediaCount: 0 } };
+	}
+
+	const others = children.filter((c) => !floatedMedia.includes(c));
+	const hasWrap = floatedMedia.some((media) =>
+		others.some(
+			(other) =>
+				horizontallyOverlaps(media.boundingBox, other.boundingBox) &&
+				verticallyOverlaps(media.boundingBox, other.boundingBox),
+		),
+	);
+
+	return {
+		matched: hasWrap,
+		confidence: hasWrap ? 0.75 : 0,
+		signals: { floatedMediaCount: floatedMedia.length, hasWrap },
+	};
+}

--- a/packages/@d-zero/anatomist/src/detect-grid-pattern.spec.ts
+++ b/packages/@d-zero/anatomist/src/detect-grid-pattern.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import { mockNode } from './__fixtures__/mock-node.js';
+import { clusterIntoRows } from './cluster-into-rows.js';
+import { detectGridPattern } from './detect-grid-pattern.js';
+
+/**
+ * @param x
+ * @param y
+ * @param width
+ * @param height
+ */
+function cell(x: number, y: number, width: number, height: number) {
+	return mockNode({ boundingBox: { x, y, width, height } });
+}
+
+/**
+ * @param children
+ */
+function detect(children: ReturnType<typeof cell>[]) {
+	return detectGridPattern(clusterIntoRows(children), children);
+}
+
+describe('detectGridPattern', () => {
+	it('does not match fewer than two children', () => {
+		expect(detect([cell(0, 0, 100, 40)])).toMatchObject({
+			matched: false,
+			variant: null,
+		});
+	});
+
+	it('does not match a single row (that is horizontal-row territory)', () => {
+		const children = [cell(0, 0, 100, 40), cell(120, 0, 100, 40), cell(240, 0, 100, 40)];
+		expect(detect(children)).toMatchObject({ matched: false, variant: null });
+	});
+
+	it('matches a uniform 3x2 grid as simple', () => {
+		const children = [
+			cell(0, 0, 100, 100),
+			cell(120, 0, 100, 100),
+			cell(240, 0, 100, 100),
+			cell(0, 120, 100, 100),
+			cell(120, 120, 100, 100),
+			cell(240, 120, 100, 100),
+		];
+		const result = detect(children);
+		expect(result.matched).toBe(true);
+		expect(result.variant).toBe('simple');
+		expect(result.confidence).toBeGreaterThan(0.8);
+	});
+
+	it('classifies uneven row sizes (masonry-like) as complex', () => {
+		const children = [
+			cell(0, 0, 100, 100),
+			cell(120, 0, 100, 100),
+			cell(240, 0, 100, 100),
+			cell(0, 120, 100, 100),
+			cell(120, 120, 100, 100),
+		];
+		const result = detect(children);
+		expect(result.matched).toBe(true);
+		expect(result.variant).toBe('complex');
+	});
+
+	it('classifies a spanning cell (much wider than the typical cell) as complex', () => {
+		const children = [
+			cell(0, 0, 320, 100), // spans what would be 3 columns
+			cell(0, 120, 100, 100),
+			cell(120, 120, 100, 100),
+			cell(240, 120, 100, 100),
+		];
+		const result = detect(children);
+		expect(result.matched).toBe(true);
+		expect(result.variant).toBe('complex');
+		expect(result.signals.hasSpanning).toBe(true);
+	});
+
+	it('does not match when every row has exactly one child (that is vertical-stack territory)', () => {
+		const children = [cell(0, 0, 700, 40), cell(0, 60, 700, 40), cell(0, 120, 700, 40)];
+		expect(detect(children)).toMatchObject({ matched: false, variant: null });
+	});
+});

--- a/packages/@d-zero/anatomist/src/detect-grid-pattern.ts
+++ b/packages/@d-zero/anatomist/src/detect-grid-pattern.ts
@@ -1,0 +1,119 @@
+import type { DetectionResult, RawLayoutNode } from './types.js';
+
+import { maxOf } from './max-of.js';
+
+/**
+ * @param values
+ */
+function median(values: readonly number[]): number {
+	if (values.length === 0) {
+		return 0;
+	}
+	const sorted = values.toSorted((a, b) => a - b);
+	const mid = Math.floor(sorted.length / 2);
+	return sorted.length % 2 === 0 ? (sorted[mid - 1]! + sorted[mid]!) / 2 : sorted[mid]!;
+}
+
+/**
+ * @param values
+ */
+function coefficientOfVariation(values: readonly number[]): number {
+	if (values.length === 0) {
+		return 0;
+	}
+	const mean = values.reduce((sum, v) => sum + v, 0) / values.length;
+	if (mean === 0) {
+		return 0;
+	}
+	const variance = values.reduce((sum, v) => sum + (v - mean) ** 2, 0) / values.length;
+	return Math.sqrt(variance) / mean;
+}
+
+/** Multiple of the typical cell size beyond which a child is treated as spanning more than one cell. */
+const SPANNING_RATIO = 1.5;
+
+export type GridDetectionResult = DetectionResult & {
+	variant: 'simple' | 'complex' | null;
+};
+
+/**
+ * Detects a grid pattern (2+ rows of children arranged in columns) from
+ * geometry alone, and classifies it as `simple` (uniform row sizes, no
+ * cell spans more than one cell) or `complex` (uneven row sizes, or a
+ * child spanning multiple cells — the masonry / `grid-template-areas`
+ * case). A single row is never a grid — see `detect-horizontal-row-pattern.ts`.
+ * @param rows - `children` pre-clustered into rows (see `cluster-into-rows.ts`).
+ *   Computed once by `resolve-layout-type.ts` and shared across every
+ *   row-based detector rather than re-clustered here, since the geometric
+ *   clustering pass is identical work each detector would otherwise repeat.
+ * @param children - The same children `rows` was built from, in original order.
+ * @example
+ * ```ts
+ * detectGridPattern(clusterIntoRows(threeByThreeCards), threeByThreeCards);
+ * // { matched: true, variant: 'simple', ... }
+ * ```
+ */
+export function detectGridPattern(
+	rows: readonly (readonly RawLayoutNode[])[],
+	children: readonly RawLayoutNode[],
+): GridDetectionResult {
+	if (children.length < 2) {
+		return {
+			matched: false,
+			confidence: 0,
+			signals: { childCount: children.length },
+			variant: null,
+		};
+	}
+
+	if (rows.length < 2) {
+		return {
+			matched: false,
+			confidence: 0,
+			signals: { rowCount: rows.length },
+			variant: null,
+		};
+	}
+
+	const rowSizes = rows.map((row) => row.length);
+	// A grid needs at least one row with 2+ columns — every row having
+	// exactly one child is N rows of one column each, i.e. a vertical stack
+	// (see detect-vertical-stack-pattern.ts), not a grid.
+	if (maxOf(rowSizes) < 2) {
+		return {
+			matched: false,
+			confidence: 0,
+			signals: { rowCount: rows.length, rowSizes },
+			variant: null,
+		};
+	}
+
+	const uniformRowSize = rowSizes.every((size) => size === rowSizes[0]);
+
+	const widths = children.map((c) => c.boundingBox.width);
+	const heights = children.map((c) => c.boundingBox.height);
+	const typicalWidth = median(widths);
+	const typicalHeight = median(heights);
+	const hasSpanning =
+		(typicalWidth > 0 &&
+			children.some((c) => c.boundingBox.width > typicalWidth * SPANNING_RATIO)) ||
+		(typicalHeight > 0 &&
+			children.some((c) => c.boundingBox.height > typicalHeight * SPANNING_RATIO));
+
+	const widthCv = coefficientOfVariation(widths);
+	const isComplex = !uniformRowSize || hasSpanning;
+
+	return {
+		matched: true,
+		confidence: isComplex ? 0.6 : 0.85,
+		signals: {
+			rowCount: rows.length,
+			rowSizes,
+			widthCv,
+			hasSpanning,
+			typicalWidth,
+			typicalHeight,
+		},
+		variant: isComplex ? 'complex' : 'simple',
+	};
+}

--- a/packages/@d-zero/anatomist/src/detect-horizontal-row-pattern.spec.ts
+++ b/packages/@d-zero/anatomist/src/detect-horizontal-row-pattern.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { mockNode } from './__fixtures__/mock-node.js';
+import { clusterIntoRows } from './cluster-into-rows.js';
+import { detectHorizontalRowPattern } from './detect-horizontal-row-pattern.js';
+
+/**
+ * @param children
+ */
+function detect(children: ReturnType<typeof mockNode>[]) {
+	return detectHorizontalRowPattern(clusterIntoRows(children), children.length);
+}
+
+describe('detectHorizontalRowPattern', () => {
+	it('does not match fewer than two children', () => {
+		expect(detect([mockNode()]).matched).toBe(false);
+	});
+
+	it('matches when all children share a single row', () => {
+		const children = [
+			mockNode({ boundingBox: { x: 0, y: 0, width: 100, height: 40 } }),
+			mockNode({ boundingBox: { x: 120, y: 0, width: 100, height: 40 } }),
+			mockNode({ boundingBox: { x: 240, y: 0, width: 100, height: 40 } }),
+		];
+		const result = detect(children);
+		expect(result.matched).toBe(true);
+		expect(result.confidence).toBe(0.8);
+	});
+
+	it('does not match when children fall into more than one row', () => {
+		const children = [
+			mockNode({ boundingBox: { x: 0, y: 0, width: 100, height: 40 } }),
+			mockNode({ boundingBox: { x: 0, y: 100, width: 100, height: 40 } }),
+		];
+		expect(detect(children).matched).toBe(false);
+	});
+});

--- a/packages/@d-zero/anatomist/src/detect-horizontal-row-pattern.ts
+++ b/packages/@d-zero/anatomist/src/detect-horizontal-row-pattern.ts
@@ -1,0 +1,35 @@
+import type { DetectionResult, RawLayoutNode } from './types.js';
+
+/**
+ * Detects a single-row layout: every child falls into one row cluster
+ * (see `cluster-into-rows.ts`). This is a purely visual read — the same
+ * shape can come from `display: flex`, `display: grid` with one row, or
+ * `inline-block` children; the CSS mechanism is not this detector's
+ * concern (see `resolve-layout-type.ts` for how `signals` carries that
+ * detail separately).
+ * @param rows - `children` pre-clustered into rows. Computed once by
+ *   `resolve-layout-type.ts` and shared across every row-based detector.
+ * @param childCount - `children.length`, passed separately rather than
+ *   re-deriving it from `rows` since a childless call has zero rows either way.
+ * @example
+ * ```ts
+ * detectHorizontalRowPattern(clusterIntoRows(threeCardsSideBySide), 3);
+ * // { matched: true, confidence: 0.8, ... }
+ * ```
+ */
+export function detectHorizontalRowPattern(
+	rows: readonly (readonly RawLayoutNode[])[],
+	childCount: number,
+): DetectionResult {
+	if (childCount < 2) {
+		return { matched: false, confidence: 0, signals: { childCount } };
+	}
+
+	const matched = rows.length === 1;
+
+	return {
+		matched,
+		confidence: matched ? 0.8 : 0,
+		signals: { rowCount: rows.length, childCount },
+	};
+}

--- a/packages/@d-zero/anatomist/src/detect-table-pattern.spec.ts
+++ b/packages/@d-zero/anatomist/src/detect-table-pattern.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+
+import { mockNode } from './__fixtures__/mock-node.js';
+import { detectTablePattern } from './detect-table-pattern.js';
+
+describe('detectTablePattern', () => {
+	it('matches a <table> tag regardless of its display value', () => {
+		const result = detectTablePattern(
+			mockNode({
+				tagName: 'TABLE',
+				style: {
+					display: 'block',
+					float: 'none',
+					position: 'static',
+					visibility: 'visible',
+				},
+			}),
+		);
+		expect(result.matched).toBe(true);
+		expect(result.confidence).toBe(1);
+	});
+
+	it('matches display: table on a non-table tag', () => {
+		const result = detectTablePattern(
+			mockNode({
+				tagName: 'DIV',
+				style: {
+					display: 'table',
+					float: 'none',
+					position: 'static',
+					visibility: 'visible',
+				},
+			}),
+		);
+		expect(result.matched).toBe(true);
+		expect(result.confidence).toBe(0.9);
+	});
+
+	it('matches the two-value syntax "block table"', () => {
+		const result = detectTablePattern(
+			mockNode({
+				style: {
+					display: 'block table',
+					float: 'none',
+					position: 'static',
+					visibility: 'visible',
+				},
+			}),
+		);
+		expect(result.matched).toBe(true);
+	});
+
+	it('matches table-internal display values', () => {
+		const result = detectTablePattern(
+			mockNode({
+				style: {
+					display: 'table-cell',
+					float: 'none',
+					position: 'static',
+					visibility: 'visible',
+				},
+			}),
+		);
+		expect(result.matched).toBe(true);
+	});
+
+	it('does not match ruby-base, a different internal display value', () => {
+		const result = detectTablePattern(
+			mockNode({
+				style: {
+					display: 'ruby-base',
+					float: 'none',
+					position: 'static',
+					visibility: 'visible',
+				},
+			}),
+		);
+		expect(result.matched).toBe(false);
+	});
+
+	it('does not match a plain block div', () => {
+		const result = detectTablePattern(mockNode());
+		expect(result.matched).toBe(false);
+		expect(result.confidence).toBe(0);
+	});
+
+	it('always reports raw signals, even when unmatched', () => {
+		const result = detectTablePattern(mockNode());
+		expect(result.signals).toMatchObject({ tagName: 'DIV', display: 'block' });
+	});
+});

--- a/packages/@d-zero/anatomist/src/detect-table-pattern.ts
+++ b/packages/@d-zero/anatomist/src/detect-table-pattern.ts
@@ -1,0 +1,53 @@
+import type { DetectionResult, RawLayoutNode } from './types.js';
+
+import { parseDisplay } from './parse-display.js';
+
+/**
+ * Internal display values that participate in a CSS table (as opposed to
+ * ruby's internal values, which don't). Listed explicitly rather than
+ * matched by prefix so this stays a closed, reviewable set instead of a
+ * string-shape guess.
+ */
+const TABLE_INTERNAL_DISPLAY_VALUES: ReadonlySet<string> = new Set([
+	'table-row-group',
+	'table-header-group',
+	'table-footer-group',
+	'table-row',
+	'table-cell',
+	'table-column-group',
+	'table-column',
+	'table-caption',
+]);
+
+/**
+ * Detects whether a container itself is a table — either the `<table>`
+ * element or a CSS table display (`display: table`/`inline-table`, or one
+ * of the table-internal display values). Checked first, ahead of all
+ * geometric detectors, because a `<table>`'s row/column structure is
+ * authoritative regardless of what its cell geometry looks like.
+ * @param node
+ * @example
+ * ```ts
+ * detectTablePattern({ tagName: 'TABLE', style: { display: 'table', ... }, ... });
+ * // { matched: true, confidence: 1, signals: { ... } }
+ * ```
+ */
+export function detectTablePattern(node: RawLayoutNode): DetectionResult {
+	const parsed = parseDisplay(node.style.display);
+	const isTableTag = node.tagName === 'TABLE';
+	const isTableDisplay = parsed.kind === 'box-generating' && parsed.inside === 'table';
+	const isTableInternal =
+		parsed.kind === 'internal' && TABLE_INTERNAL_DISPLAY_VALUES.has(parsed.value);
+
+	const matched = isTableTag || isTableDisplay || isTableInternal;
+
+	return {
+		matched,
+		confidence: matched ? (isTableTag ? 1 : 0.9) : 0,
+		signals: {
+			tagName: node.tagName,
+			display: node.style.display,
+			parsedDisplay: parsed,
+		},
+	};
+}

--- a/packages/@d-zero/anatomist/src/detect-vertical-stack-pattern.spec.ts
+++ b/packages/@d-zero/anatomist/src/detect-vertical-stack-pattern.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { mockNode } from './__fixtures__/mock-node.js';
+import { clusterIntoRows } from './cluster-into-rows.js';
+import { detectVerticalStackPattern } from './detect-vertical-stack-pattern.js';
+
+/**
+ * @param children
+ */
+function detect(children: ReturnType<typeof mockNode>[]) {
+	return detectVerticalStackPattern(clusterIntoRows(children), children.length);
+}
+
+describe('detectVerticalStackPattern', () => {
+	it('does not match zero children', () => {
+		expect(detect([]).matched).toBe(false);
+	});
+
+	it('matches a single child (degenerate stack of one)', () => {
+		expect(detect([mockNode()]).matched).toBe(true);
+	});
+
+	it('matches children stacked one per row', () => {
+		const children = [
+			mockNode({ boundingBox: { x: 0, y: 0, width: 200, height: 40 } }),
+			mockNode({ boundingBox: { x: 0, y: 50, width: 200, height: 40 } }),
+			mockNode({ boundingBox: { x: 0, y: 100, width: 200, height: 40 } }),
+		];
+		const result = detect(children);
+		expect(result.matched).toBe(true);
+		expect(result.confidence).toBe(0.8);
+	});
+
+	it('does not match when any row has more than one child', () => {
+		const children = [
+			mockNode({ boundingBox: { x: 0, y: 0, width: 100, height: 40 } }),
+			mockNode({ boundingBox: { x: 120, y: 0, width: 100, height: 40 } }),
+		];
+		expect(detect(children).matched).toBe(false);
+	});
+});

--- a/packages/@d-zero/anatomist/src/detect-vertical-stack-pattern.ts
+++ b/packages/@d-zero/anatomist/src/detect-vertical-stack-pattern.ts
@@ -1,0 +1,34 @@
+import type { DetectionResult, RawLayoutNode } from './types.js';
+
+/**
+ * Detects a stacked layout: every row cluster (see `cluster-into-rows.ts`)
+ * contains exactly one child, i.e. children are stacked one per row with
+ * no two sharing a row. This is the fallback-shaped pattern (matches a
+ * lone child too), so `resolve-layout-type.ts` checks it last among the
+ * geometric detectors.
+ * @param rows - `children` pre-clustered into rows. Computed once by
+ *   `resolve-layout-type.ts` and shared across every row-based detector.
+ * @param childCount - `children.length`, passed separately rather than
+ *   re-deriving it from `rows` for symmetry with the other row-based detectors.
+ * @example
+ * ```ts
+ * detectVerticalStackPattern(clusterIntoRows(threeParagraphsStacked), 3);
+ * // { matched: true, confidence: 0.8, ... }
+ * ```
+ */
+export function detectVerticalStackPattern(
+	rows: readonly (readonly RawLayoutNode[])[],
+	childCount: number,
+): DetectionResult {
+	if (childCount === 0) {
+		return { matched: false, confidence: 0, signals: { childCount: 0 } };
+	}
+
+	const matched = rows.every((row) => row.length === 1);
+
+	return {
+		matched,
+		confidence: matched ? 0.8 : 0,
+		signals: { rowCount: rows.length, childCount },
+	};
+}

--- a/packages/@d-zero/anatomist/src/format-output.spec.ts
+++ b/packages/@d-zero/anatomist/src/format-output.spec.ts
@@ -1,0 +1,94 @@
+import type { LayoutAnalysisResult } from './types.js';
+
+import { describe, expect, it } from 'vitest';
+
+import { formatResultLine } from './format-output.js';
+
+const NESTED_RESULT: LayoutAnalysisResult = {
+	url: 'https://example.com/',
+	viewport: { name: 'pc', width: 1280 },
+	mainSelector: 'main',
+	root: {
+		layoutType: 'horizontal-row',
+		tagName: 'DIV',
+		id: 'root',
+		classList: [],
+		boundingBox: { x: 0, y: 0, width: 800, height: 100 },
+		innerHTML: '<div>a</div><div>b</div>',
+		confidence: 0.8,
+		signals: { rowCount: 1 },
+		children: [
+			{
+				layoutType: 'leaf',
+				tagName: 'DIV',
+				id: null,
+				classList: [],
+				boundingBox: { x: 0, y: 0, width: 100, height: 100 },
+				innerHTML: 'a',
+				confidence: 0,
+				signals: {},
+				children: [],
+			},
+		],
+	},
+};
+
+describe('formatResultLine', () => {
+	it('emits single-line JSON by default', () => {
+		const line = formatResultLine(NESTED_RESULT);
+		expect(line).not.toContain('\n');
+		expect(JSON.parse(line)).toMatchObject({
+			url: 'https://example.com/',
+			mainSelector: 'main',
+		});
+	});
+
+	it('pretty-prints when requested', () => {
+		const line = formatResultLine(NESTED_RESULT, { pretty: true });
+		expect(line).toContain('\n');
+	});
+
+	it('includes boundingBox by default', () => {
+		const parsed = JSON.parse(formatResultLine(NESTED_RESULT));
+		expect(parsed.root.boundingBox).toEqual({ x: 0, y: 0, width: 800, height: 100 });
+	});
+
+	it('omits boundingBox when includeBoundingBox is false', () => {
+		const parsed = JSON.parse(
+			formatResultLine(NESTED_RESULT, { includeBoundingBox: false }),
+		);
+		expect(parsed.root.boundingBox).toBeUndefined();
+		expect(parsed.root.children[0].boundingBox).toBeUndefined();
+	});
+
+	it('includes innerHTML on every block by default (mode "all")', () => {
+		const parsed = JSON.parse(formatResultLine(NESTED_RESULT));
+		expect(parsed.root.innerHTML).toBe('<div>a</div><div>b</div>');
+		expect(parsed.root.children[0].innerHTML).toBe('a');
+	});
+
+	it('includes innerHTML only on leaves in "leaf-only" mode', () => {
+		const parsed = JSON.parse(
+			formatResultLine(NESTED_RESULT, { innerHtmlMode: 'leaf-only' }),
+		);
+		expect(parsed.root.innerHTML).toBeUndefined();
+		expect(parsed.root.children[0].innerHTML).toBe('a');
+	});
+
+	it('omits innerHTML everywhere in "none" mode', () => {
+		const parsed = JSON.parse(formatResultLine(NESTED_RESULT, { innerHtmlMode: 'none' }));
+		expect(parsed.root.innerHTML).toBeUndefined();
+		expect(parsed.root.children[0].innerHTML).toBeUndefined();
+	});
+
+	it('renders a null root as null', () => {
+		const result: LayoutAnalysisResult = {
+			url: 'https://example.com/',
+			viewport: { name: 'pc', width: 1280 },
+			mainSelector: null,
+			root: null,
+		};
+		const parsed = JSON.parse(formatResultLine(result));
+		expect(parsed.root).toBeNull();
+	});
+});

--- a/packages/@d-zero/anatomist/src/format-output.ts
+++ b/packages/@d-zero/anatomist/src/format-output.ts
@@ -1,0 +1,76 @@
+import type { LayoutAnalysisResult, LayoutBlock } from './types.js';
+
+export type InnerHtmlMode = 'all' | 'leaf-only' | 'none';
+
+export type FormatOutputOptions = {
+	/** Pretty-print with 2-space indent instead of single-line JSON. Default `false`. */
+	pretty?: boolean;
+	/** Include each block's `boundingBox`. Default `true`. */
+	includeBoundingBox?: boolean;
+	/** Which blocks carry `innerHTML`: every block, only leaves, or none. Default `'all'`. */
+	innerHtmlMode?: InnerHtmlMode;
+};
+
+/**
+ * @param block
+ * @param options
+ */
+function transformBlock(
+	block: LayoutBlock,
+	options: Required<FormatOutputOptions>,
+): Record<string, unknown> {
+	const isLeaf = block.children.length === 0;
+	const includeInnerHtml =
+		options.innerHtmlMode === 'all' || (options.innerHtmlMode === 'leaf-only' && isLeaf);
+
+	return {
+		layoutType: block.layoutType,
+		tagName: block.tagName,
+		id: block.id,
+		classList: block.classList,
+		...(options.includeBoundingBox ? { boundingBox: block.boundingBox } : {}),
+		...(includeInnerHtml ? { innerHTML: block.innerHTML } : {}),
+		confidence: block.confidence,
+		signals: block.signals,
+		children: block.children.map((child) => transformBlock(child, options)),
+	};
+}
+
+/**
+ * Formats one `LayoutAnalysisResult` as a JSON string, one result per
+ * line by default (JSONL) so a batch run can stream output incrementally
+ * rather than buffering the whole run in memory before writing anything.
+ *
+ * `innerHtmlMode: 'all'` (the default) means recursive blocks duplicate
+ * content between a parent and its children — each layer's `innerHTML`
+ * is meant to be self-contained ("what does this block look like on its
+ * own"), not a non-overlapping partition of the page like
+ * `@d-zero/html-distiller`'s AST. `'leaf-only'`/`'none'` trade that
+ * self-containment for output size, for callers where duplication across
+ * `maxDepth` levels would blow past a reasonable payload size.
+ * @param result
+ * @param options
+ * @example
+ * ```ts
+ * process.stdout.write(formatResultLine(result) + '\n');
+ * ```
+ */
+export function formatResultLine(
+	result: LayoutAnalysisResult,
+	options: FormatOutputOptions = {},
+): string {
+	const resolved: Required<FormatOutputOptions> = {
+		pretty: options.pretty ?? false,
+		includeBoundingBox: options.includeBoundingBox ?? true,
+		innerHtmlMode: options.innerHtmlMode ?? 'all',
+	};
+
+	const output = {
+		url: result.url,
+		viewport: result.viewport,
+		mainSelector: result.mainSelector,
+		root: result.root ? transformBlock(result.root, resolved) : null,
+	};
+
+	return resolved.pretty ? JSON.stringify(output, null, 2) : JSON.stringify(output);
+}

--- a/packages/@d-zero/anatomist/src/max-of.spec.ts
+++ b/packages/@d-zero/anatomist/src/max-of.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { maxOf } from './max-of.js';
+
+describe('maxOf', () => {
+	it('returns 0 for an empty array', () => {
+		expect(maxOf([])).toBe(0);
+	});
+
+	it('returns the largest value', () => {
+		expect(maxOf([3, 1, 4, 1, 5, 9, 2, 6])).toBe(9);
+	});
+
+	it('returns the only value for a single-element array', () => {
+		expect(maxOf([42])).toBe(42);
+	});
+
+	it('does not throw on a very large array (unlike Math.max(...spread))', () => {
+		const large = Array.from({ length: 200_000 }, (_, i) => i);
+		expect(maxOf(large)).toBe(199_999);
+	});
+});

--- a/packages/@d-zero/anatomist/src/max-of.ts
+++ b/packages/@d-zero/anatomist/src/max-of.ts
@@ -1,0 +1,29 @@
+/**
+ * Largest value in `values`, or `0` for an empty array. Assumes all values
+ * are non-negative (box coordinates, sizes, counts) — the only callers in
+ * this package — so `0` doubles as both the empty-array result and a safe
+ * starting accumulator.
+ *
+ * WHY not `Math.max(...values)`: spreading into a function call passes
+ * each element as its own call argument, and V8 (and most engines) throws
+ * `RangeError: Maximum call stack size exceeded` once the argument count
+ * reaches roughly 65k–125k. A container with a very large number of
+ * meaningful children (a long list or table region) can realistically hit
+ * that, which would abort classification for the whole page instead of
+ * degrading to a low-confidence result.
+ * @param values
+ * @example
+ * ```ts
+ * maxOf([3, 1, 4, 1, 5]); // 5
+ * maxOf([]); // 0
+ * ```
+ */
+export function maxOf(values: readonly number[]): number {
+	let max = 0;
+	for (const value of values) {
+		if (value > max) {
+			max = value;
+		}
+	}
+	return max;
+}

--- a/packages/@d-zero/anatomist/src/parse-args.spec.ts
+++ b/packages/@d-zero/anatomist/src/parse-args.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseArgs } from './parse-args.js';
+
+describe('parseArgs', () => {
+	it('returns defaults for an empty argv', () => {
+		expect(parseArgs([])).toEqual({
+			inputFormat: 'lines',
+			viewports: [],
+			innerHtml: 'all',
+			noBoundingBox: false,
+			pretty: false,
+		});
+	});
+
+	it.each([
+		['--help', 'help'],
+		['-h', 'help'],
+		['--version', 'version'],
+		['-v', 'version'],
+	] as const)('parses %s as %s', (flag, key) => {
+		expect(parseArgs([flag])).toMatchObject({ [key]: true });
+	});
+
+	it('parses --input / -f with its value', () => {
+		expect(parseArgs(['--input', 'urls.txt'])).toMatchObject({ input: 'urls.txt' });
+		expect(parseArgs(['-f', 'urls.txt'])).toMatchObject({ input: 'urls.txt' });
+	});
+
+	it('parses --input-format', () => {
+		expect(parseArgs(['--input-format', 'json'])).toMatchObject({ inputFormat: 'json' });
+	});
+
+	it('rejects an invalid --input-format value', () => {
+		expect(parseArgs(['--input-format', 'yaml']).unknownFlag).toMatch(
+			/"lines" or "json"/,
+		);
+	});
+
+	it('parses --main-selector', () => {
+		expect(parseArgs(['--main-selector', '#x'])).toMatchObject({ mainSelector: '#x' });
+	});
+
+	it('accumulates repeated --viewport flags', () => {
+		expect(parseArgs(['--viewport', 'pc:1280', '--viewport', 'sp:375'])).toMatchObject({
+			viewports: ['pc:1280', 'sp:375'],
+		});
+	});
+
+	it('parses numeric options', () => {
+		expect(parseArgs(['--max-depth', '4'])).toMatchObject({ maxDepth: 4 });
+		expect(parseArgs(['--min-area', '500'])).toMatchObject({ minArea: 500 });
+		expect(parseArgs(['--concurrency', '8'])).toMatchObject({ concurrency: 8 });
+		expect(parseArgs(['--timeout', '30000'])).toMatchObject({ timeout: 30_000 });
+		expect(parseArgs(['--max-scroll-height', '100000'])).toMatchObject({
+			maxScrollHeight: 100_000,
+		});
+	});
+
+	it('rejects a non-numeric value for a numeric option', () => {
+		expect(parseArgs(['--max-depth', 'deep']).unknownFlag).toMatch(/requires a number/);
+	});
+
+	it('rejects a numeric option missing its value', () => {
+		expect(parseArgs(['--max-depth']).unknownFlag).toMatch(/requires a number/);
+	});
+
+	it('parses --inner-html', () => {
+		expect(parseArgs(['--inner-html', 'leaf-only'])).toMatchObject({
+			innerHtml: 'leaf-only',
+		});
+		expect(parseArgs(['--inner-html', 'none'])).toMatchObject({ innerHtml: 'none' });
+	});
+
+	it('rejects an invalid --inner-html value', () => {
+		expect(parseArgs(['--inner-html', 'bogus']).unknownFlag).toMatch(
+			/"all", "leaf-only", or "none"/,
+		);
+	});
+
+	it('parses --no-bounding-box as a boolean flag', () => {
+		expect(parseArgs(['--no-bounding-box'])).toMatchObject({ noBoundingBox: true });
+	});
+
+	it('parses --out and --pretty', () => {
+		expect(parseArgs(['--out', 'result.json', '--pretty'])).toMatchObject({
+			out: 'result.json',
+			pretty: true,
+		});
+	});
+
+	it('reports an unrecognized flag and stops parsing', () => {
+		const result = parseArgs(['--bogus', '--pretty']);
+		expect(result.unknownFlag).toBe('--bogus');
+		expect(result.pretty).toBe(false);
+	});
+
+	it('reports a missing value for a value-taking flag', () => {
+		expect(parseArgs(['--input']).unknownFlag).toBe('--input requires a value');
+	});
+});

--- a/packages/@d-zero/anatomist/src/parse-args.ts
+++ b/packages/@d-zero/anatomist/src/parse-args.ts
@@ -1,0 +1,221 @@
+import type { InnerHtmlMode } from './format-output.js';
+import type { UrlListFormat } from './parse-url-list.js';
+
+/**
+ * Parsed CLI shape. Kept as a plain record so tests can build it directly
+ * without going through the argv parser (pattern shared with
+ * `@d-zero/page-cluster`'s `CliArgs`).
+ */
+export type CliArgs = {
+	readonly input?: string;
+	readonly inputFormat: UrlListFormat;
+	readonly mainSelector?: string;
+	readonly viewports: readonly string[];
+	readonly maxDepth?: number;
+	readonly minArea?: number;
+	readonly innerHtml: InnerHtmlMode;
+	readonly noBoundingBox: boolean;
+	readonly concurrency?: number;
+	readonly timeout?: number;
+	readonly maxScrollHeight?: number;
+	readonly out?: string;
+	readonly pretty: boolean;
+	readonly help?: boolean;
+	readonly version?: boolean;
+	readonly unknownFlag?: string;
+};
+
+/**
+ * @param argv
+ * @param index
+ */
+function requireValue(argv: readonly string[], index: number): string | undefined {
+	return argv[index + 1];
+}
+
+/**
+ * @param argv
+ * @param index
+ */
+function requireNumber(argv: readonly string[], index: number): number | undefined {
+	const raw = argv[index + 1];
+	if (raw === undefined) {
+		return undefined;
+	}
+	const value = Number(raw);
+	return Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Parses `process.argv`-style arguments (already sliced past `node script`)
+ * into a `CliArgs`. Deliberately tolerant of an unknown flag so the caller
+ * can decide the error message shape (pattern shared with
+ * `@d-zero/page-cluster`'s `parseArgs`).
+ * @param argv
+ */
+export function parseArgs(argv: readonly string[]): CliArgs {
+	const out: {
+		input?: string;
+		inputFormat: UrlListFormat;
+		mainSelector?: string;
+		viewports: string[];
+		maxDepth?: number;
+		minArea?: number;
+		innerHtml: InnerHtmlMode;
+		noBoundingBox: boolean;
+		concurrency?: number;
+		timeout?: number;
+		maxScrollHeight?: number;
+		out?: string;
+		pretty: boolean;
+		help?: boolean;
+		version?: boolean;
+		unknownFlag?: string;
+	} = {
+		inputFormat: 'lines',
+		viewports: [],
+		innerHtml: 'all',
+		noBoundingBox: false,
+		pretty: false,
+	};
+
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i]!;
+		switch (arg) {
+			case '--help':
+			case '-h': {
+				out.help = true;
+				break;
+			}
+			case '--version':
+			case '-v': {
+				out.version = true;
+				break;
+			}
+			case '--input':
+			case '-f': {
+				const next = requireValue(argv, i);
+				if (next === undefined) {
+					out.unknownFlag = `${arg} requires a value`;
+					return out;
+				}
+				out.input = next;
+				i++;
+				break;
+			}
+			case '--input-format': {
+				const next = requireValue(argv, i);
+				if (next !== 'lines' && next !== 'json') {
+					out.unknownFlag = `${arg} requires "lines" or "json"`;
+					return out;
+				}
+				out.inputFormat = next;
+				i++;
+				break;
+			}
+			case '--main-selector': {
+				const next = requireValue(argv, i);
+				if (next === undefined) {
+					out.unknownFlag = `${arg} requires a value`;
+					return out;
+				}
+				out.mainSelector = next;
+				i++;
+				break;
+			}
+			case '--viewport': {
+				const next = requireValue(argv, i);
+				if (next === undefined) {
+					out.unknownFlag = `${arg} requires a value`;
+					return out;
+				}
+				out.viewports.push(next);
+				i++;
+				break;
+			}
+			case '--max-depth': {
+				const value = requireNumber(argv, i);
+				if (value === undefined) {
+					out.unknownFlag = `${arg} requires a number`;
+					return out;
+				}
+				out.maxDepth = value;
+				i++;
+				break;
+			}
+			case '--min-area': {
+				const value = requireNumber(argv, i);
+				if (value === undefined) {
+					out.unknownFlag = `${arg} requires a number`;
+					return out;
+				}
+				out.minArea = value;
+				i++;
+				break;
+			}
+			case '--inner-html': {
+				const next = requireValue(argv, i);
+				if (next !== 'all' && next !== 'leaf-only' && next !== 'none') {
+					out.unknownFlag = `${arg} requires "all", "leaf-only", or "none"`;
+					return out;
+				}
+				out.innerHtml = next;
+				i++;
+				break;
+			}
+			case '--no-bounding-box': {
+				out.noBoundingBox = true;
+				break;
+			}
+			case '--concurrency': {
+				const value = requireNumber(argv, i);
+				if (value === undefined) {
+					out.unknownFlag = `${arg} requires a number`;
+					return out;
+				}
+				out.concurrency = value;
+				i++;
+				break;
+			}
+			case '--timeout': {
+				const value = requireNumber(argv, i);
+				if (value === undefined) {
+					out.unknownFlag = `${arg} requires a number`;
+					return out;
+				}
+				out.timeout = value;
+				i++;
+				break;
+			}
+			case '--max-scroll-height': {
+				const value = requireNumber(argv, i);
+				if (value === undefined) {
+					out.unknownFlag = `${arg} requires a number`;
+					return out;
+				}
+				out.maxScrollHeight = value;
+				i++;
+				break;
+			}
+			case '--out': {
+				const next = requireValue(argv, i);
+				if (next === undefined) {
+					out.unknownFlag = `${arg} requires a value`;
+					return out;
+				}
+				out.out = next;
+				i++;
+				break;
+			}
+			case '--pretty': {
+				out.pretty = true;
+				break;
+			}
+			default: {
+				out.unknownFlag = arg;
+				return out;
+			}
+		}
+	}
+	return out;
+}

--- a/packages/@d-zero/anatomist/src/parse-display.spec.ts
+++ b/packages/@d-zero/anatomist/src/parse-display.spec.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseDisplay } from './parse-display.js';
+
+describe('parseDisplay', () => {
+	it.each([
+		[
+			'block',
+			{ kind: 'box-generating', outside: 'block', inside: 'flow', listItem: false },
+		],
+		[
+			'inline',
+			{ kind: 'box-generating', outside: 'inline', inside: 'flow', listItem: false },
+		],
+		[
+			'inline-block',
+			{ kind: 'box-generating', outside: 'inline', inside: 'flow-root', listItem: false },
+		],
+		[
+			'flow-root',
+			{ kind: 'box-generating', outside: 'block', inside: 'flow-root', listItem: false },
+		],
+		[
+			'flex',
+			{ kind: 'box-generating', outside: 'block', inside: 'flex', listItem: false },
+		],
+		[
+			'inline-flex',
+			{ kind: 'box-generating', outside: 'inline', inside: 'flex', listItem: false },
+		],
+		[
+			'grid',
+			{ kind: 'box-generating', outside: 'block', inside: 'grid', listItem: false },
+		],
+		[
+			'inline-grid',
+			{ kind: 'box-generating', outside: 'inline', inside: 'grid', listItem: false },
+		],
+		[
+			'table',
+			{ kind: 'box-generating', outside: 'block', inside: 'table', listItem: false },
+		],
+		[
+			'inline-table',
+			{ kind: 'box-generating', outside: 'inline', inside: 'table', listItem: false },
+		],
+	] as const)('normalizes legacy keyword %s', (raw, expected) => {
+		expect(parseDisplay(raw)).toEqual(expected);
+	});
+
+	it.each([
+		[
+			'block flex',
+			{ kind: 'box-generating', outside: 'block', inside: 'flex', listItem: false },
+		],
+		[
+			'inline flex',
+			{ kind: 'box-generating', outside: 'inline', inside: 'flex', listItem: false },
+		],
+		[
+			'inline grid',
+			{ kind: 'box-generating', outside: 'inline', inside: 'grid', listItem: false },
+		],
+		[
+			'block flow-root',
+			{ kind: 'box-generating', outside: 'block', inside: 'flow-root', listItem: false },
+		],
+		// Token order shouldn't matter.
+		[
+			'flex block',
+			{ kind: 'box-generating', outside: 'block', inside: 'flex', listItem: false },
+		],
+	] as const)('parses two-value syntax %s', (raw, expected) => {
+		expect(parseDisplay(raw)).toEqual(expected);
+	});
+
+	it('parses list-item alone as a block box with listItem set', () => {
+		expect(parseDisplay('list-item')).toEqual({
+			kind: 'box-generating',
+			outside: 'block',
+			inside: 'flow',
+			listItem: true,
+		});
+	});
+
+	it('parses list-item combined with a two-value pair', () => {
+		expect(parseDisplay('block flow list-item')).toEqual({
+			kind: 'box-generating',
+			outside: 'block',
+			inside: 'flow',
+			listItem: true,
+		});
+	});
+
+	it.each([
+		'table-row',
+		'table-cell',
+		'table-row-group',
+		'table-header-group',
+		'table-footer-group',
+		'table-column',
+		'table-column-group',
+		'table-caption',
+		'ruby-base',
+		'ruby-text',
+	])('treats %s as an internal display value', (value) => {
+		expect(parseDisplay(value)).toEqual({ kind: 'internal', value });
+	});
+
+	it('treats "none" as none regardless of surrounding tokens', () => {
+		expect(parseDisplay('none')).toEqual({ kind: 'none' });
+	});
+
+	it('treats "contents" as contents', () => {
+		expect(parseDisplay('contents')).toEqual({ kind: 'contents' });
+	});
+
+	it('does not misparse "table-cell" as the table box via substring matching', () => {
+		const result = parseDisplay('table-cell');
+		expect(result).not.toMatchObject({ kind: 'box-generating', inside: 'table' });
+	});
+
+	it('falls back to a block/flow box for an unrecognized single keyword', () => {
+		expect(parseDisplay('some-future-keyword')).toEqual({
+			kind: 'box-generating',
+			outside: 'block',
+			inside: 'flow',
+			listItem: false,
+		});
+	});
+
+	it('tolerates extra whitespace between tokens', () => {
+		expect(parseDisplay('  inline   grid  ')).toEqual({
+			kind: 'box-generating',
+			outside: 'inline',
+			inside: 'grid',
+			listItem: false,
+		});
+	});
+});

--- a/packages/@d-zero/anatomist/src/parse-display.ts
+++ b/packages/@d-zero/anatomist/src/parse-display.ts
@@ -1,0 +1,137 @@
+/**
+ * Structured parser for computed `display` values.
+ *
+ * WHY not string matching: CSS Display Module Level 3 allows a two-value
+ * syntax (`<display-outside> <display-inside>`, e.g. `block flex`,
+ * `inline grid`) alongside the legacy single-keyword forms (`flex`,
+ * `inline-grid`). A substring check like `display.includes('grid')` would
+ * misparse `inline-grid-column` style false positives were such a value
+ * ever introduced, and can't distinguish `table` the box type from
+ * `table-cell` the internal display value. This module tokenizes on
+ * whitespace and matches whole tokens against known keyword sets instead.
+ * @module
+ */
+
+export type DisplayOutside = 'block' | 'inline' | 'run-in';
+export type DisplayInside = 'flow' | 'flow-root' | 'table' | 'flex' | 'grid' | 'ruby';
+
+export type ParsedDisplay =
+	| {
+			kind: 'box-generating';
+			outside: DisplayOutside;
+			inside: DisplayInside;
+			/** `true` when the `list-item` keyword is present alongside the outer/inner pair. */
+			listItem: boolean;
+	  }
+	| {
+			/** Table/ruby internal parts (`table-cell`, `table-row`, `ruby-base`, ...) that don't generate an independent principal box. */
+			kind: 'internal';
+			value: string;
+	  }
+	| { kind: 'none' }
+	| { kind: 'contents' };
+
+/** Legacy single-keyword forms, normalized to their two-value equivalent. */
+const LEGACY_DISPLAY_MAP: Readonly<
+	Record<string, { outside: DisplayOutside; inside: DisplayInside }>
+> = {
+	block: { outside: 'block', inside: 'flow' },
+	inline: { outside: 'inline', inside: 'flow' },
+	'run-in': { outside: 'run-in', inside: 'flow' },
+	'inline-block': { outside: 'inline', inside: 'flow-root' },
+	'flow-root': { outside: 'block', inside: 'flow-root' },
+	flex: { outside: 'block', inside: 'flex' },
+	'inline-flex': { outside: 'inline', inside: 'flex' },
+	grid: { outside: 'block', inside: 'grid' },
+	'inline-grid': { outside: 'inline', inside: 'grid' },
+	table: { outside: 'block', inside: 'table' },
+	'inline-table': { outside: 'inline', inside: 'table' },
+};
+
+const OUTSIDE_VALUES: ReadonlySet<string> = new Set(['block', 'inline', 'run-in']);
+const INSIDE_VALUES: ReadonlySet<string> = new Set([
+	'flow',
+	'flow-root',
+	'table',
+	'flex',
+	'grid',
+	'ruby',
+]);
+const INTERNAL_VALUES: ReadonlySet<string> = new Set([
+	'table-row-group',
+	'table-header-group',
+	'table-footer-group',
+	'table-row',
+	'table-cell',
+	'table-column-group',
+	'table-column',
+	'table-caption',
+	'ruby-base',
+	'ruby-text',
+	'ruby-base-container',
+	'ruby-text-container',
+]);
+
+/**
+ * Parses a computed `display` string into its outer/inner display parts.
+ * Accepts both legacy single-keyword values and the two-value syntax, in
+ * any token order. Unrecognized tokens are ignored rather than treated as
+ * a parse failure, since `getComputedStyle` values are never attacker- or
+ * author-controlled strings we need to reject — only interpret.
+ * @param rawDisplay - The verbatim `getComputedStyle(...).display` value.
+ * @example
+ * ```ts
+ * parseDisplay('flex'); // { kind: 'box-generating', outside: 'block', inside: 'flex', listItem: false }
+ * parseDisplay('inline grid'); // { kind: 'box-generating', outside: 'inline', inside: 'grid', listItem: false }
+ * parseDisplay('table-cell'); // { kind: 'internal', value: 'table-cell' }
+ * ```
+ */
+export function parseDisplay(rawDisplay: string): ParsedDisplay {
+	const tokens = rawDisplay.trim().split(/\s+/u).filter(Boolean);
+
+	if (tokens.length === 0 || tokens.includes('none')) {
+		return { kind: 'none' };
+	}
+	if (tokens.includes('contents')) {
+		return { kind: 'contents' };
+	}
+
+	if (tokens.length === 1) {
+		const token = tokens[0]!;
+		if (INTERNAL_VALUES.has(token)) {
+			return { kind: 'internal', value: token };
+		}
+		if (token === 'list-item') {
+			return { kind: 'box-generating', outside: 'block', inside: 'flow', listItem: true };
+		}
+		const legacy = LEGACY_DISPLAY_MAP[token];
+		if (legacy) {
+			return { kind: 'box-generating', ...legacy, listItem: false };
+		}
+		// Unrecognized single keyword (e.g. a future CSS value): fall back to
+		// the most conservative box-generating interpretation rather than
+		// throwing, so an unfamiliar value degrades to "ordinary block" instead
+		// of crashing the whole capture.
+		return { kind: 'box-generating', outside: 'block', inside: 'flow', listItem: false };
+	}
+
+	// Two-value syntax (in either token order) plus an optional `list-item`.
+	let outside: DisplayOutside | undefined;
+	let inside: DisplayInside | undefined;
+	let listItem = false;
+	for (const token of tokens) {
+		if (outside === undefined && OUTSIDE_VALUES.has(token)) {
+			outside = token as DisplayOutside;
+		} else if (inside === undefined && INSIDE_VALUES.has(token)) {
+			inside = token as DisplayInside;
+		} else if (token === 'list-item') {
+			listItem = true;
+		}
+	}
+	return {
+		kind: 'box-generating',
+		outside: outside ?? 'block',
+		inside: inside ?? 'flow',
+		listItem,
+	};
+}

--- a/packages/@d-zero/anatomist/src/parse-url-list.spec.ts
+++ b/packages/@d-zero/anatomist/src/parse-url-list.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseUrlList } from './parse-url-list.js';
+
+describe('parseUrlList', () => {
+	it('parses one URL per line', () => {
+		expect(parseUrlList('https://a.example/\nhttps://b.example/')).toEqual([
+			'https://a.example/',
+			'https://b.example/',
+		]);
+	});
+
+	it('ignores blank lines and comment lines', () => {
+		const text = 'https://a.example/\n\n# a comment\nhttps://b.example/\n';
+		expect(parseUrlList(text)).toEqual(['https://a.example/', 'https://b.example/']);
+	});
+
+	it('trims surrounding whitespace on each line', () => {
+		expect(parseUrlList('  https://a.example/  \n')).toEqual(['https://a.example/']);
+	});
+
+	it('parses a JSON array of strings', () => {
+		expect(parseUrlList('["https://a.example/", "https://b.example/"]', 'json')).toEqual([
+			'https://a.example/',
+			'https://b.example/',
+		]);
+	});
+
+	it('throws on invalid JSON when format is json', () => {
+		expect(() => parseUrlList('not json', 'json')).toThrow(/failed to parse/);
+	});
+
+	it('throws when JSON is not an array of strings', () => {
+		expect(() => parseUrlList('{"a": 1}', 'json')).toThrow(/array of strings/);
+		expect(() => parseUrlList('[1, 2]', 'json')).toThrow(/array of strings/);
+	});
+});

--- a/packages/@d-zero/anatomist/src/parse-url-list.ts
+++ b/packages/@d-zero/anatomist/src/parse-url-list.ts
@@ -1,0 +1,36 @@
+export type UrlListFormat = 'lines' | 'json';
+
+/**
+ * Parses a URL list from text, in one of two formats:
+ * - `lines` (default): one URL per line; blank lines and lines starting
+ *   with `#` are ignored, so a list can carry comments.
+ * - `json`: a JSON array of strings.
+ * @param text - The raw file/stdin contents.
+ * @param format - Default `'lines'`.
+ * @throws {Error} When `format` is `'json'` and `text` doesn't parse as a
+ *   JSON array of strings.
+ * @example
+ * ```ts
+ * parseUrlList('https://a.example/\n# comment\nhttps://b.example/');
+ * // ['https://a.example/', 'https://b.example/']
+ * ```
+ */
+export function parseUrlList(text: string, format: UrlListFormat = 'lines'): string[] {
+	if (format === 'json') {
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(text);
+		} catch (error) {
+			throw new Error(`failed to parse URL list as JSON: ${(error as Error).message}`);
+		}
+		if (!Array.isArray(parsed) || !parsed.every((item) => typeof item === 'string')) {
+			throw new TypeError('URL list JSON must be an array of strings');
+		}
+		return parsed;
+	}
+
+	return text
+		.split('\n')
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0 && !line.startsWith('#'));
+}

--- a/packages/@d-zero/anatomist/src/parse-viewport-spec.spec.ts
+++ b/packages/@d-zero/anatomist/src/parse-viewport-spec.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseViewportSpec } from './parse-viewport-spec.js';
+
+describe('parseViewportSpec', () => {
+	it('parses a name:width pair', () => {
+		expect(parseViewportSpec('pc:1280')).toEqual({ name: 'pc', width: 1280 });
+	});
+
+	it('throws when there is no colon separator', () => {
+		expect(() => parseViewportSpec('pc1280')).toThrow(/expected "name:width"/);
+	});
+
+	it('throws when the name is empty', () => {
+		expect(() => parseViewportSpec(':1280')).toThrow(/name must not be empty/);
+	});
+
+	it('throws when the width is not numeric', () => {
+		expect(() => parseViewportSpec('pc:wide')).toThrow(/positive number/);
+	});
+
+	it('throws when the width is zero or negative', () => {
+		expect(() => parseViewportSpec('pc:0')).toThrow(/positive number/);
+		expect(() => parseViewportSpec('pc:-100')).toThrow(/positive number/);
+	});
+});

--- a/packages/@d-zero/anatomist/src/parse-viewport-spec.ts
+++ b/packages/@d-zero/anatomist/src/parse-viewport-spec.ts
@@ -1,0 +1,34 @@
+import type { ViewportSpec } from './types.js';
+
+/**
+ * Parses a `--viewport name:width` CLI value. Height is intentionally not
+ * part of this syntax: `beforePageScan` (from `@d-zero/puppeteer-page-scan`)
+ * derives height from width itself (`width * 0.75` above 1000px, `* 1.5`
+ * at or below), so there is no independent height to accept here.
+ * @param spec - A `"name:width"` string, e.g. `"pc:1280"`.
+ * @throws {Error} When `spec` isn't of the form `"name:width"` with a
+ *   positive numeric width.
+ * @example
+ * ```ts
+ * parseViewportSpec('pc:1280'); // { name: 'pc', width: 1280 }
+ * ```
+ */
+export function parseViewportSpec(spec: string): ViewportSpec {
+	const separatorIndex = spec.indexOf(':');
+	if (separatorIndex === -1) {
+		throw new Error(`invalid viewport spec "${spec}": expected "name:width"`);
+	}
+
+	const name = spec.slice(0, separatorIndex);
+	const widthText = spec.slice(separatorIndex + 1);
+	if (name.length === 0) {
+		throw new Error(`invalid viewport spec "${spec}": name must not be empty`);
+	}
+
+	const width = Number(widthText);
+	if (!Number.isFinite(width) || width <= 0) {
+		throw new Error(`invalid viewport spec "${spec}": width must be a positive number`);
+	}
+
+	return { name, width };
+}

--- a/packages/@d-zero/anatomist/src/resolve-layout-type.spec.ts
+++ b/packages/@d-zero/anatomist/src/resolve-layout-type.spec.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+
+import { mockNode } from './__fixtures__/mock-node.js';
+import { resolveLayoutType } from './resolve-layout-type.js';
+
+/**
+ * @param x
+ * @param y
+ * @param width
+ * @param height
+ * @param overrides
+ */
+function cell(
+	x: number,
+	y: number,
+	width: number,
+	height: number,
+	overrides: Parameters<typeof mockNode>[0] = {},
+) {
+	return mockNode({ boundingBox: { x, y, width, height }, ...overrides });
+}
+
+const CONTAINER = mockNode({ boundingBox: { x: 0, y: 0, width: 800, height: 600 } });
+
+describe('resolveLayoutType', () => {
+	it('resolves table ahead of any geometric check, based on the container itself', () => {
+		const container = mockNode({
+			tagName: 'TABLE',
+			boundingBox: { x: 0, y: 0, width: 800, height: 600 },
+		});
+		const children = [cell(0, 0, 100, 40)];
+		expect(resolveLayoutType(container, children).layoutType).toBe('table');
+	});
+
+	it('resolves a uniform multi-row grid as simple-grid', () => {
+		const children = [
+			cell(0, 0, 100, 100),
+			cell(120, 0, 100, 100),
+			cell(0, 120, 100, 100),
+			cell(120, 120, 100, 100),
+		];
+		expect(resolveLayoutType(CONTAINER, children).layoutType).toBe('simple-grid');
+	});
+
+	it('resolves an uneven multi-row grid as complex-grid', () => {
+		const children = [
+			cell(0, 0, 100, 100),
+			cell(120, 0, 100, 100),
+			cell(240, 0, 100, 100),
+			cell(0, 120, 100, 100),
+		];
+		expect(resolveLayoutType(CONTAINER, children).layoutType).toBe('complex-grid');
+	});
+
+	it('resolves a single row of children as horizontal-row', () => {
+		const children = [cell(0, 0, 100, 40), cell(120, 0, 100, 40), cell(240, 0, 100, 40)];
+		expect(resolveLayoutType(CONTAINER, children).layoutType).toBe('horizontal-row');
+	});
+
+	it('resolves a floated image overlapping text as float-wrap', () => {
+		const image = cell(0, 0, 100, 100, {
+			tagName: 'IMG',
+			style: {
+				display: 'block',
+				float: 'left',
+				position: 'static',
+				visibility: 'visible',
+			},
+		});
+		const paragraph = cell(0, 0, 300, 150, { tagName: 'P' });
+		expect(resolveLayoutType(CONTAINER, [image, paragraph]).layoutType).toBe(
+			'float-wrap',
+		);
+	});
+
+	it('resolves stacked single children as vertical-stack', () => {
+		const children = [cell(0, 0, 700, 40), cell(0, 60, 700, 40), cell(0, 120, 700, 40)];
+		expect(resolveLayoutType(CONTAINER, children).layoutType).toBe('vertical-stack');
+	});
+
+	it('falls back to unknown when a child geometry overflows the container (carousel guard)', () => {
+		// Children span far beyond the 800px-wide container — simulates a
+		// transform-shifted carousel track rather than trustworthy layout.
+		const children = [cell(0, 0, 100, 40), cell(2000, 0, 100, 40)];
+		const result = resolveLayoutType(CONTAINER, children);
+		expect(result.layoutType).toBe('unknown');
+		expect(result.confidence).toBe(0);
+	});
+
+	it('prioritizes grid over horizontal-row when there are 2+ rows', () => {
+		// Ensures the priority order (grid checked before row) actually
+		// matters: without it, a naive "any single row" check could never
+		// misfire here since detectGridPattern requires 2+ rows anyway, but
+		// this asserts the multi-row case never falls through to row/stack.
+		const children = [
+			cell(0, 0, 100, 100),
+			cell(120, 0, 100, 100),
+			cell(0, 120, 100, 100),
+			cell(120, 120, 100, 100),
+		];
+		const result = resolveLayoutType(CONTAINER, children);
+		expect(result.layoutType).not.toBe('horizontal-row');
+		expect(result.layoutType).not.toBe('vertical-stack');
+	});
+
+	it('always returns signals, including for unknown', () => {
+		const children = [cell(0, 0, 100, 40), cell(2000, 0, 100, 40)];
+		const result = resolveLayoutType(CONTAINER, children);
+		expect(result.signals).toBeDefined();
+	});
+});

--- a/packages/@d-zero/anatomist/src/resolve-layout-type.ts
+++ b/packages/@d-zero/anatomist/src/resolve-layout-type.ts
@@ -1,0 +1,151 @@
+import type { LayoutTypeResolution, RawLayoutNode } from './types.js';
+
+import { clusterIntoRows } from './cluster-into-rows.js';
+import { detectFloatWrapPattern } from './detect-float-wrap-pattern.js';
+import { detectGridPattern } from './detect-grid-pattern.js';
+import { detectHorizontalRowPattern } from './detect-horizontal-row-pattern.js';
+import { detectTablePattern } from './detect-table-pattern.js';
+import { detectVerticalStackPattern } from './detect-vertical-stack-pattern.js';
+import { maxOf } from './max-of.js';
+
+/**
+ * Beyond this multiple of the container's own box, a child's box is
+ * treated as evidence of carousel/slider `transform` geometry rather than
+ * a real layout — see {@link checkOverflow}.
+ */
+const MAX_OVERFLOW_RATIO = 1.5;
+
+/**
+ * Guards against carousels/sliders: `getBoundingClientRect` reports
+ * `transform`-shifted geometry, so a slider that lays its slides out in
+ * one wide row and translates them off-screen looks, geometrically, like
+ * an enormous `horizontal-row` that blows past its parent's box. Rather
+ * than confidently mislabel that, treat a large overflow as a sign the
+ * geometry isn't trustworthy for classification and fall through to
+ * `unknown`.
+ * @param container
+ * @param children
+ */
+function checkOverflow(
+	container: RawLayoutNode,
+	children: readonly RawLayoutNode[],
+): { overflowing: boolean; signals: Record<string, unknown> } {
+	if (
+		children.length === 0 ||
+		container.boundingBox.width <= 0 ||
+		container.boundingBox.height <= 0
+	) {
+		return { overflowing: false, signals: {} };
+	}
+
+	const maxRight = maxOf(children.map((c) => c.boundingBox.x + c.boundingBox.width));
+	const maxBottom = maxOf(children.map((c) => c.boundingBox.y + c.boundingBox.height));
+	const overflowRatioX = maxRight / container.boundingBox.width;
+	const overflowRatioY = maxBottom / container.boundingBox.height;
+	const overflowing =
+		overflowRatioX > MAX_OVERFLOW_RATIO || overflowRatioY > MAX_OVERFLOW_RATIO;
+
+	return { overflowing, signals: { overflowRatioX, overflowRatioY } };
+}
+
+/**
+ * Resolves the visual layout pattern for one container's meaningful
+ * children, trying detectors in a fixed priority order and returning the
+ * first match. See the module-level detectors for what each pattern means
+ * and why the order is what it is:
+ *
+ * 1. `table` — checked against `container` itself, ahead of everything
+ *    else, because a `<table>`'s structure is authoritative regardless of
+ *    cell geometry.
+ * 2. Overflow guard — see {@link checkOverflow}. Falls through to
+ *    `unknown` on trip, skipping every geometric detector below.
+ * `children` is clustered into rows exactly once (via `clusterIntoRows`)
+ * and shared across every row-based detector below, rather than each
+ * detector re-clustering the identical array itself.
+ *
+ * 3. `complex-grid` / `simple-grid` — checked before `horizontal-row`
+ *    because a single-row 1×N grid and an N-item flex row look identical
+ *    geometrically; `detect-grid-pattern.ts` only fires at 2+ rows with at
+ *    least one multi-column row, so it can't false-positive against a
+ *    genuine single row or a plain vertical stack.
+ * 4. `float-wrap` — checked before `horizontal-row` on purpose, even
+ *    though `float` has no layout effect on a flex/grid item (already
+ *    ruled out above): a floated image overlapping wrapped text clusters
+ *    into the same single row `detect-horizontal-row-pattern.ts` matches,
+ *    so float-wrap must get first refusal or it would never fire.
+ * 5. `horizontal-row`
+ * 6. `vertical-stack` — the last geometric detector; it also matches a
+ *    lone child, so anything reaching this point with one child lands here.
+ * 7. `unknown` — no detector matched with confidence. Recursion continues
+ *    into `unknown` containers (unlike every matched type) since a
+ *    misjudged container's children may still be classifiable.
+ * @param container - The node whose children are being classified (used
+ *   only for the table check and the overflow guard's own box).
+ * @param children - The container's meaningful children (see `should-recurse.ts`).
+ * @example
+ * ```ts
+ * resolveLayoutType(node, node.children); // { layoutType: 'horizontal-row', confidence: 0.8, signals: {...} }
+ * ```
+ */
+export function resolveLayoutType(
+	container: RawLayoutNode,
+	children: readonly RawLayoutNode[],
+): LayoutTypeResolution {
+	const tableResult = detectTablePattern(container);
+	if (tableResult.matched) {
+		return {
+			layoutType: 'table',
+			confidence: tableResult.confidence,
+			signals: tableResult.signals,
+		};
+	}
+
+	const overflow = checkOverflow(container, children);
+	if (overflow.overflowing) {
+		return { layoutType: 'unknown', confidence: 0, signals: overflow.signals };
+	}
+
+	const rows = clusterIntoRows(children);
+
+	const gridResult = detectGridPattern(rows, children);
+	if (gridResult.matched) {
+		return {
+			layoutType: gridResult.variant === 'complex' ? 'complex-grid' : 'simple-grid',
+			confidence: gridResult.confidence,
+			signals: gridResult.signals,
+		};
+	}
+
+	const floatResult = detectFloatWrapPattern(children);
+	if (floatResult.matched) {
+		return {
+			layoutType: 'float-wrap',
+			confidence: floatResult.confidence,
+			signals: floatResult.signals,
+		};
+	}
+
+	const rowResult = detectHorizontalRowPattern(rows, children.length);
+	if (rowResult.matched) {
+		return {
+			layoutType: 'horizontal-row',
+			confidence: rowResult.confidence,
+			signals: rowResult.signals,
+		};
+	}
+
+	const stackResult = detectVerticalStackPattern(rows, children.length);
+	if (stackResult.matched) {
+		return {
+			layoutType: 'vertical-stack',
+			confidence: stackResult.confidence,
+			signals: stackResult.signals,
+		};
+	}
+
+	return {
+		layoutType: 'unknown',
+		confidence: 0,
+		signals: { childCount: children.length },
+	};
+}

--- a/packages/@d-zero/anatomist/src/resolve-viewports.spec.ts
+++ b/packages/@d-zero/anatomist/src/resolve-viewports.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_VIEWPORTS } from './default-viewports.js';
+import { resolveViewports } from './resolve-viewports.js';
+
+describe('resolveViewports', () => {
+	it('returns the default preset list when no specs are given', () => {
+		expect(resolveViewports([])).toBe(DEFAULT_VIEWPORTS);
+	});
+
+	it('parses explicit specs, replacing rather than extending the defaults', () => {
+		expect(resolveViewports(['wide:1920'])).toEqual([{ name: 'wide', width: 1920 }]);
+	});
+
+	it('parses multiple specs in the given order', () => {
+		expect(resolveViewports(['a:100', 'b:200'])).toEqual([
+			{ name: 'a', width: 100 },
+			{ name: 'b', width: 200 },
+		]);
+	});
+});

--- a/packages/@d-zero/anatomist/src/resolve-viewports.ts
+++ b/packages/@d-zero/anatomist/src/resolve-viewports.ts
@@ -1,0 +1,23 @@
+import type { ViewportSpec } from './types.js';
+
+import { DEFAULT_VIEWPORTS } from './default-viewports.js';
+import { parseViewportSpec } from './parse-viewport-spec.js';
+
+/**
+ * Resolves the viewport list to analyze: explicit `--viewport` specs when
+ * given, otherwise `DEFAULT_VIEWPORTS`. Specs fully replace the default
+ * list rather than adding to it — a caller who names one custom viewport
+ * almost certainly wants only that one, not it plus the three presets.
+ * @param specs - Raw `"name:width"` strings from repeated `--viewport` flags.
+ * @example
+ * ```ts
+ * resolveViewports([]); // DEFAULT_VIEWPORTS
+ * resolveViewports(['wide:1920']); // [{ name: 'wide', width: 1920 }]
+ * ```
+ */
+export function resolveViewports(specs: readonly string[]): readonly ViewportSpec[] {
+	if (specs.length === 0) {
+		return DEFAULT_VIEWPORTS;
+	}
+	return specs.map((spec) => parseViewportSpec(spec));
+}

--- a/packages/@d-zero/anatomist/src/run-batch.spec.ts
+++ b/packages/@d-zero/anatomist/src/run-batch.spec.ts
@@ -1,0 +1,140 @@
+import { deal } from '@d-zero/dealer';
+import { launch } from 'puppeteer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { analyzePageLayout } from './analyze-page-layout.js';
+import { runBatch } from './run-batch.js';
+
+vi.mock('puppeteer', () => ({
+	launch: vi.fn(),
+}));
+
+vi.mock('@d-zero/dealer', () => ({
+	deal: vi.fn(),
+}));
+
+vi.mock('./analyze-page-layout.js', () => ({
+	analyzePageLayout: vi.fn(),
+}));
+
+/**
+ * Drives `deal`'s mock the same way the real implementation would: call
+ * `setup` for every item, then invoke the `start` function it returns.
+ * Sequential rather than concurrent — batch ordering isn't under test here.
+ */
+function makeSequentialDealMock() {
+	return vi.fn(
+		async (items: readonly unknown[], setup: (...args: unknown[]) => unknown) => {
+			for (const [index, item] of items.entries()) {
+				const update = vi.fn();
+				const setLineHeader = vi.fn();
+				const push = vi.fn();
+				const unshift = vi.fn();
+				const start = (await setup(
+					item,
+					update,
+					index,
+					setLineHeader,
+					push,
+					unshift,
+				)) as () => Promise<void>;
+				await start();
+			}
+		},
+	);
+}
+
+describe('runBatch', () => {
+	let mockPage: { close: ReturnType<typeof vi.fn> };
+	let mockBrowser: { newPage: ReturnType<typeof vi.fn>; close: ReturnType<typeof vi.fn> };
+
+	beforeEach(() => {
+		mockPage = { close: vi.fn().mockResolvedValue() };
+		mockBrowser = {
+			newPage: vi.fn().mockResolvedValue(mockPage),
+			close: vi.fn().mockResolvedValue(),
+		};
+		vi.mocked(launch).mockResolvedValue(mockBrowser as never);
+		vi.mocked(deal).mockImplementation(makeSequentialDealMock() as never);
+		vi.mocked(analyzePageLayout).mockReset().mockResolvedValue([]);
+	});
+
+	it('launches one browser for the whole batch and closes it afterward', async () => {
+		await runBatch(['https://a.example/']);
+
+		expect(launch).toHaveBeenCalledTimes(1);
+		expect(mockBrowser.close).toHaveBeenCalledTimes(1);
+	});
+
+	it('opens and closes one page per URL', async () => {
+		await runBatch(['https://a.example/', 'https://b.example/']);
+
+		expect(mockBrowser.newPage).toHaveBeenCalledTimes(2);
+		expect(mockPage.close).toHaveBeenCalledTimes(2);
+	});
+
+	it("passes the requested concurrency as deal's limit", async () => {
+		await runBatch(['https://a.example/'], { concurrency: 4 });
+
+		expect(deal).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.anything(),
+			expect.objectContaining({ limit: 4 }),
+		);
+	});
+
+	it('clamps a concurrency of 0 up to 1 instead of passing it through (would otherwise hang forever)', async () => {
+		await runBatch(['https://a.example/'], { concurrency: 0 });
+
+		expect(deal).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.anything(),
+			expect.objectContaining({ limit: 1 }),
+		);
+	});
+
+	it('defaults concurrency to 1', async () => {
+		await runBatch(['https://a.example/']);
+
+		expect(deal).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.anything(),
+			expect.objectContaining({ limit: 1 }),
+		);
+	});
+
+	it('calls onResult for every result analyzePageLayout returns', async () => {
+		const resultA = {
+			url: 'https://a.example/',
+			viewport: { name: 'pc', width: 1280 },
+			mainSelector: null,
+			root: null,
+		};
+		vi.mocked(analyzePageLayout).mockResolvedValue([resultA]);
+		const onResult = vi.fn();
+
+		await runBatch(['https://a.example/'], { onResult });
+
+		expect(onResult).toHaveBeenCalledWith(resultA);
+	});
+
+	it('routes a failing URL to onError instead of aborting the batch', async () => {
+		vi.mocked(analyzePageLayout)
+			.mockRejectedValueOnce(new Error('boom'))
+			.mockResolvedValueOnce([]);
+		const onError = vi.fn();
+
+		await runBatch(['https://bad.example/', 'https://good.example/'], { onError });
+
+		expect(onError).toHaveBeenCalledWith('https://bad.example/', expect.any(Error));
+		expect(mockBrowser.newPage).toHaveBeenCalledTimes(2);
+	});
+
+	it('closes the page even when analyzePageLayout throws', async () => {
+		vi.mocked(analyzePageLayout).mockRejectedValueOnce(new Error('boom'));
+
+		await runBatch(['https://bad.example/'], { onError: vi.fn() });
+
+		expect(mockPage.close).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/@d-zero/anatomist/src/run-batch.ts
+++ b/packages/@d-zero/anatomist/src/run-batch.ts
@@ -1,0 +1,83 @@
+import type { AnalyzePageLayoutOptions } from './analyze-page-layout.js';
+import type { LayoutAnalysisResult } from './types.js';
+import type { DealHeader } from '@d-zero/dealer';
+
+import { deal } from '@d-zero/dealer';
+import { launch } from 'puppeteer';
+
+import { analyzePageLayout } from './analyze-page-layout.js';
+
+export type RunBatchOptions = AnalyzePageLayoutOptions & {
+	/** Number of URLs processed concurrently, each in its own tab of one shared browser process. Default `1`. */
+	concurrency?: number;
+	/** Called once per `(url, viewport)` result, as soon as it's ready — lets the caller stream output rather than buffering the whole batch. */
+	onResult?: (result: LayoutAnalysisResult) => void;
+	/** Called once per URL that fails to analyze, instead of aborting the batch. */
+	onError?: (url: string, error: unknown) => void;
+	/** Where `deal()`'s progress display writes. Default `process.stderr`. */
+	stderr?: NodeJS.WritableStream;
+};
+
+/** One item processed by `deal()`. `deal` requires `WeakKey` items, so a bare `string[]` of URLs can't be passed directly. */
+type UrlItem = { readonly index: number; readonly url: string };
+
+const HEADER: DealHeader = (_progress, done, total) =>
+	`%earth% anatomist — analyzing ${done}/${total}`;
+
+/**
+ * Analyzes many URLs concurrently, each in its own tab of one shared
+ * headless browser (a single `launch()` call for the whole batch —
+ * `@d-zero/puppeteer-dealer`'s multi-process fan-out is unnecessary here
+ * since a tab, not a process, is the unit of isolation this tool needs).
+ * @param urls
+ * @param options
+ * @example
+ * ```ts
+ * await runBatch(['https://a.example/', 'https://b.example/'], {
+ *   concurrency: 2,
+ *   onResult: (result) => console.log(JSON.stringify(result)),
+ * });
+ * ```
+ */
+export async function runBatch(
+	urls: readonly string[],
+	options: RunBatchOptions = {},
+): Promise<void> {
+	const browser = await launch({ headless: true });
+	try {
+		const items: UrlItem[] = urls.map((url, index) => ({ index, url }));
+
+		await deal(
+			items,
+			({ url }, update) => {
+				return async () => {
+					update(`analyzing ${url}`);
+					const page = await browser.newPage();
+					try {
+						const results = await analyzePageLayout(page, url, options);
+						for (const result of results) {
+							options.onResult?.(result);
+						}
+					} catch (error) {
+						options.onError?.(url, error);
+					} finally {
+						await page.close();
+					}
+				};
+			},
+			{
+				header: HEADER,
+				// Clamp to 1: `Dealer`'s worker loop (`while (this.#workers.size <
+				// this.#limit)`) never launches a worker when `limit` is `0`, and
+				// `?? 1` alone doesn't catch that — nullish coalescing only
+				// replaces `null`/`undefined`, not an explicit `0` such as
+				// `--concurrency 0` would parse to. Without this clamp, a `0`
+				// hangs the whole run with no output and no error.
+				limit: Math.max(1, options.concurrency ?? 1),
+				stream: options.stderr,
+			},
+		);
+	} finally {
+		await browser.close();
+	}
+}

--- a/packages/@d-zero/anatomist/src/should-recurse.spec.ts
+++ b/packages/@d-zero/anatomist/src/should-recurse.spec.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+
+import { mockNode } from './__fixtures__/mock-node.js';
+import { decideRecursion } from './should-recurse.js';
+
+/**
+ * @param overrides
+ */
+function bigChild(overrides: Parameters<typeof mockNode>[0] = {}) {
+	return mockNode({ boundingBox: { x: 0, y: 0, width: 200, height: 100 }, ...overrides });
+}
+
+describe('decideRecursion', () => {
+	it('leafs a node with no meaningful children', () => {
+		const node = mockNode({ children: [] });
+		expect(decideRecursion(node, 0, { maxDepth: 6 })).toEqual({ kind: 'leaf' });
+	});
+
+	it('leafs a node whose only children are below the minimum area', () => {
+		const node = mockNode({
+			children: [mockNode({ boundingBox: { x: 0, y: 0, width: 5, height: 5 } })],
+		});
+		expect(decideRecursion(node, 0, { maxDepth: 6 })).toEqual({ kind: 'leaf' });
+	});
+
+	it('leafs a node whose only children are display:none', () => {
+		const node = mockNode({
+			children: [
+				bigChild({
+					style: {
+						display: 'none',
+						float: 'none',
+						position: 'static',
+						visibility: 'visible',
+					},
+				}),
+			],
+		});
+		expect(decideRecursion(node, 0, { maxDepth: 6 })).toEqual({ kind: 'leaf' });
+	});
+
+	it('leafs a node whose only children are visibility:hidden', () => {
+		const node = mockNode({
+			children: [
+				bigChild({
+					style: {
+						display: 'block',
+						float: 'none',
+						position: 'static',
+						visibility: 'hidden',
+					},
+				}),
+			],
+		});
+		expect(decideRecursion(node, 0, { maxDepth: 6 })).toEqual({ kind: 'leaf' });
+	});
+
+	it('collapses a single-wrapper-child node instead of leaf-ing (the critical fix)', () => {
+		const onlyChild = bigChild({ id: 'inner' });
+		const node = mockNode({ children: [onlyChild] });
+		const decision = decideRecursion(node, 0, { maxDepth: 6 });
+		expect(decision).toEqual({ kind: 'collapse', child: onlyChild });
+	});
+
+	it('classifies when there are two or more meaningful children', () => {
+		const a = bigChild({ boundingBox: { x: 0, y: 0, width: 100, height: 100 } });
+		const b = bigChild({ boundingBox: { x: 120, y: 0, width: 100, height: 100 } });
+		const node = mockNode({ children: [a, b] });
+		const decision = decideRecursion(node, 0, { maxDepth: 6 });
+		expect(decision).toEqual({ kind: 'classify', children: [a, b] });
+	});
+
+	it('promotes display:contents children transparently, flattening to their children', () => {
+		const grandchildA = bigChild({
+			id: 'ga',
+			boundingBox: { x: 0, y: 0, width: 100, height: 100 },
+		});
+		const grandchildB = bigChild({
+			id: 'gb',
+			boundingBox: { x: 120, y: 0, width: 100, height: 100 },
+		});
+		const contentsWrapper = mockNode({
+			style: {
+				display: 'contents',
+				float: 'none',
+				position: 'static',
+				visibility: 'visible',
+			},
+			children: [grandchildA, grandchildB],
+		});
+		const node = mockNode({ children: [contentsWrapper] });
+		const decision = decideRecursion(node, 0, { maxDepth: 6 });
+		expect(decision).toEqual({ kind: 'classify', children: [grandchildA, grandchildB] });
+	});
+
+	it('leafs when a majority of meaningful children are inline-level (prose flow, not layout)', () => {
+		const inlineA = bigChild({
+			tagName: 'A',
+			style: {
+				display: 'inline',
+				float: 'none',
+				position: 'static',
+				visibility: 'visible',
+			},
+		});
+		const inlineB = bigChild({
+			tagName: 'A',
+			style: {
+				display: 'inline',
+				float: 'none',
+				position: 'static',
+				visibility: 'visible',
+			},
+		});
+		const block = bigChild({ tagName: 'SPAN' });
+		const node = mockNode({ children: [inlineA, inlineB, block] });
+		expect(decideRecursion(node, 0, { maxDepth: 6 })).toEqual({ kind: 'leaf' });
+	});
+
+	it('leafs once depth reaches maxDepth even with multiple meaningful children', () => {
+		const a = bigChild({ boundingBox: { x: 0, y: 0, width: 100, height: 100 } });
+		const b = bigChild({ boundingBox: { x: 120, y: 0, width: 100, height: 100 } });
+		const node = mockNode({ children: [a, b] });
+		expect(decideRecursion(node, 6, { maxDepth: 6 })).toEqual({ kind: 'leaf' });
+	});
+
+	it('respects a custom minArea', () => {
+		const node = mockNode({
+			children: [mockNode({ boundingBox: { x: 0, y: 0, width: 10, height: 10 } })],
+		});
+		// area 100 < default 800 -> leaf, but with minArea 50 it should collapse.
+		expect(decideRecursion(node, 0, { maxDepth: 6 }).kind).toBe('leaf');
+		expect(decideRecursion(node, 0, { maxDepth: 6, minArea: 50 }).kind).toBe('collapse');
+	});
+});

--- a/packages/@d-zero/anatomist/src/should-recurse.ts
+++ b/packages/@d-zero/anatomist/src/should-recurse.ts
@@ -1,0 +1,119 @@
+import type { RawLayoutNode } from './types.js';
+
+import { parseDisplay } from './parse-display.js';
+
+/** Minimum box area (px²) for a child to count as "meaningful" — below this, treat it as decorative noise (icons, spacers) rather than a layout participant. */
+export const DEFAULT_MIN_AREA = 800;
+
+/**
+ * A node this classify pass should render as a leaf (no further
+ * recursion — its `innerHTML` speaks for it).
+ */
+export type LeafDecision = { kind: 'leaf' };
+
+/**
+ * A node with exactly one meaningful child: the wrapper itself isn't
+ * counted as a layout block (see module JSDoc), so classification should
+ * skip it and continue from `child`.
+ */
+export type CollapseDecision = { kind: 'collapse'; child: RawLayoutNode };
+
+/** A node whose meaningful children should be geometrically classified. */
+export type ClassifyDecision = { kind: 'classify'; children: readonly RawLayoutNode[] };
+
+export type RecurseDecision = LeafDecision | CollapseDecision | ClassifyDecision;
+
+/**
+ * @param node
+ */
+function isInlineLevel(node: RawLayoutNode): boolean {
+	const parsed = parseDisplay(node.style.display);
+	return parsed.kind === 'box-generating' && parsed.outside === 'inline';
+}
+
+/**
+ * Collects a node's "meaningful" children: visible, non-zero-area, and
+ * with `display: contents` wrappers transparently flattened away (a
+ * `contents` box generates no box of its own, so its children are
+ * promoted to this level — recursively, in case of a `contents` chain).
+ * @param node
+ * @param minArea
+ */
+function getMeaningfulChildren(node: RawLayoutNode, minArea: number): RawLayoutNode[] {
+	const result: RawLayoutNode[] = [];
+	for (const child of node.children) {
+		const parsed = parseDisplay(child.style.display);
+		if (parsed.kind === 'none') {
+			continue;
+		}
+		if (child.style.visibility === 'hidden') {
+			continue;
+		}
+		if (child.boundingBox.width * child.boundingBox.height < minArea) {
+			continue;
+		}
+		if (parsed.kind === 'contents') {
+			result.push(...getMeaningfulChildren(child, minArea));
+			continue;
+		}
+		result.push(child);
+	}
+	return result;
+}
+
+/**
+ * Decides how classification should treat one node's children: stop here
+ * (`leaf`), skip this wrapper and continue from its one meaningful child
+ * (`collapse`), or classify these children geometrically (`classify`).
+ *
+ * WHY collapse single-child wrappers instead of leaf-ing at "fewer than 2
+ * children": real pages are almost always
+ * `main > div.inner > div.container > ...` — a single-wrapper chain before
+ * any actual content block. Treating "1 meaningful child" as a leaf would
+ * end classification right after the root on nearly every page. Treating
+ * it as collapse lets the caller (`classify-layout-tree.ts`) walk through
+ * the wrapper chain without counting it toward `maxDepth`, which is meant
+ * to bound *content* nesting, not incidental markup wrapping.
+ *
+ * A majority-inline child set is leaf'd rather than classified because
+ * geometric clustering on inline runs (a tag cloud, links inside a
+ * paragraph) reads as an irregular grid — this is prose flow, not a
+ * layout the tool should report a pattern for.
+ * @param node
+ * @param depth - Classification depth so far (collapsed wrappers don't increment this — see above).
+ * @param options
+ * @param options.maxDepth
+ * @param options.minArea
+ * @example
+ * ```ts
+ * const decision = decideRecursion(node, 0, { maxDepth: 6, minArea: 800 });
+ * if (decision.kind === 'classify') { ... }
+ * ```
+ */
+export function decideRecursion(
+	node: RawLayoutNode,
+	depth: number,
+	options: { maxDepth: number; minArea?: number },
+): RecurseDecision {
+	const minArea = options.minArea ?? DEFAULT_MIN_AREA;
+	const meaningfulChildren = getMeaningfulChildren(node, minArea);
+
+	if (meaningfulChildren.length === 0) {
+		return { kind: 'leaf' };
+	}
+
+	if (meaningfulChildren.length === 1) {
+		return { kind: 'collapse', child: meaningfulChildren[0]! };
+	}
+
+	const inlineCount = meaningfulChildren.filter((child) => isInlineLevel(child)).length;
+	if (inlineCount > meaningfulChildren.length / 2) {
+		return { kind: 'leaf' };
+	}
+
+	if (depth >= options.maxDepth) {
+		return { kind: 'leaf' };
+	}
+
+	return { kind: 'classify', children: meaningfulChildren };
+}

--- a/packages/@d-zero/anatomist/src/types.ts
+++ b/packages/@d-zero/anatomist/src/types.ts
@@ -1,0 +1,119 @@
+/**
+ * Shared types for the capture → classify pipeline.
+ *
+ * `RawLayoutNode` is what the browser realm produces (geometry + raw CSS,
+ * no judgment). `LayoutBlock` is what the classify layer produces (a
+ * judgment attached to that geometry). Keeping them as separate types
+ * — rather than one type with optional classification fields — makes it
+ * a compile error to read a classification off data that hasn't been
+ * classified yet.
+ * @module
+ */
+
+/** Axis-aligned box, in coordinates relative to the parent node's own box (not the viewport). */
+export type BoundingBox = {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+};
+
+/**
+ * The subset of `getComputedStyle` read for one element, captured verbatim
+ * (before any interpretation). `display` is the raw computed string —
+ * see `parse-display.ts` for why it isn't pre-parsed here.
+ */
+export type RawNodeStyle = {
+	display: string;
+	float: string;
+	position: string;
+	visibility: string;
+};
+
+/**
+ * One element captured from the live DOM: geometry + raw style + children,
+ * with no layout judgment attached. Produced by `capture-layout-tree.ts`
+ * inside `page.evaluate`.
+ */
+export type RawLayoutNode = {
+	tagName: string;
+	id: string | null;
+	classList: readonly string[];
+	boundingBox: BoundingBox;
+	style: RawNodeStyle;
+	innerHTML: string;
+	children: readonly RawLayoutNode[];
+};
+
+/**
+ * Visual layout pattern assigned to a block. Names describe what the
+ * geometry looks like, not the CSS mechanism that produced it — a
+ * `horizontal-row` may be `display: flex`, `grid`, or `inline-block`
+ * under the hood; the mechanism is recorded in `signals` instead, so both
+ * the visual read and the implementation detail stay inspectable.
+ */
+export type LayoutType =
+	| 'vertical-stack'
+	| 'horizontal-row'
+	| 'simple-grid'
+	| 'complex-grid'
+	| 'table'
+	| 'float-wrap'
+	| 'unknown'
+	/** No layout judgment was made because this block has no children to arrange (see `should-recurse.ts`) — `confidence` is always `0` and `children` is always empty. Distinct from `unknown`, which means children exist but no detector matched. */
+	| 'leaf';
+
+/**
+ * One classified block in the recursive layout tree. `boundingBox` and
+ * `innerHTML` are carried over verbatim from the matching `RawLayoutNode`;
+ * `layoutType`/`confidence`/`signals` are the classify layer's judgment.
+ */
+export type LayoutBlock = {
+	layoutType: LayoutType;
+	tagName: string;
+	id: string | null;
+	classList: readonly string[];
+	boundingBox: BoundingBox;
+	innerHTML: string;
+	/** 0–1. Not a probability — a relative measure of how cleanly the geometry matched `layoutType`'s pattern. */
+	confidence: number;
+	/** Raw evidence behind the judgment (computed style values, row/column counts, overflow ratios, etc.). Always present, even for `unknown`, so misclassifications are debuggable instead of silent. */
+	signals: Record<string, unknown>;
+	children: readonly LayoutBlock[];
+};
+
+/** One viewport preset: a name plus the width passed to `beforePageScan` (height is derived from width, not settable — see `default-viewports.ts`). */
+export type ViewportSpec = {
+	name: string;
+	width: number;
+};
+
+/**
+ * Result of one pattern detector (`detect-*-pattern.ts`) run against a
+ * container's children. `signals` always carries the raw evidence the
+ * detector looked at, matched or not, so a rejected detector's reasoning
+ * is inspectable too.
+ */
+export type DetectionResult = {
+	matched: boolean;
+	/** 0–1. Meaningful only when `matched` is `true`. */
+	confidence: number;
+	signals: Record<string, unknown>;
+};
+
+/** The judgment `resolve-layout-type.ts` attaches to a container: which pattern its children matched, and why. */
+export type LayoutTypeResolution = {
+	layoutType: LayoutType;
+	confidence: number;
+	signals: Record<string, unknown>;
+};
+
+/** Layout analysis result for one URL at one viewport. */
+export type LayoutAnalysisResult = {
+	url: string;
+	viewport: ViewportSpec;
+	/** The selector that resolved the main-content element, or `null` when none matched. */
+	mainSelector: string | null;
+	/** `null` when no main-content element was found for this URL/viewport. */
+	root: LayoutBlock | null;
+};

--- a/packages/@d-zero/anatomist/tsconfig.json
+++ b/packages/@d-zero/anatomist/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["./src/**/*"],
+	"exclude": ["node_modules", "dist", "./src/**/*.spec.ts"]
+}

--- a/packages/@d-zero/beholder/src/get-main-contents.ts
+++ b/packages/@d-zero/beholder/src/get-main-contents.ts
@@ -94,6 +94,10 @@ export function extractMainContentsFromDocument(
 	const title = doc.title?.trim() ?? '';
 	const bodyWordCount = removeSpaces(doc.body?.textContent ?? null)?.length ?? 0;
 
+	// Kept in sync with MAIN_CONTENT_SELECTORS in main-content-selectors.ts
+	// (main-content-selectors.spec.ts asserts the two stay identical). Inlined
+	// rather than imported because this function must stay closure-free — see
+	// the module JSDoc.
 	const selectors = [
 		'main',
 		'[role="main"]',
@@ -126,6 +130,8 @@ export function extractMainContentsFromDocument(
 	}
 
 	if (!$main) {
+		// Kept in sync with MAIN_CONTENT_FALLBACK_SELECTORS in
+		// main-content-selectors.ts — see the comment on `selectors` above.
 		const fallbackSelectors = [
 			'[id*="main" i]',
 			'[class*="main" i]',

--- a/packages/@d-zero/beholder/src/index.ts
+++ b/packages/@d-zero/beholder/src/index.ts
@@ -14,6 +14,10 @@ export { default as default } from './scraper.js';
 export { isError } from './is-error.js';
 export { extractMetaFromDocument } from './extract-meta.js';
 export type { ExtractMetaContext } from './extract-meta.js';
+export {
+	MAIN_CONTENT_FALLBACK_SELECTORS,
+	MAIN_CONTENT_SELECTORS,
+} from './main-content-selectors.js';
 export { detectCompress } from '@d-zero/shared/detect-compress';
 export type { CompressType } from '@d-zero/shared/detect-compress';
 export { detectCDN } from '@d-zero/shared/detect-cdn';

--- a/packages/@d-zero/beholder/src/main-content-selectors.spec.ts
+++ b/packages/@d-zero/beholder/src/main-content-selectors.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractMainContentsFromDocument } from './get-main-contents.js';
+import {
+	MAIN_CONTENT_FALLBACK_SELECTORS,
+	MAIN_CONTENT_SELECTORS,
+} from './main-content-selectors.js';
+
+/**
+ * Extracts every quoted string literal from a slice of source text (either
+ * quote style, tolerating `\"`/`\'` escapes) in order of appearance.
+ *
+ * WHY this instead of a membership-only check: asserting only that every
+ * shared-constant selector *appears somewhere* in the inlined function
+ * catches a selector being dropped from the constants, but not the
+ * reverse — an inlined selector added or edited without updating
+ * `main-content-selectors.ts` would still pass. Extracting the exact
+ * inlined array's contents and comparing it (in order) against the
+ * exported constant catches drift in both directions.
+ * @param source
+ */
+function extractStringLiterals(source: string): string[] {
+	return [...source.matchAll(/(["'])((?:\\.|(?!\1).)*)\1/g)].map((m) =>
+		m[2]!.replaceAll(String.raw`\"`, '"').replaceAll(String.raw`\'`, "'"),
+	);
+}
+
+/**
+ * @param source
+ * @param variableName
+ */
+function extractInlineArray(source: string, variableName: string): string[] {
+	const match = new RegExp(`const ${variableName} = (\\[[\\s\\S]*?\\]);`).exec(source);
+	if (!match) {
+		throw new Error(
+			`could not find "const ${variableName} = [...]" in the function source`,
+		);
+	}
+	return extractStringLiterals(match[1]!);
+}
+
+describe('main-content-selectors', () => {
+	it('matches, in order, the selectors array inlined in extractMainContentsFromDocument', () => {
+		const source = extractMainContentsFromDocument.toString();
+		expect(extractInlineArray(source, 'selectors')).toEqual(MAIN_CONTENT_SELECTORS);
+	});
+
+	it('matches, in order, the fallbackSelectors array inlined in extractMainContentsFromDocument', () => {
+		const source = extractMainContentsFromDocument.toString();
+		expect(extractInlineArray(source, 'fallbackSelectors')).toEqual(
+			MAIN_CONTENT_FALLBACK_SELECTORS,
+		);
+	});
+});

--- a/packages/@d-zero/beholder/src/main-content-selectors.ts
+++ b/packages/@d-zero/beholder/src/main-content-selectors.ts
@@ -1,0 +1,46 @@
+/**
+ * Selector lists for locating a page's main-content region, shared as data
+ * so other packages (e.g. `@d-zero/anatomist`) can resolve the same element
+ * without duplicating the heuristic.
+ *
+ * WHY duplicated in `extractMainContentsFromDocument` (`get-main-contents.ts`): that function
+ * must stay closure-free so Puppeteer can serialize it into `page.evaluate`
+ * (see its module JSDoc). A `page.evaluate`-bound function cannot reference
+ * an imported module-level constant — Puppeteer only sends the function's
+ * source text across, not its closure — so the arrays there stay inlined.
+ * `main-content-selectors.spec.ts` asserts the two lists stay in sync.
+ * @module
+ */
+
+/**
+ * Selectors tried first, in priority order. The caller-supplied selector
+ * (when present) is prepended ahead of these by the consumer.
+ */
+export const MAIN_CONTENT_SELECTORS: readonly string[] = [
+	'main',
+	'[role="main"]',
+	'#main',
+	'.main',
+	'#content',
+	'.content',
+	'#contents',
+	'.contents',
+	'#main-content',
+	'.main-content',
+	'#main_content',
+	'.main_content',
+	'#mainContent',
+	'.mainContent',
+];
+
+/**
+ * Fallback selectors tried, in order, only when none of
+ * {@link MAIN_CONTENT_SELECTORS} match. The first match that isn't `<body>`
+ * or `<html>` wins.
+ */
+export const MAIN_CONTENT_FALLBACK_SELECTORS: readonly string[] = [
+	'[id*="main" i]',
+	'[class*="main" i]',
+	'[id*="content" i]',
+	'[class*="content" i]',
+];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1127,6 +1127,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@d-zero/anatomist@workspace:packages/@d-zero/anatomist":
+  version: 0.0.0-use.local
+  resolution: "@d-zero/anatomist@workspace:packages/@d-zero/anatomist"
+  dependencies:
+    "@d-zero/beholder": "npm:4.1.1"
+    "@d-zero/dealer": "npm:1.10.2"
+    "@d-zero/puppeteer-page-scan": "npm:4.6.6"
+    "@d-zero/shared": "npm:0.22.3"
+    puppeteer: "npm:25.3.0"
+  bin:
+    anatomist: ./dist/cli.js
+  languageName: unknown
+  linkType: soft
+
 "@d-zero/archaeologist@workspace:packages/@d-zero/archaeologist":
   version: 0.0.0-use.local
   resolution: "@d-zero/archaeologist@workspace:packages/@d-zero/archaeologist"
@@ -1176,7 +1190,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@d-zero/beholder@workspace:packages/@d-zero/beholder":
+"@d-zero/beholder@npm:4.1.1, @d-zero/beholder@workspace:packages/@d-zero/beholder":
   version: 0.0.0-use.local
   resolution: "@d-zero/beholder@workspace:packages/@d-zero/beholder"
   dependencies:


### PR DESCRIPTION
## Summary

- Adds `@d-zero/anatomist`, a new CLI/library package that renders a URL in a real browser and classifies its main-content child blocks into visual layout patterns (vertical stack, horizontal row, simple/complex grid, table, float-wrap) from measured box geometry (`getBoundingClientRect`), using CSS properties only as corroborating signal.
- Exports `@d-zero/beholder`'s main-content selector priority/fallback lists (`MAIN_CONTENT_SELECTORS` / `MAIN_CONTENT_FALLBACK_SELECTORS`) as shared constants so anatomist's own main-element resolution reuses the exact same heuristic instead of duplicating it.

## Details

- **capture layer** (`capture-layout-tree.ts` / `capture-layout.ts`): resolves the main-content element and walks its subtree into raw geometry + style + innerHTML via a single `page.evaluate`. Every helper is nested inside the evaluated function since Puppeteer only serializes that function's own source text into the browser realm.
- **classify layer** (pure functions, no browser dependency): row/column geometry clustering, per-pattern detectors (table/grid/horizontal-row/float-wrap/vertical-stack), a carousel-overflow guard, and single-child-wrapper collapsing so a `main > div.inner > div.container` chain doesn't end classification immediately after the root.
- **orchestration** (`analyze-page-layout.ts` / `run-batch.ts`): one URL across multiple viewports (PC → tablet → mobile, largest first) reusing one page; many URLs concurrently via `@d-zero/dealer`, each in its own tab of one shared browser.
- **CLI** (`cli.ts`): reads a URL list from stdin or `--input`, writes JSONL to stdout or `--out`.
- Fixture-driven integration tests (`classify-layout-tree.integration.spec.ts`) exercise capture → classify end-to-end against real HTML fixtures for each layout pattern, using `@d-zero/beholder`'s actual selector constants.

## Test plan

- [x] `yarn build` — all 29 projects build successfully
- [x] `yarn test` — 1854 tests pass across 142 files (including new fixture-driven integration tests)
- [x] `yarn lint` — no errors
- [x] `/code-review medium`, `/qa-engineer`, `/product-manager` reviewed; all findings addressed (see commit history for the fixes: closure-free `page.evaluate` bug, `Math.max(...spread)` RangeError risk, `--concurrency 0` hang, duplicate row-clustering, dead code removal, bidirectional selector-sync test, missing `--input`/`--out` coverage)
