### PR TITLE
fix(anatomist): expose types via ./types subpath export

### DIFF
--- a/packages/@d-zero/anatomist/README.md
+++ b/packages/@d-zero/anatomist/README.md
@@ -73,11 +73,12 @@ main 要素が見つからなかった場合は `mainSelector: null, root: null`
 
 サブパスエクスポート構成。
 
-| import パス                              | 提供関数                                                                       |
+| import パス                              | 提供 API                                                                       |
 | ---------------------------------------- | ------------------------------------------------------------------------------ |
 | `@d-zero/anatomist`                      | `analyzePageLayout` — 1 URL を複数ビューポートで解析するメインエントリー       |
 | `@d-zero/anatomist/capture-layout`       | `captureLayout` — Puppeteer の `Page` から main 配下の座標・スタイルを採取する |
 | `@d-zero/anatomist/classify-layout-tree` | `classifyLayoutTree` — 採取済みツリーからレイアウトパターンを判定する純粋関数  |
+| `@d-zero/anatomist/types`                | 型のみ — `LayoutAnalysisResult` / `ViewportSpec` / `LayoutBlock` 等            |
 
 ```ts
 import puppeteer from 'puppeteer';

--- a/packages/@d-zero/anatomist/package.json
+++ b/packages/@d-zero/anatomist/package.json
@@ -20,6 +20,9 @@
 		"./capture-layout": {
 			"import": "./dist/capture-layout.js",
 			"types": "./dist/capture-layout.d.ts"
+		},
+		"./types": {
+			"types": "./dist/types.d.ts"
 		}
 	},
 	"bin": {


### PR DESCRIPTION
## Summary

- Add a `./types` subpath export to `@d-zero/anatomist`'s `package.json`, exposing `src/types.ts` (`LayoutAnalysisResult`, `ViewportSpec`, `LayoutBlock`, etc.) so consumers under `moduleResolution: NodeNext` can `import type { ... } from '@d-zero/anatomist/types'` instead of hitting `TS2305`.
- Follows the same types-only subpath pattern already used by `@d-zero/shared` and `@d-zero/notion` (`"types"` condition only, no `"import"`).
- Update the README's Library table with the new subpath and rename the column header from "提供関数" to "提供 API" since it now also lists a types-only entry.

## Test plan

- [x] `yarn build` (full repo, `NX_WORKSPACE_ROOT_PATH` set for worktree) — `dist/types.d.ts` generated correctly
- [x] Manually verified `import type { LayoutAnalysisResult, ViewportSpec, LayoutBlock } from '@d-zero/anatomist/types'` type-checks under `moduleResolution: NodeNext` (no `TS2305`)
- [x] Confirmed the same import from the root `@d-zero/anatomist` entry still fails as expected (subpath-only, no root re-export — matches existing `shared`/`notion` precedent)
- [x] `yarn lint`
- [x] `yarn test` (142 files / 1862 tests passed)

Fixes #938

🤖 Generated with [Claude Code](https://claude.com/claude-code)
