### PR TITLE
feat(dealer): add type-safe sequential pipeline with live task-list TUI

### DIFF
--- a/packages/@d-zero/dealer/README.md
+++ b/packages/@d-zero/dealer/README.md
@@ -1,6 +1,7 @@
 # `@d-zero/dealer`
 
-コレクションを並列処理し、ログを順次出力する API。並列数制御・キャンセル・進捗ヘッダー対応。
+コレクションを並列処理し、ログを順次出力する API（`deal`。並列数制御・キャンセル・進捗ヘッダー対応）と、
+型安全な逐次パイプラインを構築するとタスクリストTUIが自動生成される API（`TaskList`）を提供する。
 
 ## Installation
 
@@ -37,6 +38,27 @@ await deal(items, setup, { limit: 10, signal: controller.signal });
 ```
 
 abort 時の挙動: **新規ワーカー起動を停止、実行中ワーカーは完了まで待機、`push`/`unshift` は無視**。詳細は `src/deal.ts` / `src/dealer.ts` の JSDoc。
+
+## Sequential Pipeline（`TaskList`）
+
+```ts
+import { TaskList } from '@d-zero/dealer';
+
+const id = await TaskList.pipe('fetch', async () => fetchUser(userId))
+	.pipe('normalize', (user) => normalizeUser(user))
+	.pipe('save', async (user, ctx) => {
+		ctx.progress('writing to db...');
+		await db.save(user);
+		return user.id;
+	})
+	.run();
+```
+
+`.pipe()` を連結するたびに前段の戻り値を受け取り型変換する新しいステップが追加され、`run()` を呼ぶと全ステップを最初から `[ ] タスク名: 進捗メッセージ` の形式で表示し、先頭から逐次実行しながら状態（pending/running/done/error）を更新する。あるステップが失敗すると即座に停止し、`TaskListStepError` で reject する（後続ステップは実行されない）。
+
+- 各パイプラインインスタンスの `run()` は1回のみ呼び出せる（再実行したい場合は `TaskList.pipe()` から新しく構築する）
+- `ctx.insertNext()` で、実行中に同じ型のステップを直後へ動的に割り込み挿入できる
+- 詳細は `src/task-list-pipeline.ts` / `src/types.ts` の JSDoc を参照
 
 ## 重要な制約
 

--- a/packages/@d-zero/dealer/package.json
+++ b/packages/@d-zero/dealer/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@d-zero/dealer",
 	"version": "1.11.0",
-	"description": "A tool that provides an API and CLI for parallel processing of collections and sequential logging to standard output",
+	"description": "A tool that provides an API and CLI for parallel processing of collections and sequential logging to standard output, plus a type-safe sequential pipeline builder that renders a live task-list TUI while running",
 	"author": "D-ZERO",
 	"license": "MIT",
 	"publishConfig": {

--- a/packages/@d-zero/dealer/src/describe-cause.spec.ts
+++ b/packages/@d-zero/dealer/src/describe-cause.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from 'vitest';
+
+import { describeCause } from './describe-cause.js';
+
+test('returns the message of an Error instance', () => {
+	expect(describeCause(new Error('boom'))).toBe('boom');
+});
+
+test('stringifies a non-Error thrown value', () => {
+	expect(describeCause('boom')).toBe('boom');
+});

--- a/packages/@d-zero/dealer/src/describe-cause.ts
+++ b/packages/@d-zero/dealer/src/describe-cause.ts
@@ -1,0 +1,16 @@
+/**
+ * 例外・スロー値（`unknown`）を1行の説明文に変換する。`Error` インスタンスなら
+ * `message` を、それ以外は `String()` による文字列表現を返す。
+ * {@link TaskListStepError} のメッセージ生成と、`TaskListPipeline.run` 実行中の
+ * エラー行表示の両方で、同じ説明文を使うために共有する。
+ * @param cause - 説明文に変換する値
+ * @returns 1行の説明文
+ * @example
+ * ```ts
+ * describeCause(new Error('boom')); // 'boom'
+ * describeCause('boom'); // 'boom'
+ * ```
+ */
+export function describeCause(cause: unknown): string {
+	return cause instanceof Error ? cause.message : String(cause);
+}

--- a/packages/@d-zero/dealer/src/format-elapsed.spec.ts
+++ b/packages/@d-zero/dealer/src/format-elapsed.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from 'vitest';
+
+import { formatElapsed } from './format-elapsed.js';
+
+test('formats whole seconds with one decimal place', () => {
+	expect(formatElapsed(3000)).toBe('(3.0s)');
+});
+
+test('formats sub-second durations rounded to one decimal place', () => {
+	expect(formatElapsed(3400)).toBe('(3.4s)');
+});
+
+test('formats zero elapsed time', () => {
+	expect(formatElapsed(0)).toBe('(0.0s)');
+});

--- a/packages/@d-zero/dealer/src/format-elapsed.ts
+++ b/packages/@d-zero/dealer/src/format-elapsed.ts
@@ -1,0 +1,11 @@
+const MS_PER_SECOND = 1000;
+
+/**
+ * 経過時間をタスク行の末尾に表示する形式（例: `(3.4s)`）に変換する。
+ * @param elapsedMs - 経過時間（ミリ秒）
+ * @returns `(<秒数>s)` 形式の文字列
+ */
+export function formatElapsed(elapsedMs: number): string {
+	const seconds = elapsedMs / MS_PER_SECOND;
+	return `(${seconds.toFixed(1)}s)`;
+}

--- a/packages/@d-zero/dealer/src/format-task-line.spec.ts
+++ b/packages/@d-zero/dealer/src/format-task-line.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from 'vitest';
+
+import { formatTaskLine } from './format-task-line.js';
+
+test('renders a pending step with no message as just the icon and name', () => {
+	expect(formatTaskLine('pending', 'fetch', '')).toBe('[ ] fetch');
+});
+
+test('appends the message after a colon when present', () => {
+	expect(formatTaskLine('running', 'fetch', 'downloading...')).toBe(
+		'[%taskSpin%] fetch: downloading...',
+	);
+});
+
+test('appends the elapsed time after the message when provided', () => {
+	expect(formatTaskLine('running', 'fetch', 'downloading...', 3400)).toBe(
+		'[%taskSpin%] fetch: downloading... (3.4s)',
+	);
+});
+
+test('omits the elapsed time when not provided', () => {
+	expect(formatTaskLine('done', 'fetch', 'done')).not.toContain('(');
+});
+
+test('renders the done icon with a checkmark character', () => {
+	expect(formatTaskLine('done', 'fetch', '')).toContain('✔');
+});
+
+test('renders the error icon with a cross character', () => {
+	expect(formatTaskLine('error', 'fetch', 'network down')).toContain('✘');
+});

--- a/packages/@d-zero/dealer/src/format-task-line.ts
+++ b/packages/@d-zero/dealer/src/format-task-line.ts
@@ -1,0 +1,24 @@
+import type { TaskState } from './types.js';
+
+import { formatElapsed } from './format-elapsed.js';
+import { ICON } from './task-icons.js';
+
+/**
+ * `TaskListPipeline` の1行を `[状態アイコン] タスク名: 進捗メッセージ (経過時間)` の
+ * 形式に整形する。`message` が空文字の場合はコロン以降を省略する。
+ * @param state - タスクの実行状態
+ * @param name - タスク名
+ * @param message - 進捗メッセージ（未設定なら空文字）
+ * @param elapsedMs - 経過時間（ミリ秒）。指定時のみ行末に付与する
+ * @returns 整形済みの1行分の文字列
+ */
+export function formatTaskLine(
+	state: TaskState,
+	name: string,
+	message: string,
+	elapsedMs?: number,
+): string {
+	const label = message ? `${name}: ${message}` : name;
+	const elapsed = elapsedMs == null ? '' : ` ${formatElapsed(elapsedMs)}`;
+	return `${ICON[state]} ${label}${elapsed}`;
+}

--- a/packages/@d-zero/dealer/src/from.spec.ts
+++ b/packages/@d-zero/dealer/src/from.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { from } from './from.js';
+
+let stdoutWriteSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+	stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+});
+
+afterEach(() => {
+	stdoutWriteSpy.mockRestore();
+});
+
+test('starts with no steps registered', () => {
+	const pipeline = from(42);
+
+	expect(pipeline.steps).toStrictEqual([]);
+});
+
+test('passes the initial value into the first piped step', async () => {
+	const pipeline = from(42).pipe('double', (n) => n * 2);
+
+	await expect(pipeline.run()).resolves.toBe(84);
+});
+
+test('resolves with the initial value untouched when no steps are piped', async () => {
+	const pipeline = from('seed');
+
+	await expect(pipeline.run()).resolves.toBe('seed');
+});

--- a/packages/@d-zero/dealer/src/from.ts
+++ b/packages/@d-zero/dealer/src/from.ts
@@ -1,0 +1,16 @@
+import { TaskListPipeline } from './task-list-pipeline.js';
+
+/**
+ * 既知の初期値からパイプラインを開始する。{@link pipe} と異なり、この初期値は
+ * TUI 上のタスク行として表示されない（最初のステップへの入力の種にすぎない）。
+ * @template T - 初期値の型
+ * @param value - 最初のステップに渡す初期値
+ * @returns まだステップを持たない、型が `T` の新しいパイプライン
+ * @example
+ * ```ts
+ * const pipeline = from(42).pipe('double', (n) => n * 2);
+ * ```
+ */
+export function from<T>(value: T): TaskListPipeline<T> {
+	return new TaskListPipeline<T>([], value);
+}

--- a/packages/@d-zero/dealer/src/index.ts
+++ b/packages/@d-zero/dealer/src/index.ts
@@ -2,3 +2,13 @@ export type { DealOptions, DealHeader } from './deal.js';
 export { deal } from './deal.js';
 export { Dealer } from './dealer.js';
 export { Lanes } from './lanes.js';
+export type {
+	StepContext,
+	StepFn,
+	TaskListRunOptions,
+	TaskListStepSnapshot,
+	TaskState,
+} from './types.js';
+export type { TaskListPipeline } from './task-list-pipeline.js';
+export { TaskListStepError } from './task-list-step-error.js';
+export { TaskList } from './task-list.js';

--- a/packages/@d-zero/dealer/src/pipe.spec.ts
+++ b/packages/@d-zero/dealer/src/pipe.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { pipe } from './pipe.js';
+
+let stdoutWriteSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+	stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+});
+
+afterEach(() => {
+	stdoutWriteSpy.mockRestore();
+});
+
+test('registers the first step as pending before running', () => {
+	const pipeline = pipe('fetch', () => 1);
+
+	expect(pipeline.steps).toStrictEqual([
+		{ name: 'fetch', state: 'pending', message: '' },
+	]);
+});
+
+test('resolves with the first step return value when run without further pipe() calls', async () => {
+	const pipeline = pipe('answer', () => 42);
+
+	await expect(pipeline.run()).resolves.toBe(42);
+});
+
+test('the first step receives undefined as input', async () => {
+	const pipeline = pipe('identity', (input) => input);
+
+	await expect(pipeline.run()).resolves.toBeUndefined();
+});

--- a/packages/@d-zero/dealer/src/pipe.ts
+++ b/packages/@d-zero/dealer/src/pipe.ts
@@ -1,0 +1,20 @@
+import type { StepFn } from './types.js';
+
+import { TaskListPipeline } from './task-list-pipeline.js';
+
+/**
+ * 新しいパイプラインを開始する。最初のステップは入力を受け取らない
+ * （`fn` の入力型は常に `undefined`）。既知の初期値から始めたい場合は
+ * {@link from} を使うこと。
+ * @template R - 最初のステップの出力型
+ * @param name - TUI に表示するタスク名
+ * @param fn - 最初のステップの処理内容
+ * @returns 型が `R` の新しいパイプライン
+ * @example
+ * ```ts
+ * const pipeline = pipe('fetch', () => fetchUser(userId));
+ * ```
+ */
+export function pipe<R>(name: string, fn: StepFn<undefined, R>): TaskListPipeline<R> {
+	return new TaskListPipeline<undefined>([]).pipe(name, fn);
+}

--- a/packages/@d-zero/dealer/src/task-icons.spec.ts
+++ b/packages/@d-zero/dealer/src/task-icons.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from 'vitest';
+
+import { ICON, TASK_LIST_ANIMATIONS } from './task-icons.js';
+
+test('pending and running icons keep the brackets uncolored', () => {
+	expect(ICON.pending).toBe('[ ]');
+	expect(ICON.running).toBe('[%taskSpin%]');
+});
+
+test('done and error icons wrap a colored checkmark/cross inside plain brackets', () => {
+	expect(ICON.done.startsWith('[')).toBe(true);
+	expect(ICON.done.endsWith(']')).toBe(true);
+	expect(ICON.done).toContain('✔');
+
+	expect(ICON.error.startsWith('[')).toBe(true);
+	expect(ICON.error.endsWith(']')).toBe(true);
+	expect(ICON.error).toContain('✘');
+});
+
+test('taskSpin animation matches the %taskSpin% placeholder used by ICON.running', () => {
+	expect(ICON.running).toBe('[%taskSpin%]');
+	expect(TASK_LIST_ANIMATIONS.taskSpin).toBeDefined();
+});
+
+test('taskSpin is a 10-frame braille spinner at 12fps', () => {
+	const [fps, ...sprites] = TASK_LIST_ANIMATIONS.taskSpin!;
+
+	expect(fps).toBe(12);
+	expect(sprites).toStrictEqual(['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']);
+});

--- a/packages/@d-zero/dealer/src/task-icons.ts
+++ b/packages/@d-zero/dealer/src/task-icons.ts
@@ -1,0 +1,24 @@
+import type { Animations } from './types.js';
+
+import c from 'ansi-colors';
+
+/**
+ * `TaskListPipeline` の状態アイコン。`[`/`]` のブラケット自体は常に無色のまま固定し、
+ * 中の記号だけを色付けする。色が無効な環境（`NO_COLOR`・非TTY）でも記号の形状自体で
+ * 状態を判別できるようにするための意図的な制約。
+ */
+export const ICON = {
+	pending: '[ ]',
+	running: '[%taskSpin%]',
+	done: `[${c.green('✔')}]`,
+	error: `[${c.red('✘')}]`,
+} as const;
+
+/**
+ * `Lanes`/`Display` の `animations` オプションに渡すスピナー定義。
+ * 10フレームの braille スピナー。この fps はアニメーション単体の進行速度であり、
+ * `LanesOptions.fps`（`Display` 全体の再描画間隔）とは独立している。
+ */
+export const TASK_LIST_ANIMATIONS: Animations = {
+	taskSpin: [12, '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'],
+};

--- a/packages/@d-zero/dealer/src/task-list-pipeline.spec.ts
+++ b/packages/@d-zero/dealer/src/task-list-pipeline.spec.ts
@@ -1,0 +1,206 @@
+import { Writable } from 'node:stream';
+
+import { test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { pipe } from './pipe.js';
+
+/**
+ * `Writable` stub for stream-option tests. Collects every chunk into an
+ * in-memory buffer and exposes the concatenated string so assertions can
+ * grep for expected fragments (mirrors display.spec.ts's helper).
+ */
+function makeStreamCollector(): {
+	readonly stream: NodeJS.WritableStream;
+	read(): string;
+} {
+	const chunks: Buffer[] = [];
+	const stream = new Writable({
+		write(chunk: Buffer | string, _encoding, cb) {
+			chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+			cb();
+		},
+	});
+	return { stream, read: () => Buffer.concat(chunks).toString('utf8') };
+}
+
+let stdoutWriteSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+	stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+});
+
+afterEach(() => {
+	stdoutWriteSpy.mockRestore();
+});
+
+test('exposes all steps as pending before run() is called', () => {
+	const pipeline = pipe('one', () => 1).pipe('two', (n) => n + 1);
+
+	expect(pipeline.steps).toStrictEqual([
+		{ name: 'one', state: 'pending', message: '' },
+		{ name: 'two', state: 'pending', message: '' },
+	]);
+});
+
+test('carries the transformed value through each pipe() step and resolves with the last one', async () => {
+	const pipeline = pipe('one', () => 1)
+		.pipe('double', (n) => n * 2)
+		.pipe('stringify', (n) => `value:${n}`);
+
+	await expect(pipeline.run()).resolves.toBe('value:2');
+});
+
+test('marks steps done after a successful run and keeps the last progress message', async () => {
+	const pipeline = pipe('work', (_input, ctx) => {
+		ctx.progress('halfway');
+		return 'ok';
+	});
+
+	await pipeline.run();
+
+	expect(pipeline.steps).toStrictEqual([
+		{ name: 'work', state: 'done', message: 'halfway' },
+	]);
+});
+
+test('rejects with TaskListStepError and stops before later steps on failure', async () => {
+	const thirdRun = vi.fn();
+	const original = new Error('boom');
+	const pipeline = pipe('first', () => 1)
+		.pipe('second', () => {
+			throw original;
+		})
+		.pipe('third', thirdRun);
+
+	await expect(pipeline.run()).rejects.toMatchObject({
+		name: 'TaskListStepError',
+		stepName: 'second',
+		stepIndex: 1,
+		cause: original,
+	});
+
+	expect(thirdRun).not.toHaveBeenCalled();
+	expect(pipeline.steps).toStrictEqual([
+		{ name: 'first', state: 'done', message: '' },
+		{ name: 'second', state: 'error', message: expect.stringContaining('boom') },
+		{ name: 'third', state: 'pending', message: '' },
+	]);
+});
+
+test('insertNext runs the inserted step immediately after the current one, and multiple calls preserve call order', async () => {
+	const order: string[] = [];
+	const pipeline = pipe('first', (_input, ctx) => {
+		order.push('first');
+		ctx.insertNext('inserted-a', () => {
+			order.push('inserted-a');
+		});
+		ctx.insertNext('inserted-b', () => {
+			order.push('inserted-b');
+		});
+	}).pipe('second', () => {
+		order.push('second');
+	});
+
+	await pipeline.run();
+
+	expect(order).toStrictEqual(['first', 'inserted-a', 'inserted-b', 'second']);
+});
+
+test('insertNext does not scramble the display order of existing steps', async () => {
+	const collector = makeStreamCollector();
+	const pipeline = pipe('first', (_input, ctx) => {
+		ctx.insertNext('inserted', () => {});
+	}).pipe('second', () => {});
+
+	await pipeline.run({ stream: collector.stream, showElapsed: false });
+
+	const output = collector.read();
+	const firstPos = output.lastIndexOf('first');
+	const insertedPos = output.lastIndexOf('inserted');
+	const secondPos = output.lastIndexOf('second');
+
+	expect(firstPos).toBeGreaterThanOrEqual(0);
+	expect(firstPos).toBeLessThan(insertedPos);
+	expect(insertedPos).toBeLessThan(secondPos);
+});
+
+test('branching does not leak run() state mutations back into the original pipeline', async () => {
+	const base = pipe('shared', () => 'value');
+	const branchA = base.pipe('a-only', (v) => `${v}-a`);
+	const branchB = base.pipe('b-only', (v) => `${v}-b`);
+
+	await branchA.run();
+
+	expect(base.steps).toStrictEqual([{ name: 'shared', state: 'pending', message: '' }]);
+	expect(branchB.steps).toStrictEqual([
+		{ name: 'shared', state: 'pending', message: '' },
+		{ name: 'b-only', state: 'pending', message: '' },
+	]);
+	expect(branchA.steps).toStrictEqual([
+		{ name: 'shared', state: 'done', message: '' },
+		{ name: 'a-only', state: 'done', message: '' },
+	]);
+});
+
+test('rejects a concurrent run() on the same instance while one is already in flight', async () => {
+	const pipeline = pipe('slow', async () => {
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		return 'done';
+	});
+
+	const first = pipeline.run();
+	await expect(pipeline.run()).rejects.toThrow(/already in progress/);
+
+	await expect(first).resolves.toBe('done');
+});
+
+test('rejects a second run() after the first one already completed successfully', async () => {
+	const pipeline = pipe('task', () => 'ok');
+
+	await expect(pipeline.run()).resolves.toBe('ok');
+	await expect(pipeline.run()).rejects.toThrow(/already completed/);
+});
+
+test('rejects a second run() after the first one already failed', async () => {
+	const pipeline = pipe('task', () => {
+		throw new Error('boom');
+	});
+
+	await expect(pipeline.run()).rejects.toThrow(/boom/);
+	await expect(pipeline.run()).rejects.toThrow(/already completed/);
+});
+
+test('a step that calls insertNext does not duplicate the inserted step across separate run() calls', async () => {
+	// insertNext splices into the shared #steps array; without the single-use
+	// guard on run(), a second run() would re-run the leftover inserted step
+	// from the first run AND insert a brand new one, duplicating side effects.
+	const pipeline = pipe('first', (_input, ctx) => {
+		ctx.insertNext('inserted', () => {});
+	}).pipe('second', () => {});
+
+	await pipeline.run();
+
+	expect(pipeline.steps.map((step) => step.name)).toStrictEqual([
+		'first',
+		'inserted',
+		'second',
+	]);
+	await expect(pipeline.run()).rejects.toThrow(/already completed/);
+	expect(pipeline.steps.map((step) => step.name)).toStrictEqual([
+		'first',
+		'inserted',
+		'second',
+	]);
+});
+
+test('clears the elapsed-time interval once the running step settles', async () => {
+	vi.useFakeTimers();
+	try {
+		const pipeline = pipe('task', () => 'ok');
+		await pipeline.run();
+
+		expect(vi.getTimerCount()).toBe(0);
+	} finally {
+		vi.useRealTimers();
+	}
+});

--- a/packages/@d-zero/dealer/src/task-list-pipeline.ts
+++ b/packages/@d-zero/dealer/src/task-list-pipeline.ts
@@ -1,0 +1,234 @@
+import type {
+	StepContext,
+	StepFn,
+	TaskListRunOptions,
+	TaskListStepSnapshot,
+	TaskState,
+} from './types.js';
+
+import { describeCause } from './describe-cause.js';
+import { formatTaskLine } from './format-task-line.js';
+import { Lanes } from './lanes.js';
+import { TASK_LIST_ANIMATIONS } from './task-icons.js';
+import { TaskListStepError } from './task-list-step-error.js';
+
+const DEFAULT_ELAPSED_INTERVAL_MS = 250;
+
+/**
+ * パイプライン内部専用の、型消去済みステップ表現。
+ * @internal
+ */
+interface StepRecord {
+	readonly name: string;
+	readonly fn: (input: unknown, ctx: StepContext<unknown>) => unknown | Promise<unknown>;
+	/**
+	 * `Lanes.update()` の `id` として使う、生成時点で確定する固有の識別子。
+	 * 配列内の物理的な位置（`insertNext` による動的挿入で変化する）とは独立しており、
+	 * 常に正しい表示順を保つ。初期ステップは整数、`insertNext` による挿入分は
+	 * 前後の `laneId` の中間値を割る。
+	 */
+	readonly laneId: number;
+	state: TaskState;
+	message: string;
+}
+
+/**
+ * `TaskList.pipe()` / `TaskList.from()` から構築される、型安全なステップ連結パイプライン。
+ *
+ * `.pipe()` を呼ぶたびに新しいインスタンスを返すイミュータブルなビルダーであり、
+ * 型パラメータ `T` は「このパイプラインを `run()` した際に解決される値の型」を表す。
+ * 直接 `new` せず `TaskList.pipe()` / `TaskList.from()` を起点にすること。
+ * @template T - `run()` が解決する値の型
+ * @example
+ * ```ts
+ * const id = await TaskList.pipe('fetch', async () => fetchUser(userId))
+ *   .pipe('normalize', (user) => normalizeUser(user))
+ *   .pipe('save', async (user, ctx) => {
+ *     ctx.progress('writing to db...');
+ *     await db.save(user);
+ *     return user.id;
+ *   })
+ *   .run();
+ * ```
+ */
+export class TaskListPipeline<T> {
+	#hasRun = false;
+	readonly #initial: unknown;
+	#running = false;
+	readonly #steps: StepRecord[];
+
+	/**
+	 * 実行前・実行中を問わず取得できる、現時点のステップ一覧のスナップショット。
+	 * `run()` 前は全件 `pending` / `message: ''` で返る。
+	 */
+	get steps(): readonly TaskListStepSnapshot[] {
+		return this.#steps.map(toSnapshot);
+	}
+
+	/**
+	 * `TaskList.pipe()` / `TaskList.from()` / 既存パイプラインの `.pipe()` 以外から
+	 * 呼び出さないこと。
+	 * @param steps
+	 * @param initial
+	 * @internal
+	 */
+	constructor(steps: readonly StepRecord[], initial?: unknown) {
+		// 各 StepRecord を clone する。配列の浅コピーだけだとレコード自体が旧インスタンスと
+		// 共有され、run() の state/message 書き換えが分岐元パイプラインの表示状態を汚染する。
+		this.#steps = steps.map((step) => ({ ...step }));
+		this.#initial = initial;
+	}
+
+	/**
+	 * 直前ステップの出力 `T` を受け取り `R` へ変換する新しいステップを連結する。
+	 * 呼び出し元のインスタンスは変更されず、新しい `TaskListPipeline<R>` を返す。
+	 * @param name - TUI に表示するタスク名
+	 * @param fn - 直前の出力を受け取り、変換後の値を返すステップ関数
+	 * @returns 型が `R` に更新された新しいパイプライン
+	 */
+	pipe<R>(name: string, fn: StepFn<T, R>): TaskListPipeline<R> {
+		const nextStep: StepRecord = {
+			name,
+			fn: fn as StepRecord['fn'],
+			laneId: this.#steps.length,
+			state: 'pending',
+			message: '',
+		};
+		return new TaskListPipeline<R>([...this.#steps, nextStep], this.#initial);
+	}
+
+	/**
+	 * 先頭から順にステップを実行し、`Lanes` を使ってターミナルに複数行の状態リストを
+	 * 描画する。いずれかのステップが例外を投げた場合は即座に停止し、後続ステップは
+	 * 実行されない（残りは `pending` のまま確定する）。
+	 *
+	 * 同一インスタンスに対しては1回しか呼び出せない（成功・失敗を問わない）。
+	 * `state`/`message` を直接書き換え、`insertNext` が `#steps` を永続的に
+	 * 成長させるため、2回目の呼び出しは以前の実行で挿入されたステップの重複実行を
+	 * 引き起こす。再実行したい場合は `TaskList.pipe()` / `.pipe()` から新しい
+	 * パイプラインを構築すること。
+	 * @param options - 描画・出力先の設定
+	 * @returns 最終ステップの出力で解決される Promise。失敗時は {@link TaskListStepError} で reject する
+	 */
+	async run(options?: TaskListRunOptions): Promise<T> {
+		if (this.#running) {
+			throw new Error('TaskListPipeline.run() is already in progress on this instance.');
+		}
+		if (this.#hasRun) {
+			throw new Error(
+				'TaskListPipeline.run() has already completed on this instance. Build a fresh pipeline via TaskList.pipe()/.pipe() to run again.',
+			);
+		}
+		this.#running = true;
+		this.#hasRun = true;
+
+		try {
+			return await this.#run(options);
+		} finally {
+			this.#running = false;
+		}
+	}
+
+	async #run(options?: TaskListRunOptions): Promise<T> {
+		const verbose = options?.verbose ?? false;
+		// verbose モードでは Lanes.update() が上書きではなく毎回1行追記になるため、
+		// 経過時間タイマーによる高頻度の再描画はログ洪水になる。常に無効化する。
+		const showElapsed = (options?.showElapsed ?? true) && !verbose;
+		const elapsedIntervalMs = options?.elapsedIntervalMs ?? DEFAULT_ELAPSED_INTERVAL_MS;
+
+		using lanes = new Lanes({
+			stream: options?.stream,
+			verbose,
+			animations: TASK_LIST_ANIMATIONS,
+		});
+
+		for (const step of this.#steps) {
+			lanes.update(step.laneId, formatTaskLine('pending', step.name, ''));
+		}
+
+		let value: unknown = this.#initial;
+		let index = 0;
+
+		while (index < this.#steps.length) {
+			const step = this.#steps[index]!;
+			step.state = 'running';
+			step.message = '';
+
+			const startedAt = Date.now();
+			const render = () => {
+				const elapsedMs = showElapsed ? Date.now() - startedAt : undefined;
+				lanes.update(
+					step.laneId,
+					formatTaskLine('running', step.name, step.message, elapsedMs),
+				);
+			};
+			render();
+
+			const timer = showElapsed ? setInterval(render, elapsedIntervalMs) : null;
+
+			// insertNext を同一ステップ中に複数回呼んだ場合、呼び出し順（a→b）で実行される
+			// ように、直前に挿入したステップの位置を追い続ける（常に index+1 に挿入すると
+			// 後着ちの呼び出しが先着ちより前に来てしまう）。
+			let insertCursor = index;
+			const ctx: StepContext<unknown> = {
+				progress: (message) => {
+					if (step.state !== 'running') {
+						return;
+					}
+					step.message = message;
+					render();
+				},
+				insertNext: (name, fn) => {
+					if (step.state !== 'running') {
+						return;
+					}
+					const prevLaneId = this.#steps[insertCursor]!.laneId;
+					const nextLaneId = this.#steps[insertCursor + 1]?.laneId;
+					const laneId =
+						nextLaneId == null ? prevLaneId + 1 : (prevLaneId + nextLaneId) / 2;
+					this.#steps.splice(insertCursor + 1, 0, {
+						name,
+						fn: fn as StepRecord['fn'],
+						laneId,
+						state: 'pending',
+						message: '',
+					});
+					lanes.update(laneId, formatTaskLine('pending', name, ''));
+					insertCursor++;
+				},
+			};
+
+			try {
+				value = await step.fn(value, ctx);
+			} catch (error_) {
+				if (timer) {
+					clearInterval(timer);
+				}
+				const error = new TaskListStepError(step.name, index, error_);
+				step.state = 'error';
+				step.message = error.message;
+				lanes.update(
+					step.laneId,
+					formatTaskLine('error', step.name, describeCause(error_)),
+				);
+				throw error;
+			}
+
+			if (timer) {
+				clearInterval(timer);
+			}
+			step.state = 'done';
+			lanes.update(step.laneId, formatTaskLine('done', step.name, step.message));
+			index++;
+		}
+
+		return value as T;
+	}
+}
+
+/**
+ * @param step
+ */
+function toSnapshot(step: StepRecord): TaskListStepSnapshot {
+	return { name: step.name, state: step.state, message: step.message };
+}

