### PR TITLE
fix(repo): allow model to invoke git/pr skills from /impl

### DIFF
--- a/.claude/skills/git/SKILL.md
+++ b/.claude/skills/git/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: git
 description: Git 操作ルール（コミット作成、メッセージ形式、事前チェック）
-disable-model-invocation: true
 ---
 
 # コミット作成

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pr
 description: プルリクエストの作成とプッシュ（プリフライトチェック、base 追従、コンフリクト検知含む）
-disable-model-invocation: true
 ---
 
 1. `dev` や `main` ではないトピックブランチにいることを確認する。


### PR DESCRIPTION
## 概要

`/impl` から呼び出される `git`・`pr` スキルの `disable-model-invocation: true` を削除しました。

## 背景

`disable-model-invocation: true` が付いたスキルは Skill ツールの起動可能スキル一覧から除外されます。そのため `/impl` の手順内から `/git`・`/pr` を Skill ツール経由で呼び出す経路が、モデルやバージョンによって失敗することがありました。この不安定さが実装フローの速度を落としていたため修正します。

対応する ai-setup 側テンプレート（オーケストレーションディレクトリ）もあわせて更新済みです。

## 変更内容

- `.claude/skills/git/SKILL.md` の `disable-model-invocation: true` を削除
- `.claude/skills/pr/SKILL.md` の `disable-model-invocation: true` を削除

## 影響

- commit・PR 作成手順自体に危険な副作用はなく、push・PR 作成をユーザー実行にする方針は変更していません
- Claude が `/impl` の外でもこれらのスキルを自発起動できるようになりますが、コミット規約に従わせる方向の変化であり安全性は損なわれません
