### PR TITLE
fix(repo): normalize npm bin path and register anatomist for publishing

### DIFF
--- a/.claude/skills/npm-publish/SKILL.md
+++ b/.claude/skills/npm-publish/SKILL.md
@@ -22,6 +22,7 @@ disable-model-invocation: true
 | `packages/@d-zero/a11y-check-axe-scenario` | `@d-zero/a11y-check-axe-scenario` |
 | `packages/@d-zero/a11y-check-core` | `@d-zero/a11y-check-core` |
 | `packages/@d-zero/a11y-check-scenarios` | `@d-zero/a11y-check-scenarios` |
+| `packages/@d-zero/anatomist` | `@d-zero/anatomist` |
 | `packages/@d-zero/archaeologist` | `@d-zero/archaeologist` |
 | `packages/@d-zero/backlog-projects` | `@d-zero/backlog-projects` |
 | `packages/@d-zero/beholder` | `@d-zero/beholder` |
@@ -175,7 +176,7 @@ gh run watch --exit-status
 
 ## 11. publish 結果の検証
 
-workflow が success でも publish が意図通りとは限らない。**「対象パッケージ」の全 28 パッケージについて**実際の npm 上の状態を確認する。
+workflow が success でも publish が意図通りとは限らない。**「対象パッケージ」の全 29 パッケージについて**実際の npm 上の状態を確認する。
 
 ```bash
 npm view <package> version
@@ -188,7 +189,7 @@ npm view <package> dist-tags
 - dist-tag が手順 10 のロジック通りか（正式リリースは `latest`、プレリリースは `alpha` / `beta` / `rc` / `next`）
 - provenance が付与されているか（npm の該当バージョンページ、または `npm view <package> --json` の `dist.attestations`）
 
-independent モードでは**一部のパッケージだけ publish される（部分 publish）**ことがある。28 パッケージ全てを個別に確認し、漏れがあればユーザーに報告する。
+independent モードでは**一部のパッケージだけ publish される（部分 publish）**ことがある。29 パッケージ全てを個別に確認し、漏れがあればユーザーに報告する。
 
 **ここが success の判定点**。npm 上の状態を確認するまでリリース完了と判断してはいけない。
 

--- a/packages/@d-zero/a11y-check/package.json
+++ b/packages/@d-zero/a11y-check/package.json
@@ -14,7 +14,9 @@
 			"types": "./dist/a11y-check.d.ts"
 		}
 	},
-	"bin": "./dist/cli.js",
+	"bin": {
+		"a11y-check": "dist/cli.js"
+	},
 	"files": [
 		"dist"
 	],

--- a/packages/@d-zero/anatomist/package.json
+++ b/packages/@d-zero/anatomist/package.json
@@ -22,7 +22,9 @@
 			"types": "./dist/capture-layout.d.ts"
 		}
 	},
-	"bin": "./dist/cli.js",
+	"bin": {
+		"anatomist": "dist/cli.js"
+	},
 	"files": [
 		"dist"
 	],

--- a/packages/@d-zero/archaeologist/package.json
+++ b/packages/@d-zero/archaeologist/package.json
@@ -14,7 +14,9 @@
 			"types": "./dist/index.d.ts"
 		}
 	},
-	"bin": "./dist/cli.js",
+	"bin": {
+		"archaeologist": "dist/cli.js"
+	},
 	"files": [
 		"dist"
 	],

--- a/packages/@d-zero/backlog-projects/package.json
+++ b/packages/@d-zero/backlog-projects/package.json
@@ -11,7 +11,9 @@
 		"node": ">=22.1.0"
 	},
 	"type": "module",
-	"bin": "./dist/cli.js",
+	"bin": {
+		"backlog-projects": "dist/cli.js"
+	},
 	"exports": {
 		".": {
 			"import": "./dist/index.js"

--- a/packages/@d-zero/filematch/package.json
+++ b/packages/@d-zero/filematch/package.json
@@ -16,7 +16,9 @@
 			"types": "./dist/index.d.ts"
 		}
 	},
-	"bin": "./dist/cli.js",
+	"bin": {
+		"filematch": "dist/cli.js"
+	},
 	"files": [
 		"dist"
 	],

--- a/packages/@d-zero/page-cluster/package.json
+++ b/packages/@d-zero/page-cluster/package.json
@@ -38,7 +38,9 @@
 			"types": "./dist/build-cluster-reason.d.ts"
 		}
 	},
-	"bin": "./dist/cli.js",
+	"bin": {
+		"page-cluster": "dist/cli.js"
+	},
 	"files": [
 		"dist"
 	],

--- a/packages/@d-zero/print/package.json
+++ b/packages/@d-zero/print/package.json
@@ -14,7 +14,9 @@
 			"types": "./dist/print.d.ts"
 		}
 	},
-	"bin": "./dist/cli.js",
+	"bin": {
+		"print": "dist/cli.js"
+	},
 	"files": [
 		"dist"
 	],

--- a/packages/@d-zero/replicator/package.json
+++ b/packages/@d-zero/replicator/package.json
@@ -14,7 +14,9 @@
 			"types": "./dist/index.d.ts"
 		}
 	},
-	"bin": "./dist/cli.js",
+	"bin": {
+		"replicator": "dist/cli.js"
+	},
 	"files": [
 		"dist"
 	],


### PR DESCRIPTION
## Summary

- Add `@d-zero/anatomist` to the npm-publish skill's target package list (28 → 29 packages)
- Fix `bin` field format across 8 CLI packages (`a11y-check`, `anatomist`, `archaeologist`, `backlog-projects`, `filematch`, `page-cluster`, `print`, `replicator`): npm 11.17 silently strips the `bin` entry when the path has a leading `./`, leaving the published package without a CLI executable. Switched to the object form with a bare relative path.

## Test plan

- [x] `yarn lint`
- [x] `yarn build`
- [x] `yarn test`
- [x] `npm publish --dry-run` confirmed no bin warning for anatomist after the fix
- [x] `@d-zero/anatomist@0.1.0` published to npm; `npm view @d-zero/anatomist bin` returns `{ anatomist: 'dist/cli.js' }`