--- a/packages/@d-zero/dealer/src/task-list-step-error.spec.ts
+++ b/packages/@d-zero/dealer/src/task-list-step-error.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from 'vitest';
+
+import { TaskListStepError } from './task-list-step-error.js';
+
+test('keeps the original Error as cause and reports name/index in the message', () => {
+	const original = new Error('network down');
+	const error = new TaskListStepError('fetch', 1, original);
+
+	expect(error).toBeInstanceOf(Error);
+	expect(error.name).toBe('TaskListStepError');
+	expect(error.stepName).toBe('fetch');
+	expect(error.stepIndex).toBe(1);
+	expect(error.cause).toBe(original);
+	expect(error.message).toBe('Step "fetch" (index: 1) failed: network down');
+});
+
+test('describes a non-Error thrown value with String()', () => {
+	const error = new TaskListStepError('save', 2, 'boom');
+
+	expect(error.cause).toBe('boom');
+	expect(error.message).toBe('Step "save" (index: 2) failed: boom');
+});

--- a/packages/@d-zero/dealer/src/task-list-step-error.ts
+++ b/packages/@d-zero/dealer/src/task-list-step-error.ts
@@ -1,0 +1,31 @@
+import { describeCause } from './describe-cause.js';
+
+/**
+ * {@link TaskListPipeline.run} 中にステップが例外を投げたときに reject される値。
+ * 元の例外・スロー値（`unknown`）は `Error#cause` にそのまま保持し、失敗箇所を
+ * `stepName`/`stepIndex` で特定できるようにする。
+ * @example
+ * ```ts
+ * try {
+ *   await pipeline.run();
+ * } catch (error) {
+ *   if (error instanceof TaskListStepError) {
+ *     console.error(`${error.stepName} (#${error.stepIndex}) failed`, error.cause);
+ *   }
+ * }
+ * ```
+ */
+export class TaskListStepError extends Error {
+	readonly stepIndex: number;
+	readonly stepName: string;
+
+	constructor(stepName: string, stepIndex: number, cause: unknown) {
+		super(`Step "${stepName}" (index: ${stepIndex}) failed: ${describeCause(cause)}`, {
+			cause,
+		});
+		this.stepName = stepName;
+		this.stepIndex = stepIndex;
+	}
+
+	override name = 'TaskListStepError';
+}

