### PR TITLE
feat(roar): add usage, flag groups, and sub-command metadata to help rendering

### DIFF
--- a/packages/@d-zero/roar/README.md
+++ b/packages/@d-zero/roar/README.md
@@ -19,8 +19,16 @@ const result = parseCli({
 	commands: {
 		crawl: {
 			desc: 'Crawl a website',
+			usage: ['<URL> [options]', '<archive> --append <URL> [options]'],
 			flags: {
 				depth: { type: 'number', shortFlag: 'd', desc: 'Max depth', default: 10 },
+				append: {
+					type: 'string',
+					shortFlag: 'A',
+					desc: 'Append crawl',
+					valueName: 'URL',
+					group: 'Crawl modes',
+				},
 				verbose: { type: 'boolean', shortFlag: 'v', desc: 'Verbose output' },
 			},
 		},
@@ -36,5 +44,16 @@ if (result.command === 'crawl') {
 ```
 
 位置引数とフラグは任意の順序で混在可能。`--` 以降はすべて位置引数として扱う。
+
+## Help 表示
+
+`--help` / `-h` は stdout に整形済みヘルプを出力して `exit(0)` する。トップレベルではコマンド一覧、コマンドの後ろではそのコマンドのフラグ一覧を表示する。
+
+- `usage`（`string | string[]`）— `Usage:` 行の自由記述。複数指定で相互排他の起動モードを 1 行ずつ列挙できる。プログラム名とコマンド名は自動で前置される
+- `valueName` — string / number フラグの値プレースホルダ（`--interval <ms>` のような表記）。省略時は `<value>` / `<n>`
+- `group` — フラグをセクション見出しの下にまとめる。未指定のフラグは `Options:` 直下
+- `subCommands` — help 専用のサブサブコマンドメタデータ（パースには影響しない）。コマンドの help にサブコマンド一覧を表示し、`my-tool query <file> pages --help` のようにサブコマンド名を含めるとそのサブコマンドに適用されるフラグだけに絞った help を表示する。各エントリの `flags` に適用フラグのキーを列挙し、どのエントリからも参照されないフラグは全サブコマンド共通として常に表示される
+
+説明文は端末幅（上限 100 桁）で折り返され、ラベル列の幅はフラグ長に応じて自動調整される。
 
 `--version`/`-v` の発火位置（`argv[0]` 限定）、空文字列 `version` の扱い、フラグ型推論の挙動は `src/parse-cli.ts` の JSDoc を参照。

--- a/packages/@d-zero/roar/src/parse-cli.spec.ts
+++ b/packages/@d-zero/roar/src/parse-cli.spec.ts
@@ -193,6 +193,283 @@ describe('parseCli', () => {
 		}
 	});
 
+	describe('help rendering', () => {
+		let logSpy: ReturnType<typeof vi.spyOn>;
+		let errorSpy: ReturnType<typeof vi.spyOn>;
+
+		const helpSettings = {
+			name: 'npx @test/cli',
+			commands: {
+				crawl: {
+					desc: 'Crawl a website',
+					usage: ['<URL> [<URL>...] [options]', '<archive> --append <URL> [options]'],
+					flags: {
+						append: {
+							type: 'string' as const,
+							shortFlag: 'A',
+							desc: 'Append crawl',
+							valueName: 'URL',
+							group: 'Crawl modes',
+							isMultiple: true,
+						},
+						interval: {
+							type: 'number' as const,
+							shortFlag: 'I',
+							desc: 'Interval between requests',
+							valueName: 'ms',
+						},
+						imageFileSizeThreshold: {
+							type: 'number' as const,
+							desc: 'Image file size threshold',
+						},
+						verbose: { type: 'boolean' as const, desc: 'Verbose output' },
+					},
+				},
+				query: {
+					desc: 'Query an archive',
+					usage: '<file> <sub-command> [options]',
+					flags: {
+						limit: {
+							type: 'number' as const,
+							shortFlag: 'l',
+							desc: 'Maximum number of results',
+						},
+						url: { type: 'string' as const, desc: 'Target URL', valueName: 'URL' },
+						pretty: { type: 'boolean' as const, desc: 'Pretty-print JSON output' },
+					},
+					subCommands: {
+						pages: {
+							desc: 'List pages',
+							usage: '<file> pages [options]',
+							flags: ['limit'] as const,
+						},
+						'page-detail': {
+							desc: 'Show a single page',
+							flags: ['url'] as const,
+						},
+					},
+				},
+			},
+			onError: vi.fn().mockReturnValue(true),
+		} as const;
+
+		/**
+		 * Returns everything printed via console.log joined together.
+		 */
+		function loggedText(): string {
+			return logSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+		}
+
+		beforeEach(() => {
+			logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+			errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		});
+
+		afterEach(() => {
+			logSpy.mockRestore();
+			errorSpy.mockRestore();
+		});
+
+		it('prints top-level help to stdout and exits 0 for --help', () => {
+			setArgv(['--help']);
+			expect(() => parseCli(helpSettings)).toThrow('process.exit called');
+			expect(exitSpy).toHaveBeenCalledWith(0);
+			expect(errorSpy).not.toHaveBeenCalled();
+			const text = loggedText();
+			expect(text).toContain('Usage: npx @test/cli <command> [options]');
+			expect(text).toContain('crawl');
+			expect(text).toContain('Crawl a website');
+			expect(text).toContain("Run 'npx @test/cli <command> --help'");
+		});
+
+		it('prints top-level help to stdout and exits 0 for -h', () => {
+			setArgv(['-h']);
+			expect(() => parseCli(helpSettings)).toThrow('process.exit called');
+			expect(exitSpy).toHaveBeenCalledWith(0);
+			expect(loggedText()).toContain('Commands:');
+		});
+
+		it('still reports an error for a missing command', () => {
+			setArgv([]);
+			expect(() => parseCli(helpSettings)).toThrow('process.exit called');
+			expect(exitSpy).toHaveBeenCalledWith(1);
+			expect(errorSpy).toHaveBeenCalled();
+		});
+
+		it('renders every usage entry with the program and command prefix', () => {
+			setArgv(['crawl', '--help']);
+			expect(() => parseCli(helpSettings)).toThrow('process.exit called');
+			const text = loggedText();
+			expect(text).toContain('Usage: npx @test/cli crawl <URL> [<URL>...] [options]');
+			expect(text).toContain(
+				'       npx @test/cli crawl <archive> --append <URL> [options]',
+			);
+		});
+
+		it('falls back to a generic usage line when usage is omitted', () => {
+			setArgv(['crawl', '--help']);
+			expect(() =>
+				parseCli({
+					...helpSettings,
+					commands: { crawl: { desc: 'Crawl', flags: {} } },
+				}),
+			).toThrow('process.exit called');
+			expect(loggedText()).toContain('Usage: npx @test/cli crawl [options]');
+		});
+
+		it('renders value placeholders for string and number flags', () => {
+			setArgv(['crawl', '--help']);
+			expect(() => parseCli(helpSettings)).toThrow('process.exit called');
+			const text = loggedText();
+			expect(text).toContain('-A, --append <URL>...');
+			expect(text).toContain('-I, --interval <ms>');
+			expect(text).toContain('--image-file-size-threshold <n>');
+			expect(text).not.toContain('--verbose <');
+		});
+
+		it('renders grouped flags under their own section heading', () => {
+			setArgv(['crawl', '--help']);
+			expect(() => parseCli(helpSettings)).toThrow('process.exit called');
+			const text = loggedText();
+			expect(text).toContain('Crawl modes:');
+			const optionsIndex = text.indexOf('Options:');
+			const groupIndex = text.indexOf('Crawl modes:');
+			expect(optionsIndex).toBeGreaterThanOrEqual(0);
+			expect(groupIndex).toBeGreaterThan(optionsIndex);
+		});
+
+		it('lists sub-commands and hides sub-command-specific flags in command help', () => {
+			setArgv(['query', '--help']);
+			expect(() => parseCli(helpSettings)).toThrow('process.exit called');
+			const text = loggedText();
+			expect(text).toContain('Sub-commands:');
+			expect(text).toContain('pages');
+			expect(text).toContain('List pages');
+			expect(text).toContain('--pretty');
+			expect(text).not.toContain('--limit');
+			expect(text).not.toContain('--url');
+			expect(text).toContain("Run 'npx @test/cli query <sub-command> --help'");
+		});
+
+		it('filters help to the requested sub-command plus common flags', () => {
+			setArgv(['query', 'archive.db', 'pages', '--help']);
+			expect(() => parseCli(helpSettings)).toThrow('process.exit called');
+			const text = loggedText();
+			expect(text).toContain('Usage: npx @test/cli query <file> pages [options]');
+			expect(text).toContain('List pages');
+			expect(text).toContain('--limit');
+			expect(text).toContain('--pretty');
+			expect(text).not.toContain('--url');
+		});
+
+		it('applies every flag to a sub-command whose flags list is omitted', () => {
+			setArgv(['query', 'archive.db', 'all-flags', '--help']);
+			expect(() =>
+				parseCli({
+					...helpSettings,
+					commands: {
+						query: {
+							desc: 'Query an archive',
+							flags: {
+								limit: { type: 'number' as const, desc: 'Maximum number of results' },
+								url: { type: 'string' as const, desc: 'Target URL' },
+							},
+							subCommands: {
+								'all-flags': { desc: 'Sub-command without a flags list' },
+							},
+						},
+					},
+				}),
+			).toThrow('process.exit called');
+			const text = loggedText();
+			expect(text).toContain('--limit');
+			expect(text).toContain('--url');
+		});
+
+		it('omits the Options heading when every flag is grouped', () => {
+			setArgv(['crawl', '--help']);
+			expect(() =>
+				parseCli({
+					...helpSettings,
+					commands: {
+						crawl: {
+							desc: 'Crawl',
+							flags: {
+								append: {
+									type: 'string' as const,
+									desc: 'Append crawl',
+									group: 'Crawl modes',
+								},
+								output: {
+									type: 'string' as const,
+									desc: 'Output file path',
+									group: 'Output',
+								},
+							},
+						},
+					},
+				}),
+			).toThrow('process.exit called');
+			const text = loggedText();
+			expect(text).not.toContain('Options:');
+			const modesIndex = text.indexOf('Crawl modes:');
+			const outputIndex = text.indexOf('Output:');
+			expect(modesIndex).toBeGreaterThanOrEqual(0);
+			expect(outputIndex).toBeGreaterThan(modesIndex);
+		});
+
+		it('renders an over-cap label on its own line with the description below', () => {
+			setArgv(['crawl', '--help']);
+			expect(() => parseCli(helpSettings)).toThrow('process.exit called');
+			const lines = loggedText().split('\n');
+			const labelLineIndex = lines.findIndex((line) =>
+				line.includes('--image-file-size-threshold <n>'),
+			);
+			expect(labelLineIndex).toBeGreaterThanOrEqual(0);
+			expect(lines[labelLineIndex]).not.toContain('Image file size threshold');
+			expect(lines[labelLineIndex + 1]).toContain('Image file size threshold');
+		});
+
+		it('falls back to a generic sub-command usage line when omitted', () => {
+			setArgv(['query', 'archive.db', 'page-detail', '--help']);
+			expect(() => parseCli(helpSettings)).toThrow('process.exit called');
+			const text = loggedText();
+			expect(text).toContain('Usage: npx @test/cli query page-detail [options]');
+			expect(text).toContain('--url');
+			expect(text).not.toContain('--limit');
+		});
+
+		it('shows full command help when --help is used with an unknown sub-command', () => {
+			setArgv(['query', 'archive.db', '--help']);
+			expect(() => parseCli(helpSettings)).toThrow('process.exit called');
+			expect(loggedText()).toContain('Sub-commands:');
+		});
+
+		it('wraps long descriptions instead of emitting one long line', () => {
+			setArgv(['crawl', '--help']);
+			const longDesc =
+				'Same-cluster soft cap: stop enqueueing newly-discovered internal URLs whose shape has accumulated this many matching-title observations and see the events query for what fired.';
+			expect(() =>
+				parseCli({
+					...helpSettings,
+					commands: {
+						crawl: {
+							desc: 'Crawl',
+							flags: {
+								dedupeCap: { type: 'number' as const, desc: longDesc },
+							},
+						},
+					},
+				}),
+			).toThrow('process.exit called');
+			const lines = loggedText().split('\n');
+			expect(lines.some((line) => line.includes('Same-cluster soft cap'))).toBe(true);
+			for (const line of lines) {
+				expect(line.length).toBeLessThanOrEqual(100);
+			}
+		});
+	});
+
 	describe('version flag', () => {
 		let logSpy: ReturnType<typeof vi.spyOn>;
 

--- a/packages/@d-zero/roar/src/parse-cli.ts
+++ b/packages/@d-zero/roar/src/parse-cli.ts
@@ -10,6 +10,7 @@ import yargsParser from 'yargs-parser';
  *   type: 'string',
  *   shortFlag: 'u',
  *   desc: 'Target URL',
+ *   valueName: 'URL',
  *   isRequired: true,
  * };
  * ```
@@ -20,6 +21,16 @@ interface StringFlag {
 	readonly shortFlag?: string;
 	/** Description shown in `--help` output. */
 	readonly desc?: string;
+	/**
+	 * Value placeholder shown in `--help` output (e.g. `'URL'` renders
+	 * `--url <URL>`). Defaults to `'value'` when omitted.
+	 */
+	readonly valueName?: string;
+	/**
+	 * Section heading this flag is listed under in `--help` output.
+	 * Flags without a group are listed first under `Options:`.
+	 */
+	readonly group?: string;
 	/** Default value applied when the flag is omitted. */
 	readonly default?: string;
 	/** When `true`, the flag accepts multiple values and produces a `string[]`. */
@@ -37,6 +48,16 @@ interface NumberFlag {
 	readonly shortFlag?: string;
 	/** Description shown in `--help` output. */
 	readonly desc?: string;
+	/**
+	 * Value placeholder shown in `--help` output (e.g. `'ms'` renders
+	 * `--interval <ms>`). Defaults to `'n'` when omitted.
+	 */
+	readonly valueName?: string;
+	/**
+	 * Section heading this flag is listed under in `--help` output.
+	 * Flags without a group are listed first under `Options:`.
+	 */
+	readonly group?: string;
 	/** Default value applied when the flag is omitted. */
 	readonly default?: number;
 	/** When `true`, the flag accepts multiple values and produces a `number[]`. */
@@ -53,6 +74,11 @@ interface BooleanFlag {
 	readonly shortFlag?: string;
 	/** Description shown in `--help` output. */
 	readonly desc?: string;
+	/**
+	 * Section heading this flag is listed under in `--help` output.
+	 * Flags without a group are listed first under `Options:`.
+	 */
+	readonly group?: string;
 	/** Default value applied when the flag is omitted. */
 	readonly default?: boolean;
 }
@@ -104,12 +130,49 @@ export type InferFlags<F extends AnyFlags> = {
 // ---- Command definition ----
 
 /**
+ * Help-only metadata for a sub-command nested under a command
+ * (e.g. `my-cli query pages`).
+ *
+ * roar does not parse or dispatch sub-commands — the host CLI keeps
+ * receiving them as positional arguments and dispatches on its own.
+ * This metadata only drives `--help` rendering: the command help lists
+ * sub-commands, and `my-cli <command> <sub-command> --help` renders a
+ * help page filtered to the flags that apply to that sub-command.
+ * @template F - Flag definitions record of the parent command
+ * @example
+ * ```ts
+ * const pagesSubCommand: SubCommandDef = {
+ *   desc: 'List pages in the archive',
+ *   usage: '<file> pages [options]',
+ *   flags: ['limit', 'offset', 'status'],
+ * };
+ * ```
+ */
+export interface SubCommandDef<F extends AnyFlags = AnyFlags> {
+	/** Human-readable description shown in the sub-command list. */
+	readonly desc: string;
+	/**
+	 * Usage line(s) for this sub-command's filtered help, written relative
+	 * to the program name and command name (both are prepended automatically).
+	 * When omitted, a generic `<sub-command> [options]` line is rendered.
+	 */
+	readonly usage?: string | readonly string[];
+	/**
+	 * Keys of the parent command's `flags` that apply to this sub-command.
+	 * Flags not referenced by any sub-command are treated as common to all
+	 * sub-commands and always shown. When omitted, every flag applies.
+	 */
+	readonly flags?: readonly (keyof F & string)[];
+}
+
+/**
  * Defines a single CLI sub-command with its description and optional flags.
  * @template F - Flag definitions record for this command
  * @example
  * ```ts
  * const crawlCommand = {
  *   desc: 'Crawl a website',
+ *   usage: ['<URL> [<URL>...] [options]', '<archive> --append <URL> [options]'],
  *   flags: {
  *     depth: { type: 'number' as const, shortFlag: 'd', desc: 'Max crawl depth', default: 10 },
  *     verbose: { type: 'boolean' as const, shortFlag: 'v', desc: 'Enable verbose output' },
@@ -120,8 +183,20 @@ export type InferFlags<F extends AnyFlags> = {
 export interface CommandDef<F extends AnyFlags = AnyFlags> {
 	/** Human-readable description of the command. */
 	readonly desc: string;
+	/**
+	 * Usage line(s) shown in `--help`, written relative to the program name
+	 * and command name (both are prepended automatically). Multiple entries
+	 * render one `Usage:` block line each — useful for mutually exclusive
+	 * invocation modes. When omitted, a generic `[options]` line is rendered.
+	 */
+	readonly usage?: string | readonly string[];
 	/** Flag definitions. When omitted, the command accepts no flags. */
 	readonly flags?: F;
+	/**
+	 * Help-only sub-command metadata. See {@link SubCommandDef} for how it
+	 * changes `--help` rendering. Parsing behaviour is unaffected.
+	 */
+	readonly subCommands?: Readonly<Record<string, SubCommandDef<F>>>;
 }
 
 // ---- Settings and result types ----
@@ -131,7 +206,11 @@ export interface CommandDef<F extends AnyFlags = AnyFlags> {
  * @template Commands - Record of command name to {@link CommandDef}
  */
 interface RoarSettings<Commands extends Record<string, CommandDef>> {
-	/** CLI program name shown in help text (e.g. `"my-cli"`). */
+	/**
+	 * CLI program name shown in help text. Use the canonical invocation
+	 * (e.g. the full `npx`-prefixed command for a scoped package) rather
+	 * than the bare binary name when the CLI is not expected to be on `PATH`.
+	 */
 	name: string;
 	/**
 	 * Program version string (e.g. `"1.2.3"`).
@@ -151,6 +230,9 @@ interface RoarSettings<Commands extends Record<string, CommandDef>> {
 	/**
 	 * Called when no command or an unknown command is specified.
 	 * Return `true` to print help text to stderr before exiting.
+	 *
+	 * `--help` / `-h` as the first argument is not an error: it prints the
+	 * same help to stdout and exits with code `0` without calling this.
 	 */
 	onError?: (error: Error) => boolean;
 }
@@ -177,12 +259,233 @@ type RoarResult<Commands extends Record<string, CommandDef>> = {
 // ---- Help text generation ----
 
 /**
+ * Layout constants for help rendering.
+ *
+ * WHY a max width: unbounded lines follow the terminal width, which makes
+ * long flag descriptions unreadable on wide displays; 100 columns keeps
+ * the text measure comfortable while still using wide terminals.
+ * WHY a label column cap: a single long flag (e.g.
+ * `--image-file-size-threshold <bytes>`) must not push every description
+ * across the screen — over-long labels get their own line instead.
+ */
+const HELP_MAX_WIDTH = 100;
+const HELP_MIN_WIDTH = 40;
+const LABEL_COLUMN_CAP = 32;
+const INDENT = '  ';
+const COLUMN_GAP = '  ';
+
+/**
+ * Resolves the effective help width from the current terminal.
+ * @returns Column count clamped to a readable range
+ */
+function helpWidth(): number {
+	const columns = process.stdout.columns ?? 80;
+	return Math.min(Math.max(columns, HELP_MIN_WIDTH), HELP_MAX_WIDTH);
+}
+
+/**
+ * Wraps text at word boundaries to fit the given width.
+ * @param text - Text to wrap (single logical line)
+ * @param width - Maximum characters per line (at least one word per line)
+ * @returns Wrapped lines; `['']` for empty text so callers always get a line
+ */
+function wrapText(text: string, width: number): string[] {
+	const words = text.split(' ').filter((word) => word.length > 0);
+	if (words.length === 0) {
+		return [''];
+	}
+	const lines: string[] = [];
+	let current = '';
+	for (const word of words) {
+		if (current.length === 0) {
+			current = word;
+		} else if (current.length + 1 + word.length <= width) {
+			current += ` ${word}`;
+		} else {
+			lines.push(current);
+			current = word;
+		}
+	}
+	lines.push(current);
+	return lines;
+}
+
+/** A single label/description row in a two-column help section. */
+interface HelpRow {
+	readonly label: string;
+	readonly desc: string;
+}
+
+/**
+ * Renders label/description rows as two aligned columns.
+ *
+ * The label column width adapts to the longest label, capped at
+ * {@link LABEL_COLUMN_CAP}; labels beyond the cap are rendered on their own
+ * line with the description continuing on the next line. Descriptions wrap
+ * at the terminal width with a hanging indent aligned to the description
+ * column.
+ * @param rows - Rows to render
+ * @returns Formatted lines
+ */
+function renderRows(rows: readonly HelpRow[]): string[] {
+	const labelWidth = Math.min(
+		Math.max(...rows.map((row) => row.label.length), 0),
+		LABEL_COLUMN_CAP,
+	);
+	const descColumn = INDENT.length + labelWidth + COLUMN_GAP.length;
+	const descWidth = Math.max(helpWidth() - descColumn, 20);
+	const lines: string[] = [];
+	for (const row of rows) {
+		const descLines = wrapText(row.desc, descWidth);
+		if (row.label.length > labelWidth) {
+			lines.push(`${INDENT}${row.label}`);
+			for (const descLine of descLines) {
+				if (descLine.length > 0) {
+					lines.push(`${' '.repeat(descColumn)}${descLine}`);
+				}
+			}
+			continue;
+		}
+		const [first = '', ...rest] = descLines;
+		const firstLine = `${INDENT}${row.label.padEnd(labelWidth)}${COLUMN_GAP}${first}`;
+		lines.push(firstLine.trimEnd());
+		for (const descLine of rest) {
+			lines.push(`${' '.repeat(descColumn)}${descLine}`);
+		}
+	}
+	return lines;
+}
+
+/**
  * Converts a camelCase string to kebab-case for CLI flag display.
  * @param str - camelCase identifier (e.g. `"maxDepth"`)
  * @returns kebab-case string (e.g. `"max-depth"`)
  */
 function camelToKebab(str: string): string {
 	return str.replaceAll(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
+}
+
+/**
+ * Builds the label column text for a flag (short alias, long name, and
+ * value placeholder).
+ * @param key - camelCase flag key
+ * @param def - Flag definition
+ * @returns Label such as `-I, --interval <ms>` or `    --verbose`
+ */
+function flagLabel(key: string, def: FlagDef): string {
+	const kebab = camelToKebab(key);
+	const short = def.shortFlag ? `-${def.shortFlag}, ` : '    ';
+	let label = `${short}--${kebab}`;
+	if (def.type !== 'boolean') {
+		const valueName = def.valueName ?? (def.type === 'number' ? 'n' : 'value');
+		label += ` <${valueName}>`;
+		if ('isMultiple' in def && def.isMultiple) {
+			label += '...';
+		}
+	}
+	return label;
+}
+
+/**
+ * Builds the description column text for a flag (description plus
+ * default-value suffix).
+ * @param def - Flag definition
+ * @returns Description such as `Number of parallel scraping (default: 3)`
+ */
+function flagDesc(def: FlagDef): string {
+	const desc = def.desc ?? '';
+	const defaultStr =
+		'default' in def && def.default !== undefined ? ` (default: ${def.default})` : '';
+	return `${desc}${defaultStr}`.trim();
+}
+
+/**
+ * Renders flags as grouped two-column sections. Ungrouped flags come first
+ * under `Options:`; grouped flags follow under their `group` heading in
+ * first-appearance order.
+ * @param flags - Flag definitions to render
+ * @param keys - Flag keys to include, in definition order
+ * @returns Formatted lines including section headings
+ */
+function renderFlagSections<F extends AnyFlags>(
+	flags: F,
+	keys: readonly string[],
+): string[] {
+	const sections = new Map<string, HelpRow[]>();
+	for (const key of keys) {
+		const def = flags[key];
+		if (!def) {
+			continue;
+		}
+		const group = def.group ?? 'Options';
+		const rows = sections.get(group) ?? [];
+		rows.push({ label: flagLabel(key, def), desc: flagDesc(def) });
+		sections.set(group, rows);
+	}
+	const lines: string[] = [];
+	const ungrouped = sections.get('Options');
+	if (ungrouped) {
+		lines.push('Options:', ...renderRows(ungrouped));
+	}
+	for (const [group, rows] of sections) {
+		if (group === 'Options') {
+			continue;
+		}
+		if (lines.length > 0) {
+			lines.push('');
+		}
+		lines.push(`${group}:`, ...renderRows(rows));
+	}
+	return lines;
+}
+
+/**
+ * Renders a `Usage:` block from usage entries, prepending the given prefix
+ * (program name and command name) to each entry.
+ * @param prefix - Invocation prefix (e.g. `"my-cli crawl"`)
+ * @param usage - Usage entries relative to the prefix
+ * @returns Formatted lines
+ */
+function renderUsage(prefix: string, usage: readonly string[]): string[] {
+	return usage.map((entry, index) =>
+		index === 0 ? `Usage: ${prefix} ${entry}` : `       ${prefix} ${entry}`,
+	);
+}
+
+/**
+ * Normalizes a `string | readonly string[]` usage value to an array.
+ * @param usage - Usage value from a command or sub-command definition
+ * @param fallback - Entry used when the definition has no usage
+ * @returns Usage entries
+ */
+function usageEntries(
+	usage: string | readonly string[] | undefined,
+	fallback: string,
+): readonly string[] {
+	if (usage === undefined) {
+		return [fallback];
+	}
+	return typeof usage === 'string' ? [usage] : usage;
+}
+
+/**
+ * Collects the flag keys that are common to all sub-commands: keys not
+ * referenced by any sub-command's `flags` list.
+ *
+ * WHY implicit: listing common flags (e.g. `--pretty`) on every one of
+ * dozens of sub-commands would be pure noise in the definitions; a flag
+ * that no sub-command claims is by definition sub-command-agnostic.
+ * @param def - Command definition with sub-commands
+ * @returns Common flag keys in definition order
+ */
+function commonFlagKeys(def: CommandDef): string[] {
+	const referenced = new Set<string>();
+	for (const sub of Object.values(def.subCommands ?? {})) {
+		for (const key of sub.flags ?? []) {
+			referenced.add(key);
+		}
+	}
+	return Object.keys(def.flags ?? {}).filter((key) => !referenced.has(key));
 }
 
 /**
@@ -193,44 +496,85 @@ function camelToKebab(str: string): string {
 function generateHelp<Commands extends Record<string, CommandDef>>(
 	settings: RoarSettings<Commands>,
 ): string {
-	const lines: string[] = [
+	const rows: HelpRow[] = Object.entries(settings.commands).map(([name, def]) => ({
+		label: name,
+		desc: def.desc,
+	}));
+	return [
 		`Usage: ${settings.name} <command> [options]`,
 		'',
 		'Commands:',
-	];
-
-	for (const [name, def] of Object.entries(settings.commands)) {
-		lines.push(`  ${name.padEnd(16)} ${def.desc}`);
-	}
-
-	return lines.join('\n');
+		...renderRows(rows),
+		'',
+		`Run '${settings.name} <command> --help' for details on a command.`,
+	].join('\n');
 }
 
 /**
- * Generates per-command help text listing all available flags
- * with their short aliases, descriptions, and defaults.
- * @param name - CLI program name
- * @param commandName - The sub-command name
- * @param flags - Flag definitions for the command
+ * Generates per-command help text.
+ *
+ * Three shapes depending on the definition and the requested scope:
+ * - Plain command: usage block plus all flags in grouped sections.
+ * - Command with `subCommands`, no sub-command requested: usage block,
+ *   sub-command list, and only the flags common to all sub-commands,
+ *   with a hint pointing at per-sub-command help.
+ * - Sub-command requested: the sub-command's usage block and the flags
+ *   that apply to it (its own list plus the common flags).
+ * @param settings - The roar settings containing the program name
+ * @param commandName - The command name
+ * @param def - The command definition
+ * @param subCommandName - Sub-command to filter help to, when requested
  * @returns Formatted multi-line help string
  */
-function generateCommandHelp<F extends AnyFlags>(
-	name: string,
+function generateCommandHelp<Commands extends Record<string, CommandDef>>(
+	settings: RoarSettings<Commands>,
 	commandName: string,
-	flags: F,
+	def: CommandDef,
+	subCommandName?: string,
 ): string {
-	const lines: string[] = [`Usage: ${name} ${commandName} [options]`, '', 'Options:'];
+	const prefix = `${settings.name} ${commandName}`;
+	const flags = def.flags ?? {};
+	const allKeys = Object.keys(flags);
 
-	for (const [key, def] of Object.entries(flags)) {
-		const kebab = camelToKebab(key);
-		const short = def.shortFlag ? `-${def.shortFlag}, ` : '    ';
-		const flagStr = `${short}--${kebab}`;
-		const desc = def.desc ?? '';
-		const defaultStr =
-			'default' in def && def.default !== undefined ? ` (default: ${def.default})` : '';
-		lines.push(`  ${flagStr.padEnd(30)} ${desc}${defaultStr}`);
+	const subCommand =
+		subCommandName === undefined ? undefined : def.subCommands?.[subCommandName];
+	if (subCommand && subCommandName !== undefined) {
+		const common = new Set(commonFlagKeys(def));
+		const own = new Set(subCommand.flags ?? allKeys);
+		const keys = allKeys.filter((key) => own.has(key) || common.has(key));
+		const lines = [
+			...renderUsage(
+				prefix,
+				usageEntries(subCommand.usage, `${subCommandName} [options]`),
+			),
+			'',
+			...wrapText(subCommand.desc, helpWidth()),
+		];
+		if (keys.length > 0) {
+			lines.push('', ...renderFlagSections(flags, keys));
+		}
+		return lines.join('\n');
 	}
 
+	const lines = [...renderUsage(prefix, usageEntries(def.usage, '[options]'))];
+
+	if (def.subCommands) {
+		const rows: HelpRow[] = Object.entries(def.subCommands).map(([name, sub]) => ({
+			label: name,
+			desc: sub.desc,
+		}));
+		lines.push('', 'Sub-commands:', ...renderRows(rows));
+		const common = commonFlagKeys(def);
+		if (common.length > 0) {
+			lines.push('', ...renderFlagSections(flags, common));
+		}
+		lines.push('', `Run '${prefix} <sub-command> --help' for details on a sub-command.`);
+		return lines.join('\n');
+	}
+
+	if (allKeys.length > 0) {
+		lines.push('', ...renderFlagSections(flags, allKeys));
+	}
 	return lines.join('\n');
 }
 
@@ -318,7 +662,11 @@ function parseFlags<F extends AnyFlags>(
  *
  * A minimal CLI framework built on yargs-parser. It provides:
  * - Sub-command dispatch with typed flag inference
- * - Automatic `--help` / `-h` handling per command
+ * - Automatic `--help` / `-h` handling: at the top level it prints the
+ *   command list; after a command it prints that command's flags; when the
+ *   command defines `subCommands` and a sub-command name is present
+ *   (e.g. `my-cli query file.db pages --help`), it prints help filtered
+ *   to that sub-command. All help goes to stdout with exit code `0`.
  * - Automatic `--version` / `-v` handling at the top level when `version` is set
  * - camelCase flag names converted to kebab-case in help text
  * @template Commands - Record of command name to {@link CommandDef}
@@ -331,6 +679,7 @@ function parseFlags<F extends AnyFlags>(
  *   commands: {
  *     crawl: {
  *       desc: 'Crawl a website',
+ *       usage: '<URL> [options]',
  *       flags: {
  *         depth: { type: 'number', shortFlag: 'd', desc: 'Max depth', default: 10 },
  *       },
@@ -359,6 +708,12 @@ export function parseCli<const Commands extends Record<string, CommandDef>>(
 		process.exit(0);
 	}
 
+	if (command === '--help' || command === '-h') {
+		// eslint-disable-next-line no-console
+		console.log(generateHelp(settings));
+		process.exit(0);
+	}
+
 	if (!command || !(command in settings.commands)) {
 		if (settings.onError) {
 			const showHelp = settings.onError(new Error('No command specified'));
@@ -377,8 +732,14 @@ export function parseCli<const Commands extends Record<string, CommandDef>>(
 	const commandArgv = argv.slice(1);
 
 	if (commandArgv.includes('--help') || commandArgv.includes('-h')) {
+		const subCommandName = commandDef.subCommands
+			? commandArgv.find(
+					(arg) =>
+						!arg.startsWith('-') && Object.hasOwn(commandDef.subCommands ?? {}, arg),
+				)
+			: undefined;
 		// eslint-disable-next-line no-console
-		console.log(generateCommandHelp(settings.name, command, commandDef.flags ?? {}));
+		console.log(generateCommandHelp(settings, command, commandDef, subCommandName));
 		process.exit(0);
 	}
 


### PR DESCRIPTION
## 概要

roar の `--help` 出力は「固定 30 桁パディングのフラット一覧」しか表現できず、ホスト CLI（nitpicker 等）の実際の形を隠していた:

- positional 引数が Usage 行に一切出ない（`usage` を書くフィールド自体が無い）
- 値を取るフラグと boolean フラグの区別がつかない
- 長い説明文が折り返されず画面外へ、長いフラグ名は列崩れ
- ホスト側でディスパッチする positional サブコマンド（`query pages` 等）を文書化する手段が無い
- トップレベル `--help` が「コマンド未指定エラー」扱いで stderr + exit 1

## 変更内容

### CommandDef / FlagDef の拡張（すべて追加的・後方互換）

| フィールド | 型 | 効果 |
|---|---|---|
| `CommandDef.usage` | `string \| string[]` | 自由記述の Usage 行。複数指定で相互排他モードを 1 行ずつ列挙。プログラム名・コマンド名は自動前置 |
| `CommandDef.subCommands` | `Record<string, SubCommandDef>` | help 専用メタデータ（パース挙動に影響しない）。コマンド help にサブコマンド一覧を表示し、`--help` と併せてサブコマンド名があればそのサブコマンドに適用されるフラグだけに絞った help を表示 |
| `FlagDef.valueName` | `string` | 値プレースホルダ（`--interval <ms>`）。省略時は string → `<value>`、number → `<n>` |
| `FlagDef.group` | `string` | セクション見出し。未指定フラグは `Options:` 直下 |

`SubCommandDef.flags` に適用フラグのキーを列挙する。どのサブコマンドからも参照されないフラグは「全サブコマンド共通」として常に表示される（`--pretty` のような整形フラグを全エントリに書かせないため）。

### レンダラ改善

- 説明文を端末幅（上限 100 桁・下限 40 桁）で語単位に折り返し、説明列にぶら下げインデント
- ラベル列幅はフラグ長に応じて動的調整（上限 32 桁）。超過するラベルは独立行にして説明を次行へ
- help ページ末尾に `Run '<name> <command> --help' ...` の誘導行を追加

### 挙動修正

- トップレベル `--help` / `-h` は stdout にコマンド一覧を出力して exit 0（従来は onError 経由で stderr + exit 1）。コマンド未指定・未知コマンドのエラーパスは従来通り stderr + exit 1

## テスト

help レンダリングの describe を新設（14 ケース追加、計 1877 テストすべてパス）:

- トップレベル help の stdout / exit 0 / 誘導行、エラーパスの維持
- 複数 usage 行の前置・省略時のフォールバック
- 値プレースホルダ（valueName 指定 / 型別デフォルト / isMultiple の `...` / boolean には付かない）
- グループのセクション化・全フラググループ化時の `Options:` 省略・順序
- サブコマンド一覧表示・共通フラグのみの表示・絞り込み help・`flags` 省略時の全フラグ適用
- 折り返し（100 桁以内）・ラベル超過時の独立行

## 互換性

追加的 API のみで破壊的変更なし（minor）。help のテキストレイアウトは変わるが、パース結果（`command` / `args` / `flags`）は完全に不変。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
