### PR TITLE
fix(github): pin renovate to platform-independent automerge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"configMigration": true,
+	"platformAutomerge": false,
 	"extends": [
 		"config:recommended",
 		"docker:pinDigests",


### PR DESCRIPTION
## 背景

このリポジトリはブランチ保護（`dev`）で `required_approving_review_count: 1` が設定されているが、`bypass_pull_request_allowances` に Renovate app が登録されており、従来 Renovate は自身の direct マージ API を使ってレビュー要件をバイパスし自動マージできていた。

今回、リポジトリ設定 `allow_auto_merge` を `false` から `true` に変更した。他リポジトリ（kamado, linters）で検証した結果、`allow_auto_merge: true` にすると Renovate の挙動が「GitHub native auto-merge 予約」方式に切り替わり、これはブランチ保護の `bypass_pull_request_allowances` を評価しないため、レビュー必須要件を満たせず CI 成功済み PR が永久にブロックされる問題が確認されている。このリポジトリは元々 `allow_auto_merge: false` の direct マージ方式でうまく機能していたため、同じ退行が起きるリスクが高い。

## 対応内容

`.github/renovate.json` のトップレベルに `platformAutomerge: false` を追加した。これにより `allow_auto_merge` の値に関わらず、Renovate は常に自前の direct マージ API（bypass が効く方式）を使うようになる。

## 影響範囲

- `.github/renovate.json` の1行追加のみ
- 既存の `packageRules` 内の automerge 設定（minor/patch 等の自動マージ対象範囲）には変更なし

## 確認事項

- [x] JSON構文検証（`node -e "JSON.parse(...)"`）
- [x] `yarn lint` パス
- [x] `yarn build` パス
- [x] `yarn test` パス（142 files / 1884 tests）