--- a/packages/@d-zero/dealer/src/task-list.ts
+++ b/packages/@d-zero/dealer/src/task-list.ts
@@ -1,0 +1,23 @@
+import { from } from './from.js';
+import { pipe } from './pipe.js';
+
+/**
+ * 型安全な逐次パイプライン・ビルダーのエントリポイント。
+ * `.pipe()` で連結するたびに前段の出力型 `T` を受け取り `R` へ変換する新しい
+ * ステップが追加され、`.run()` を呼ぶと `Lanes` を使ったタスクリストTUIが
+ * 自動的に生成され、先頭から逐次実行される。
+ * @example
+ * ```ts
+ * import { TaskList } from '@d-zero/dealer';
+ *
+ * const result = await TaskList.pipe('fetch', () => fetchUser(userId))
+ *   .pipe('normalize', (user) => normalizeUser(user))
+ *   .pipe('save', async (user, ctx) => {
+ *     ctx.progress('writing to db...');
+ *     await db.save(user);
+ *     return user.id;
+ *   })
+ *   .run();
+ * ```
+ */
+export const TaskList = { pipe, from } as const;

--- a/packages/@d-zero/dealer/src/types.ts
+++ b/packages/@d-zero/dealer/src/types.ts
@@ -20,3 +20,103 @@ export type FPS = 12 | 24 | 30 | 60;
 export interface ProcessInitializer<T> {
 	(process: T, index: number): Promise<() => Promise<void> | void>;
 }
