### PR TITLE
chore(repo): apply lint formatting fixes

### DIFF
--- a/packages/@d-zero/beholder/src/meta/keys.ts
+++ b/packages/@d-zero/beholder/src/meta/keys.ts
@@ -11,11 +11,7 @@
  */
 
 export type KeyTransform =
-	| 'string'
-	| 'number'
-	| 'boolean-yes'
-	| 'boolean-on'
-	| 'boolean-true';
+	'string' | 'number' | 'boolean-yes' | 'boolean-on' | 'boolean-true';
 
 export type KeyDef = {
 	/** One or more dot-paths under `Meta` to write the value into. */

--- a/packages/@d-zero/google-sheets/src/sheets/sheet.spec.ts
+++ b/packages/@d-zero/google-sheets/src/sheets/sheet.spec.ts
@@ -175,8 +175,7 @@ describe('appendRow / flush', () => {
 		const parent = {
 			batchUpdate: vi.fn((req: Record<string, unknown>) => {
 				const updateCells = req.updateCells as
-					| { rows?: { values?: unknown[] }[] }
-					| undefined;
+					{ rows?: { values?: unknown[] }[] } | undefined;
 				if (updateCells?.rows) {
 					updateCellsRows.push(updateCells.rows.length);
 				}

--- a/packages/@d-zero/google-sheets/src/sheets/sheets.ts
+++ b/packages/@d-zero/google-sheets/src/sheets/sheets.ts
@@ -81,8 +81,7 @@ export class Sheets {
 				return;
 			}
 			const req = request[requestName] as
-				| { sheetId?: string; start?: { sheetId?: string } }
-				| undefined;
+				{ sheetId?: string; start?: { sheetId?: string } } | undefined;
 			const sheetId = req?.sheetId ?? req?.start?.sheetId;
 			sheetsLog(`Sheet(#${sheetId})::BatchUpdate.${requestName}`);
 			const res = await this.#sheets.spreadsheets.batchUpdate({

--- a/packages/@d-zero/puppeteer-dealer/README.md
+++ b/packages/@d-zero/puppeteer-dealer/README.md
@@ -18,14 +18,7 @@ import { deal, createProcess } from '@d-zero/puppeteer-dealer';
 await deal(
 	[{ id: '1', url: 'https://example.com' }],
 	(progress, done, total) => `${done}/${total}`,
-	() =>
-		createProcess(
-			'./child.js',
-			{
-				/* params */
-			},
-			{ locale: 'ja-JP', headless: true },
-		),
+	() => createProcess('./child.js', {/* params */}, { locale: 'ja-JP', headless: true }),
 	{ limit: 5 },
 );
 ```

--- a/packages/@d-zero/shared/src/detect-compress.ts
+++ b/packages/@d-zero/shared/src/detect-compress.ts
@@ -1,11 +1,5 @@
 export type CompressType =
-	| 'gzip'
-	| 'compress'
-	| 'deflate'
-	| 'br'
-	| 'sdch'
-	| 'vcdiff'
-	| 'xdelta';
+	'gzip' | 'compress' | 'deflate' | 'br' | 'sdch' | 'vcdiff' | 'xdelta';
 
 /**
  * Detects the HTTP response compression algorithm from the `Content-Encoding` header.

--- a/packages/@d-zero/shared/src/sample-distribution.ts
+++ b/packages/@d-zero/shared/src/sample-distribution.ts
@@ -4,11 +4,7 @@ import { randomInt, type RandomIntRange } from './random-int.js';
  * Preset distribution types for random sampling.
  */
 export type DistributionPreset =
-	| 'uniform'
-	| 'normal'
-	| 'triangular'
-	| 'right-skewed'
-	| 'left-skewed';
+	'uniform' | 'normal' | 'triangular' | 'right-skewed' | 'left-skewed';
 
 /**
  * Bimodal distribution configuration with peak positions.


### PR DESCRIPTION
## 概要

`dev` ブランチ最新化後に `yarn install` → `yarn lint` を実行した際に発生した、フォーマット修正のみを反映したPRです。

ロジック変更や手動でのlintエラー修正は含んでいません。

## 変更内容

- eslint --fix / prettier による自動整形のみ
  - union型の折り返し方法の変更（`packages/@d-zero/beholder/src/meta/keys.ts`、`packages/@d-zero/shared/src/detect-compress.ts`、`packages/@d-zero/shared/src/sample-distribution.ts`）
  - 型キャストの改行スタイル変更（`packages/@d-zero/google-sheets/src/sheets/sheet.spec.ts`、`packages/@d-zero/google-sheets/src/sheets/sheets.ts`）
  - README内のコードブロック整形（`packages/@d-zero/puppeteer-dealer/README.md`）

## 確認事項

- `yarn lint` はエラー0・警告11件（既存のJSDoc関連warning、いずれも本PRの変更対象外）
- `git diff` で差分がフォーマットのみであることを確認済み
- 機密情報・案件固有情報の混入なし
