### PR TITLE
chore(repo): upgrade dev and CI environments to Node 26

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,12 +21,15 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
+      # Node 26 以降は corepack が同梱されないため、先に明示的にインストールする
+      - name: Install Corepack
+        run: npm install -g corepack
       - name: Enable Corepack
         run: corepack enable
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 26
           registry-url: "https://registry.npmjs.org"
       - name: Install dependencies
         run: yarn install --immutable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,10 +72,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 24
+          node-version: 26
 
+      # Node 26 以降は corepack が同梱されないため、先に明示的にインストールする
       - name: Enable Corepack and setup Yarn v4
         run: |
+          npm install -g corepack
           corepack enable
           yarn --version
 
@@ -84,7 +86,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: "**/node_modules"
-          key: os-ubuntu-latest-node24-${{ hashFiles('yarn.lock') }}
+          key: os-ubuntu-latest-node26-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
         if: steps.cache-depends.outputs.cache-hit != 'true'
@@ -107,10 +109,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 24
+          node-version: 26
 
+      # Node 26 以降は corepack が同梱されないため、先に明示的にインストールする
       - name: Enable Corepack and setup Yarn v4
         run: |
+          npm install -g corepack
           corepack enable
           yarn --version
 
@@ -119,7 +123,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: "**/node_modules"
-          key: os-${{ matrix.os }}-node24-${{ hashFiles('yarn.lock') }}
+          key: os-${{ matrix.os }}-node26-${{ hashFiles('yarn.lock') }}
 
       - name: Create .yarnrc for Windows
         if: runner.os == 'Windows' && steps.cache-depends.outputs.cache-hit != 'true'

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 	},
 	"packageManager": "yarn@4.17.0",
 	"volta": {
-		"node": "24.18.0",
+		"node": "26.7.0",
 		"yarn": "4.17.0"
 	}
 }


### PR DESCRIPTION
## Summary
- Bump the dev environment (Volta-pinned Node) and the `test`/`publish` GitHub Actions workflows to Node 26.7.0.
- Node 26 no longer bundles `corepack`, so install it explicitly via `npm install -g corepack` before `corepack enable` in every workflow job that sets up Node.
- Rename `test.yml`'s `node_modules` cache key from `node24` to `node26` to match the actual Node version it now targets.
- Package `engines` fields (`>=24.11.0`) are left untouched — they describe the minimum Node version for consumers of the published packages, independent of this repo's internal dev/CI tooling version.

## Test plan
- [x] `yarn lint` passes
- [x] `yarn build` passes
- [x] `yarn test` passes — full suite (160 files / 1989 tests)
- [ ] CI green on this PR