+
+/**
+ * {@link TaskListPipeline} の各ステップの実行状態。
+ * - `pending`: 未実行
+ * - `running`: 実行中（{@link StepContext.progress} によるメッセージ更新を受け付ける）
+ * - `done`: 正常終了
+ * - `error`: 例外により終了（この状態になった時点でパイプライン全体が停止する）
+ * @example
+ * ```ts
+ * const stillPending = pipeline.steps.filter((step) => step.state === 'pending');
+ * ```
+ */
+export type TaskState = 'pending' | 'running' | 'done' | 'error';
+
+/**
+ * ステップ関数に渡される実行コンテキスト。
+ * @template R - このステップ自身の出力型。{@link StepContext.insertNext} で挿入する
+ * ステップは、直後の既存ステップが期待する入力型と同じ `R` でなければならない
+ * （型が変わる割り込みは、直後の既存ステップの入力型が構築時に確定済みであるため
+ * 静的に安全にできない。同一型限定のワークアラウンドとして提供する）。
+ * @example
+ * ```ts
+ * TaskList.pipe('fetch page', async (_input, ctx) => {
+ *   ctx.progress('downloading...');
+ *   const page = await fetchPage();
+ *   if (page.hasNext) {
+ *     // 同じ型（Page）を受け取り Page を返すステップだけ割り込み挿入できる
+ *     ctx.insertNext('fetch next page', (prev) => fetchPage(prev.nextUrl));
+ *   }
+ *   return page;
+ * });
+ * ```
+ */
+export interface StepContext<R> {
+	/**
+	 * 実行中の進捗メッセージを更新する。
+	 * 同期・戻り値なし・例外を投げない契約。ステップが `done`/`error` に確定した後の
+	 * 呼び出しは無視される。
+	 * @param message - 表示する進捗メッセージ
+	 */
+	progress(message: string): void;
+	/**
+	 * 現在のステップの直後に、同じ型 `R` を受け取り `R` を返すステップを実行時に
+	 * 割り込み挿入する。挿入されたステップは元々直後に控えていたステップより先に
+	 * 実行される。同一ステップ中に複数回呼んだ場合は呼び出し順に実行される
+	 * （2回目以降は直前に挿入したステップの直後に挿入する）。
+	 * @param name - TUI に表示するタスク名
+	 * @param fn - 割り込み挿入するステップの処理内容
+	 */
+	insertNext(name: string, fn: StepFn<R, R>): void;
+}
+
+/**
+ * {@link TaskListPipeline} の1ステップを表す関数。同期・非同期どちらでもよい。
+ * variance 注釈（`in`/`out`）は付けない。{@link StepContext} が
+ * `insertNext(fn: StepFn<R, R>)` を持つため `R` は不変（invariant）であり、
+ * `out R` と宣言するとコンパイラに拒否される。
+ * @template T - 直前のステップの出力型（このステップの入力）
+ * @template R - このステップの出力型
+ * @example
+ * ```ts
+ * const double: StepFn<number, number> = (n) => n * 2;
+ * ```
+ */
+export type StepFn<T, R> = (input: T, ctx: StepContext<R>) => R | Promise<R>;
+
+/**
+ * 実行前・実行中を問わず取得できる、ステップ1件分の型消去済みスナップショット。
+ * @example
+ * ```ts
+ * const stillPending = pipeline.steps.filter((step) => step.state === 'pending');
+ * console.log(stillPending.map((step) => step.name));
+ * ```
+ */
+export interface TaskListStepSnapshot {
+	readonly name: string;
+	readonly state: TaskState;
+	readonly message: string;
+}
+
+/**
+ * {@link TaskListPipeline.run} のオプション。
+ * @example
+ * ```ts
+ * // CI ログ向け: stderr へ追記出力し、経過時間タイマーは無効化する
+ * await pipeline.run({ stream: process.stderr, verbose: true, showElapsed: false });
+ * ```
+ */
+export interface TaskListRunOptions {
+	/**
+	 * 出力先ストリーム。省略時は `process.stdout`。
+	 */
+	readonly stream?: NodeJS.WritableStream;
+	/** verbose モードでは上書き表示ではなく追記出力を行う。 */
+	readonly verbose?: boolean;
+	/** 実行中のステップの経過時間を行末に表示するか。既定は `true`。 */
+	readonly showElapsed?: boolean;
+	/** 経過時間の再描画間隔（ミリ秒）。既定は `250`。 */
+	readonly elapsedIntervalMs?: number;
+}


