### PR TITLE
fix(dealer): omit undefined prefix in Lanes verbose update without header

### DIFF
--- a/packages/@d-zero/dealer/src/lanes.spec.ts
+++ b/packages/@d-zero/dealer/src/lanes.spec.ts
@@ -45,3 +45,37 @@ describe('Lanes dispose', () => {
 		expect(process.stdout.listenerCount('resize')).toBe(resizeBefore);
 	});
 });
+
+describe('Lanes verbose update', () => {
+	test('update() without header() writes the log with no "undefined" prefix', () => {
+		using lanes = new Lanes({ verbose: true });
+
+		lanes.update(0, 'some log message');
+
+		expect(stdoutWriteSpy).toHaveBeenCalledWith(
+			expect.stringContaining('some log message'),
+		);
+		expect(stdoutWriteSpy).not.toHaveBeenCalledWith(expect.stringContaining('undefined'));
+	});
+
+	test('update() after header() still prefixes the log with the header', () => {
+		using lanes = new Lanes({ verbose: true });
+
+		lanes.header('My Header');
+		lanes.update(0, 'some log message');
+
+		const lastCall = stdoutWriteSpy.mock.calls.at(-1)?.[0] as string;
+		expect(lastCall).toContain('My Header');
+		expect(lastCall).toContain('some log message');
+	});
+
+	test('update() after header("") still writes without a prefix (empty string is falsy)', () => {
+		using lanes = new Lanes({ verbose: true });
+
+		lanes.header('');
+		lanes.update(0, 'some log message');
+
+		const lastCall = stdoutWriteSpy.mock.calls.at(-1)?.[0] as string;
+		expect(lastCall).not.toContain('undefined');
+	});
+});

--- a/packages/@d-zero/dealer/src/lanes.ts
+++ b/packages/@d-zero/dealer/src/lanes.ts
@@ -115,13 +115,14 @@ export class Lanes {
 	}
 	/**
 	 * 指定した ID のログを更新する。
-	 * verbose モードではヘッダーとログを連結して即時出力する。
+	 * verbose モードではヘッダー設定済みならヘッダーとログを連結し、未設定なら
+	 * ログのみを即時出力する。
 	 * @param id - 更新するログの ID
 	 * @param log - ログメッセージ
 	 */
 	update(id: number, log: string) {
 		if (this.#verbose) {
-			this.#display.write(`${RESET}${this.#header}${RESET} ${log}`);
+			this.#display.write(this.#header ? `${RESET}${this.#header}${RESET} ${log}` : log);
 			return;
 		}
 


### PR DESCRIPTION
## Summary

- Fixes #953: `Lanes` in verbose mode printed a literal `undefined` prefix on every line when `update()` was called before `header()` was ever set, since `#header` (initial value `undefined`) was unconditionally interpolated into the output string.
- `update()` now only prepends the header when one has actually been set, matching the existing `if (this.#header)` guard already used by the non-verbose `write()` path.

## Test plan

- [x] Added tests covering: no header set (no `undefined` prefix), header set (prefix present), and empty-string header (falsy, no prefix)
- [x] `yarn lint`
- [x] `yarn build`
- [x] `yarn test` (full suite, 1992 tests passed)