### PR DESCRIPTION
## Summary

- Add `TaskList.pipe()` / `TaskList.from()`, a type-safe sequential pipeline builder where each step receives the previous step's typed output. `.pipe<R>()` returns a new immutable `TaskListPipeline<R>` — no shared mutable state between branches.
- `run()` renders every step as a `[ ] name: message` line from the start via the existing `Lanes` class, then updates it in place through `pending → running → done | error` as steps execute sequentially (braille spinner + elapsed-time counter while running). A failing step stops the pipeline immediately and rejects with `TaskListStepError` (`stepName`/`stepIndex`/`cause`); later steps stay `pending`.
- `ctx.insertNext(name, fn)` lets a running step splice in an extra same-type (`R → R`) step immediately after itself at runtime, using fractional lane ids so existing rows keep their correct display order regardless of where new rows are inserted.
- `run()` is single-use per pipeline instance — a second call throws, since `insertNext` mutates the step list in place and a second run would silently re-execute (and duplicate) any steps inserted during the first run. Build a fresh pipeline via `pipe()`/`.pipe()` to run again.
- Update `@d-zero/dealer`'s `package.json` description and README with the new `TaskList` usage and constraints.

Purely additive — no existing exports (`deal`, `Dealer`, `Lanes`, `DealOptions`, `DealHeader`) changed.

## Test plan

- [x] Unit tests for the state machine: pending→running→done, type propagation through `.pipe()` chains, immediate stop + `TaskListStepError` on failure with later steps left `pending`, `insertNext` ordering (including multiple calls in one step) and lane-id display order, branching not leaking state between instances, concurrent `run()` rejection, single-use `run()` rejection (including the `insertNext` duplication regression), elapsed-time interval cleanup
- [x] Unit tests for `formatTaskLine`/`formatElapsed`/`describeCause`/`task-icons` (icon shapes, spinner frame data)
- [x] Existing `deal`/`Dealer`/`Lanes`/`Display` tests unaffected (full suite: 168 files / 2027 tests passed)
- [x] `yarn build`, `yarn lint`, `yarn test` all pass
- [x] Manual smoke test against the built dist: normal run, a failing step, and an `insertNext`-driven insertion, all rendering correctly in a real terminal
